### PR TITLE
feat: disable peripherals wakeup when lid closed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,13 @@ install: build translate install-dde-data install-icons install-pam-module
 	mkdir -pv ${DESTDIR}/etc/grub.d
 	cp -f misc/etc/grub.d/* ${DESTDIR}/etc/grub.d
 
+	mkdir -pv ${DESTDIR}/etc/acpi/events
+	cp -f misc/etc/acpi/events/* ${DESTDIR}/etc/acpi/events/
+
+	mkdir -pv ${DESTDIR}/etc/acpi/actions
+	cp -f misc/etc/acpi/actions/* ${DESTDIR}/etc/acpi/actions/
+
+
 install-pam-module:
 	mkdir -pv ${DESTDIR}/${PAM_MODULE_DIR}
 	cp -f out/pam_deepin_auth.so ${DESTDIR}/${PAM_MODULE_DIR}

--- a/misc/etc/acpi/actions/deepin_lid.sh
+++ b/misc/etc/acpi/actions/deepin_lid.sh
@@ -1,0 +1,24 @@
+#! /bin/sh
+
+# check if lid button exists
+ls /proc/acpi/button/lid/* >/dev/null 2>&1 || exit 0
+
+# enable external peripherals wakeup
+handle_lid_open() {
+	if grep XHC /proc/acpi/wakeup | grep -q disabled; then
+		echo XHC > /proc/acpi/wakeup
+	fi
+}
+
+# disable external peripherals wakeup
+handle_lid_close() {
+	if grep XHC /proc/acpi/wakeup | grep -q enabled; then
+		echo XHC > /proc/acpi/wakeup
+	fi
+}
+
+if grep -q open /proc/acpi/button/lid/*/state; then
+	handle_lid_open
+else
+	handle_lid_close
+fi

--- a/misc/etc/acpi/events/deepin_lid
+++ b/misc/etc/acpi/events/deepin_lid
@@ -1,0 +1,2 @@
+event=button[ /]lid
+action=/etc/acpi/actions/deepin_lid.sh


### PR DESCRIPTION
it's annoying when you suspend your laptop by closing the lid, but
immediately waken up by accidently touching your USB mouse.