### PR TITLE
fix: 增加对dde-dconfig-daemon的依赖

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -91,6 +91,7 @@ Depends:
  user-setup,
  xdotool,
  xkb-data,
+ dde-dconfig-daemon,
  ${dist:Depends},
  ${misc:Depends},
  ${shlibs:Depends},


### PR DESCRIPTION
由于dde包存在被卸载的可能，导致系统跨版本升级时不会安装dde-dconfig-daemon包，因此在dde-daemon中增加运行依赖

Log: 增加对dde-dconfig-daemon的依赖
Bug: https://pms.uniontech.com/bug-view-152593.html
Influence: 构建升级
Change-Id: I7232f3ddcdf6d15e61e38d9bd5e79d6c334a60db