### PR TITLE
English suspend messages don't make sense

### DIFF
--- a/misc/po/en_GB.po
+++ b/misc/po/en_GB.po
@@ -1975,12 +1975,12 @@ msgstr ""
 #: ../../session/power/manager_events.go:133
 #: ../../session/power/manager_events.go:157
 msgid "Battery Critical Low"
-msgstr ""
+msgstr "Battery Critically Low"
 
 #: ../../session/power/manager_events.go:134
 #: ../../session/power/manager_events.go:158
 msgid "Computer has been in suspend mode, please plug in"
-msgstr ""
+msgstr "Computer will suspend very soon, please plug in now"
 
 #: ../../session/power/manager_events.go:164
 msgid "Battery Low"
@@ -1988,7 +1988,7 @@ msgstr ""
 
 #: ../../session/power/manager_events.go:165
 msgid "Computer will be in suspend mode, please plug in now"
-msgstr ""
+msgstr "Computer will suspend soon, please plug in"
 
 #: ../../timedate/manager_ifc.go:56
 msgid "Authentication is required to set the system time."


### PR DESCRIPTION
The suggested changes need to be applied for en_gb and en_au in transifex.

The battery low message (lines 1986, 1991) is displayed when the battery is at 20%.
The battery critically low message (lines 1978, 1983) is displayed when the battery is at 10% and also before the machine is suspended at 5%.

The percentages are the default values on my system and are configurable.