### PR TITLE
appearance: check backround before sync with gnome

### DIFF
--- a/appearance/handle_gsetting.go
+++ b/appearance/handle_gsetting.go
@@ -2,6 +2,7 @@ package appearance
 
 import (
 	"gir/gio-2.0"
+	"pkg.deepin.io/dde/daemon/appearance/background"
 	"time"
 )
 
@@ -41,6 +42,10 @@ func (m *Manager) listenBgGsettings() {
 		uri := m.gnomeBgSetting.GetString(gsKeyBackground)
 		logger.Debug("[Gnome background] sync wrap bg:", uri, m.wrapBgSetting.GetString(gsKeyBackground))
 		if uri == m.wrapBgSetting.GetString(gsKeyBackground) {
+			return
+		}
+		if !background.IsBackgroundFile(uri) {
+			logger.Debugf("[Gnome background] Invalid background file '%v'", uri)
 			return
 		}
 


### PR DESCRIPTION
Deepin is unable to handle animated backgrounds yet. Make sure that the background file is valid.

Previously this change was accepted and merged in PR https://github.com/linuxdeepin/dde-daemon/pull/8, but I can't see it on the release/3.0 branch, so I submit it again.