### PR TITLE
fix: use the not-deprecated gio open

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -71,7 +71,7 @@ Depends:
  dmidecode,
  dnsmasq-base,
  gnome-keyring,
- gvfs-bin,
+ libglib2.0-bin,
  hwinfo,
  imwheel,
  ipwatchd,

--- a/keybinding/shortcuts/media_shortcut.go
+++ b/keybinding/shortcuts/media_shortcut.go
@@ -37,8 +37,8 @@ const (
 )
 
 const (
-	cmdMyComputer = "gvfs-open computer:///"
-	cmdDocuments  = "gvfs-open ~/Documents"
+	cmdMyComputer = "gio open computer:///"
+	cmdDocuments  = "gio open ~/Documents"
 	cmdEject      = "eject -r"
 	cmdCalculator = "deepin-calculator"
 	cmdCalendar   = "dde-calendar"
@@ -114,7 +114,7 @@ var mediaIdActionMap = map[string]*Action{
 	"log-off": &Action{Type: ActionTypeSystemLogOff},
 	"away":    &Action{Type: ActionTypeSystemAway},
 
-	"web-cam":              NewExecCmdAction(cmdCamera, false),
+	"web-cam": NewExecCmdAction(cmdCamera, false),
 
 	// We do not need to deal with XF86Wlan key default,
 	// but can be specially by 'EnableNetworkController'


### PR DESCRIPTION
gvfs-open is deprecated and no longer exists on other distributions

gvfs-open 已被废弃，在较新的发行版已不存在。`gio` 工具在现有 deepin v20 版本也存在，此处直接更换至 gio。

这个 PR 是与 https://github.com/linuxdeepin/developer-center/issues/3230 相关的一部分。