### PR TITLE
fix: fix error rules order

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -8,17 +8,17 @@ export GOPATH = /usr/share/gocode
 SYSTYPE=Desktop
 SYSTYPE=$(shell cat /etc/deepin-version | grep Type= | awk -F'=' '{print $$2}')
 
-ifeq ($(SYSTYPE), Desktop)
-override_dh_gencontrol:
-	dh_gencontrol -- -Vdist:Depends="fprintd, libpam-fprintd"
-endif
-
 ifneq ($(DEB_BUILD_ARCH), mips64el)
 	export GOBUILD_OPTIONS=-ldflags '-linkmode=external -extldflags "-pie"'
 endif
 
 %:
 	dh $@
+
+ifeq ($(SYSTYPE), Desktop)
+override_dh_gencontrol:
+	dh_gencontrol -- -Vdist:Depends="fprintd, libpam-fprintd"
+endif
 
 ifeq ($(DEB_BUILD_ARCH), sw_64)
 override_dh_strip:


### PR DESCRIPTION
on 23 GOBUILD_OPTIONS will append after gencontrol
will cause no use GOBUILD_OPTIONS

Log: fix error rules order
