### PR TITLE
fix(power): 修复S3测试300次后，插拔AC电池图标还是保持接入AC状态

### DIFF
--- a/system/power/battery.go
+++ b/system/power/battery.go
@@ -26,9 +26,9 @@ import (
 	"time"
 
 	dbus "github.com/godbus/dbus"
+	"github.com/linuxdeepin/dde-api/powersupply/battery"
 	gudev "github.com/linuxdeepin/go-gir/gudev-1.0"
 	"github.com/linuxdeepin/go-lib/dbusutil"
-	"github.com/linuxdeepin/dde-api/powersupply/battery"
 )
 
 type Battery struct {
@@ -144,6 +144,12 @@ func (bat *Battery) refresh(dev *gudev.Device) (ok bool) {
 	endDelay := bat.service.DelayEmitPropertyChanged(bat)
 	batInfo := battery.GetBatteryInfo(dev)
 	if batInfo == nil {
+		if endDelay != nil {
+			err := endDelay()
+			if err != nil {
+				logger.Warning(err)
+			}
+		}
 		return
 	}
 


### PR DESCRIPTION
 错误以后没有释放Delay Emit资源,导致锁没有释放
 错误以后,需要正确释放资源

Log: 修复插拔电源,电池图标显示问题
Influence: 电池相关状态
Bug: https://pms.uniontech.com/bug-view-137373.html
Change-Id: I92a8459a0d79fb6ef9019c371feaa8b66db3cf61