### PR TITLE
appearance: don't sync gnome background at all

### DIFF
--- a/appearance/handle_gsetting.go
+++ b/appearance/handle_gsetting.go
@@ -2,7 +2,6 @@ package appearance
 
 import (
 	"gir/gio-2.0"
-	"time"
 )
 
 func (m *Manager) listenGSettingChanged() {
@@ -31,21 +30,4 @@ func (m *Manager) listenBgGsettings() {
 		logger.Debug("[Wrap background] changed OVER ENDDDDDDDDDDD:", key, uri)
 	})
 	m.wrapBgSetting.GetString(gsKeyBackground)
-
-	if m.gnomeBgSetting == nil {
-		return
-	}
-	m.gnomeBgSetting.Connect("changed::picture-uri", func(s *gio.Settings, key string) {
-		// Wait for file copy finished
-		time.Sleep(time.Millisecond * 500)
-		uri := m.gnomeBgSetting.GetString(gsKeyBackground)
-		logger.Debug("[Gnome background] sync wrap bg:", uri, m.wrapBgSetting.GetString(gsKeyBackground))
-		if uri == m.wrapBgSetting.GetString(gsKeyBackground) {
-			return
-		}
-
-		m.wrapBgSetting.SetString(gsKeyBackground, uri)
-		logger.Debug("[Gnome background] sync wrap bg OVER ENDDDDDDDD:", uri, m.wrapBgSetting.GetString(gsKeyBackground))
-	})
-	m.gnomeBgSetting.GetString(gsKeyBackground)
 }

--- a/appearance/manager.go
+++ b/appearance/manager.go
@@ -31,7 +31,6 @@ const (
 	dthemeCustomId  = "Custom"
 
 	wrapBgSchema    = "com.deepin.wrap.gnome.desktop.background"
-	gnomeBgSchema   = "org.gnome.desktop.background"
 	gsKeyBackground = "picture-uri"
 
 	appearanceSchema = "com.deepin.dde.appearance"
@@ -52,7 +51,6 @@ type Manager struct {
 	setting *gio.Settings
 
 	wrapBgSetting  *gio.Settings
-	gnomeBgSetting *gio.Settings
 
 	watcher    *fsnotify.Watcher
 	endWatcher chan struct{}
@@ -65,7 +63,6 @@ func NewManager() *Manager {
 	m.setPropFontSize(m.setting.GetInt(gsKeyFontSize))
 
 	m.wrapBgSetting, _ = dutils.CheckAndNewGSettings(wrapBgSchema)
-	m.gnomeBgSetting, _ = dutils.CheckAndNewGSettings(gnomeBgSchema)
 
 	var err error
 	m.watcher, err = fsnotify.NewWatcher()
@@ -85,10 +82,6 @@ func (m *Manager) destroy() {
 
 	if m.wrapBgSetting != nil {
 		m.wrapBgSetting.Unref()
-	}
-
-	if m.gnomeBgSetting != nil {
-		m.gnomeBgSetting.Unref()
 	}
 
 	if m.watcher != nil {


### PR DESCRIPTION
Deepin is unable to handle animated backgrounds. It's better to leave these settings separated from each other.