### PR TITLE
fix: 新增dconfig蓝牙传送文件配置

### DIFF
--- a/misc/dsg-configs/org.deepin.dde.daemon.bluetooth.json
+++ b/misc/dsg-configs/org.deepin.dde.daemon.bluetooth.json
@@ -11,6 +11,16 @@
           "description": "Save Airplane Mode for Bluetooth",
           "permissions": "readwrite",
           "visibility": "private"
+      },
+      "sendFileEnable": {
+          "value": true,
+          "serial": 0,
+          "flags": [],
+          "name": "sendFileEnable",
+          "name[zh_CN]": "是否允许蓝牙发送文件",
+          "description": "Allow send file by bluetooth",
+          "permissions": "readwrite",
+          "visibility": "private"
       }
   }
 }


### PR DESCRIPTION
文管调用的是dde-session-daemon中蓝牙模块的CanSendFile接口来管理右键传送文件功能的，新增sendFileEnable dconfig配置来控制右键传送功能显示

Log: 蓝牙传送文件配置
Influence: 蓝牙传送文件
Task: https://pms.uniontech.com/bug-view-148679.html
Change-Id: Iaa092c64937f8ede7968bdaa8c05ae585ab5ee94