### PR TITLE
langselector: add support configure file /etc/locale.conf

### DIFF
--- a/langselector/locale.go
+++ b/langselector/locale.go
@@ -36,6 +36,7 @@ import (
 
 const (
 	systemLocaleFile  = "/etc/default/locale"
+	systemdLocaleFile  = "/etc/locale.conf"
 	userLocaleFilePAM = ".pam_environment"
 	userLocaleConfigFile = ".config/locale.conf"
 
@@ -157,7 +158,11 @@ func getLocale() string {
 	if err != nil || len(locale) == 0 {
 		locale, err = getLocaleFromFile(systemLocaleFile)
 		if err != nil || len(locale) == 0 {
-			locale = defaultLocale
+			/* This file is used by systemd to store system-wide locale settings */
+			locale, err = getLocaleFromFile(systemdLocaleFile)
+			if err != nil || len(locale) == 0 {
+				locale = defaultLocale
+			}
 		}
 
 		writeUserLocale(locale)


### PR DESCRIPTION
This file is used by systemd to store system-wide locale settings. See: http://www.freedesktop.org/software/systemd/man/locale.conf.html