### PR TITLE
feat(image_effect): run `dde-pixmix` under xvfb-run

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -83,6 +83,7 @@ Depends: ${shlibs:Depends},
  xkb-data,
  libnotify-bin,
  rfkill,
+ xvfb,
  hwinfo,
  dmidecode
 Breaks: lastore-daemon(<< 0.9.64)

--- a/image_effect/image_effect.go
+++ b/image_effect/image_effect.go
@@ -135,7 +135,7 @@ func newImageEffect() *ImageEffect {
 }
 
 func ddePixmix(uid int, inputFile, outputFile string, envVars []string) error {
-	return runCmdRedirectStdOut(uid, outputFile, []string{"dde-pixmix", "-o=-", inputFile}, envVars)
+	return runCmdRedirectStdOut(uid, outputFile, []string{"xvfb-run", "dde-pixmix", "-o=-", inputFile}, envVars)
 }
 
 func (ie *ImageEffect) Get(sender dbus.Sender, effect, filename string) (outputFile string, busErr *dbus.Error) {
@@ -173,7 +173,7 @@ func (ie *ImageEffect) Get(sender dbus.Sender, effect, filename string) (outputF
 		err = xerrors.Errorf("failed to get process %d environ: %w", pid, err)
 		return
 	}
-	var envVarNames = []string{"DISPLAY", "XDG_RUNTIME_DIR"}
+	var envVarNames = []string{"XDG_RUNTIME_DIR"}
 	var envVars = make([]string, len(envVarNames))
 	for idx, envVarName := range envVarNames {
 		envVarVal := processEnv.Get(envVarName)

--- a/rpm/dde-daemon.spec
+++ b/rpm/dde-daemon.spec
@@ -93,6 +93,7 @@ Requires:       dde-polkit-agent
 Requires:       rfkill
 Requires:       gvfs
 Requires:       iw
+Requires:       %{_bindir}/xvfb-run
 
 Recommends:     iso-codes
 Recommends:     imwheel


### PR DESCRIPTION
Use `xvfb-run` to make `dde-pixmix` runnable without a real X server

Log: run `dde-pixmix` under xvfb-run
Signed-off-by: Robin Lee <cheeselee@fedoraproject.org>