### PR TITLE
replace update-grub with grub-mkconfig

### DIFF
--- a/grub2/grub2.go
+++ b/grub2/grub2.go
@@ -34,7 +34,7 @@ func SetDefaultGrubSettingFile(file string) {
 }
 
 const (
-	grubUpdateCmd                 = "/usr/sbin/update-grub"
+	grubUpdateCmd                 = "/usr/sbin/grub-mkconfig -o /boot/grub/grub.cfg"
 	lsbReleaseCmd                 = "/usr/bin/lsb_release"
 	defaultGrubDefaultEntry       = "0"
 	defaultGrubGfxmode            = "auto"

--- a/grub2/grub2ext.go
+++ b/grub2/grub2ext.go
@@ -82,7 +82,7 @@ func (ge *Grub2Ext) DoGenerateGrubMenu() (ok bool, err error) {
 	// Unicode characters
 	// FIXME: keep same with the current system language settings
 	os.Setenv("LANG", "en_US.UTF-8")
-	cmd := exec.Command(grubUpdateCmd)
+	cmd := exec.Command("/bin/bash", "-c", grubUpdateCmd)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	err = cmd.Run()


### PR DESCRIPTION
to increase compatibility in other distros like Arch Linux, which do not have update-grub scripts.