### PR TITLE
fix: 完善性能模式逻辑

### DIFF
--- a/misc/dsg-configs/org.deepin.dde.daemon.power.json
+++ b/misc/dsg-configs/org.deepin.dde.daemon.power.json
@@ -11,6 +11,29 @@
             "description": "balance cpu governor",
             "permissions": "readwrite",
             "visibility": "private"
+        },
+        "isFirstGetCpuGovernor": {
+            "value": true,
+            "serial": 0,
+            "flags": ["global"],
+            "name": "isFirstGetCpuGovernor",
+            "name[zh_CN]": "是否第一次获取Cpu支持的Governor模式",
+            "description": "is first get cpu governor",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "supportCpuGovernors": {
+            "value": [
+                "performance", "powersave", "userspace", "ondemand", "conservative", "schedutil"
+            ],
+            "serial": 0,
+            "flags": ["global"],
+            "name": "supportCpuGovernors",
+            "name[zh_CN]": "Cpu支持的Governor模式",
+            "description": "",
+            "description[zh_CN]": "",
+            "permissions": "readwrite",
+            "visibility": "public"
         }
     }
 }

--- a/system/power/cpu_handler.go
+++ b/system/power/cpu_handler.go
@@ -26,6 +26,9 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"github.com/linuxdeepin/go-lib/strv"
+	"github.com/linuxdeepin/go-lib/dbusutil"
+	dutils "github.com/linuxdeepin/go-lib/utils"
 )
 
 const (
@@ -34,6 +37,7 @@ const (
 	globalGovernorFileName          = "scaling_governor"
 	globalAvailableGovernorFileName = "scaling_available_governors"
 	globalBoostFilePath             = "/sys/devices/system/cpu/cpufreq/boost"
+	globalDefaultPath               = "/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor"
 )
 
 type CpuHandler struct {
@@ -42,6 +46,73 @@ type CpuHandler struct {
 }
 
 type CpuHandlers []CpuHandler
+
+//内核文档：https://docs.kernel.org/admin-guide/pm/cpufreq.html#generic-scaling-governors
+var _scalingAvailableGovernors = []string {"performance", "powersave", "userspace", "ondemand", "conservative", "schedutil"}
+var _scalingBalanceAvailableGovernors = []string {"ondemand", "conservative", "schedutil", "performance"}
+var _supportGovernors []string
+
+func getScalingAvailableGovernors() []string {
+	return _scalingAvailableGovernors
+}
+
+func getScalingBalanceAvailableGovernors() []string {
+	return _scalingBalanceAvailableGovernors
+}
+
+func getSupportGovernors() []string {
+	return _supportGovernors
+}
+
+func setSupportGovernors(value []string) []string {
+	_supportGovernors = value
+	return _supportGovernors
+}
+
+func getIsBalanceSupported() bool {
+	for _, balance := range getScalingBalanceAvailableGovernors() {
+		if strv.Strv(getSupportGovernors()).Contains(balance) {
+			return true
+		}
+	}
+	return false
+}
+
+func getIsHighPerformanceSupported() bool {
+	cpus := CpuHandlers{}
+	return  cpus.IsBoostFileExist() && strv.Strv(getSupportGovernors()).Contains("performance")
+}
+
+func getIsPowerSaveSupported() bool {
+	return strv.Strv(getSupportGovernors()).Contains("powersave")
+}
+
+func trySetBalanceCpuGovernor(balanceScalingGovernor string) (error, string) {
+	if "" == balanceScalingGovernor {
+		return nil, ""
+	}
+
+	// dconfig设置的模式如果不是平衡模式类型，则不进行设置
+	if !strv.Strv(getScalingBalanceAvailableGovernors()).Contains(balanceScalingGovernor) {
+		logger.Warningf("[trySetBalanceCpuGovernor] The governor is invalid. %s ", balanceScalingGovernor)
+		return dbusutil.ToError(fmt.Errorf(" The Governor is invalid. Please use performance, powersave, userspace, ondemand, conservative or schedutil. current value : %s", balanceScalingGovernor)), ""
+	}
+
+	// 系统支持的模式不包含设置的平衡模式，则按照产品优先级设置平衡模式 : ondemand > conservative > schedutil > performance
+	// 系统支持的模式则可以直接进行设置
+	if !strv.Strv(getSupportGovernors()).Contains(balanceScalingGovernor) {
+		for _, available := range getScalingBalanceAvailableGovernors() {
+			if strv.Strv(getSupportGovernors()).Contains(available) {
+				logger.Infof(" [trySetBalanceCpuGovernor] use other support governor. %s", available)
+				balanceScalingGovernor = available
+				break
+			}
+		}
+	}
+
+	logger.Info("[trySetBalanceCpuGovernor] balanceScalingGovernor : ", balanceScalingGovernor)
+	return nil, balanceScalingGovernor
+}
 
 func NewCpuHandlers() *CpuHandlers {
 	cpus := make(CpuHandlers, 0)
@@ -90,7 +161,6 @@ func (cpu *CpuHandler) GetGovernor(force bool) (string, error) {
 }
 
 func (cpu *CpuHandler) SetGovernor(governor string) error {
-
 	err := ioutil.WriteFile(filepath.Join(cpu.path, globalGovernorFileName), []byte(governor), 0644)
 	if err != nil {
 		logger.Warning(err)
@@ -116,7 +186,83 @@ func (cpus *CpuHandlers) GetGovernor() (string, error) {
 	return governor, nil
 }
 
+// 获取可用的Governor字符串
+func (cpus *CpuHandlers) getAvailableGovernors() (ret string, err error) {
+	for i, cpu := range *cpus {
+		data, err := ioutil.ReadFile(filepath.Join(cpu.path, globalAvailableGovernorFileName))
+		if err != nil {
+			logger.Warning(err)
+			return  ret, err
+		}
+		path := string(data)
+		if ret != path {
+			ret = path
+			if i != 0 {
+				logger.Warning(err)
+				return path, dbusutil.ToError(fmt.Errorf("The cpu path not equal. path : %s ", path))
+			}
+		}
+	}
+
+	return ret, err
+}
+
+func (cpus *CpuHandlers) getCpuGovernorPath() string {
+	if len(*cpus) <= 0 {
+		return ""
+	}
+
+	if !dutils.IsFileExist((*cpus)[0].path) {
+		return ""
+	}
+	path := filepath.Join((*cpus)[0].path, globalGovernorFileName)
+	if "" == path {
+		path = globalDefaultPath
+	}
+
+	if !dutils.IsFileExist(path) {
+		path = ""
+	}
+
+	return path
+}
+
+// 通过写文件的返回情况，获取非scaling_available_governors的值是否支持
+func (cpus *CpuHandlers) tryWriteGovernor(lines []string) []string {
+	path := cpus.getCpuGovernorPath()
+	if "" == path {
+		return nil
+	}
+
+	//获取当前系统的governor值
+	oldGovernor, err := ioutil.ReadFile(path)
+	if err != nil {
+		return lines
+	}
+	logger.Infof(" [tryWriteGovernor] Test Path : %s.", path)
+	// 遍历6个内核支持的数据，以及系统支持的数据
+	// 通过是否能写入文件判断不包含在supportGovernors的值是否支持设置
+	for _, value := range getScalingAvailableGovernors() {
+		if !strv.Strv(lines).Contains(value) {
+			err = ioutil.WriteFile(path, []byte(value), 0644)
+			logger.Infof(" Not contain in supportGovernors. Governor : %s.", value)
+			if err != nil {
+				logger.Infof(" Can't use the governor : %s. err : %s", value, err)
+			} else {
+				lines = append(lines, value)
+			}
+		}
+	}
+	//将当前系统原始的governor值设置回去
+	err = ioutil.WriteFile(path, oldGovernor, 0644)
+	if err != nil {
+		logger.Warning(err)
+	}
+	return lines
+}
+
 func (cpus *CpuHandlers) SetGovernor(governor string) error {
+	logger.Info(" SetGovernor governor ： ", governor)
 	for _, cpu := range *cpus {
 		err := cpu.SetGovernor(governor)
 		if err != nil {

--- a/system/power/cpu_handler_test.go
+++ b/system/power/cpu_handler_test.go
@@ -109,6 +109,39 @@ func Test_SetGovernor1(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func Test_getScalingAvailableGovernors(t *testing.T) {
+	cpuGovernors := getScalingAvailableGovernors()
+	assert.NotEqual(t, len(cpuGovernors), 0)
+}
+
+func Test_getScalingBalanceAvailableGovernors(t *testing.T) {
+	cpuGovernors := getScalingBalanceAvailableGovernors()
+	assert.NotEqual(t, len(cpuGovernors), 0)
+	assert.Equal(t, len(cpuGovernors), 4)
+}
+
+func Test_getSupportGovernors(t *testing.T) {
+	cpuGovernors := getSupportGovernors()
+	assert.Equal(t, len(cpuGovernors), 0)
+}
+
+func Test_setSupportGovernors(t *testing.T) {
+	var lines = []string {"1", "2", "3"}
+	assert.NotEqual(t, len(setSupportGovernors(lines)), 10)
+}
+
+func Test_trySetBalanceCpuGovernor(t *testing.T)  {
+	err, target := trySetBalanceCpuGovernor("powersave")
+	assert.NotEqual(t, err, nil)
+	assert.NotEqual(t, target, "powersave")
+}
+
+func Test_getCpuGovernorPath(t *testing.T) {
+	cpus := CpuHandlers{}
+
+	assert.NotEqual(t, cpus.getCpuGovernorPath(), "/a/b/c/d")
+}
+
 func Test_IsBoostFileExist(t *testing.T) {
 	cpus := CpuHandlers{}
 

--- a/system/power/manager_ifc.go
+++ b/system/power/manager_ifc.go
@@ -121,7 +121,10 @@ func (m *Manager) SetMode(mode string) *dbus.Error {
 		err = m.saveConfig()
 	}
 
-	logger.Warning(err)
+	if err != nil {
+		logger.Warning(err)
+	}
+
 	return dbusutil.ToError(err)
 }
 

--- a/system/power/power_key_edit.go
+++ b/system/power/power_key_edit.go
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2022 ~ 2022 Deepin Technology Co., Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package power
+
+import (
+	"github.com/godbus/dbus"
+	"github.com/linuxdeepin/go-lib/dbusutil"
+	"github.com/linuxdeepin/go-lib/utils"
+)
+
+func interfaceToArrayString(v interface{}) (d []interface{}) {
+	if utils.IsInterfaceNil(v) {
+		return
+	}
+
+	d, ok := v.([]interface{})
+	if !ok {
+		logger.Errorf("interfaceToArrayString() failed: %#v", v)
+		return
+	}
+	return
+}
+
+func interfaceToString(v interface{}) (d string) {
+	if utils.IsInterfaceNil(v) {
+		return
+	}
+	d, ok := v.(string)
+	if !ok {
+		logger.Errorf("interfaceToString() failed: %#v", v)
+		return
+	}
+	return
+}
+
+func interfaceToBool(v interface{}) (d bool) {
+	if utils.IsInterfaceNil(v) {
+		return
+	}
+	d, ok := v.(bool)
+	if !ok {
+		logger.Errorf("interfaceToBool() failed: %#v", v)
+		return
+	}
+	return
+}
+
+func (m *Manager) initDsgConfig(conn *dbus.Conn) error {
+	// 加载dsg配置
+	systemConnObj := conn.Object(configManagerId, "/")
+	err := systemConnObj.Call(configManagerId+".acquireManager", 0, "org.deepin.dde.daemon", "org.deepin.dde.daemon.power", "").Store(&m.configManagerPath)
+	if err != nil {
+		logger.Warning(err)
+		return err
+	}
+	err = dbusutil.NewMatchRuleBuilder().Type("signal").
+		PathNamespace(string(m.configManagerPath)).
+		Interface("org.desktopspec.ConfigManager.Manager").
+		Member("valueChanged").Build().AddTo(conn)
+	if err != nil {
+		logger.Warning(err)
+		return err
+	}
+	return nil
+}
+
+func (m *Manager) getDsgData(key string) interface{} {
+	systemConn, err := dbus.SystemBus()
+	if err != nil {
+		logger.Warning("getDsgData systemConn err: ", err)
+		return nil
+	}
+	systemConnObj := systemConn.Object("org.desktopspec.ConfigManager", m.configManagerPath)
+	var value interface{}
+	err = systemConnObj.Call("org.desktopspec.ConfigManager.Manager.value",0, key).Store(&value)
+	if err != nil {
+		logger.Warningf("getDsgData key : %s. err : %s", key, err)
+		return nil
+	}
+	logger.Info(" getDsgData key : ", key, " , value : ", value)
+	return value
+}
+
+func (m *Manager) setDsgData(key string, value interface{}) bool {
+	systemConn, err := dbus.SystemBus()
+	if err != nil {
+		logger.Warning("setDsgData systemConn err: ", err)
+		return false
+	}
+	systemConnObj := systemConn.Object("org.desktopspec.ConfigManager", m.configManagerPath)
+	err = systemConnObj.Call("org.desktopspec.ConfigManager.Manager.setValue",0, key, dbus.MakeVariant(value)).Store()
+	if err != nil {
+		logger.Warningf("setDsgData key : %s. err : %s", key, err)
+		return false
+	}
+	logger.Infof("setDsgData key : %s , value : %s", key, value)
+
+	return true
+}

--- a/system/power/power_key_edit_test.go
+++ b/system/power/power_key_edit_test.go
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2022 ~ 2022 Deepin Technology Co., Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package power
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_interfaceToArrayString(t *testing.T) {
+	data := []struct {
+		test   interface{}
+		result []string
+	}{
+		{[]interface{}{}, []string{}},
+		{[]interface{}{"0"}, []string{"0"}},
+		{[]interface{}{"0", "1"}, []string{"0", "1"}},
+		{[]interface{}{"0", "1", "2"}, []string{"0", "1", "2"}},
+		{[]interface{}{"0", "1", "2", "3"}, []string{"0", "1", "2", "3"}},
+	}
+	for _, d := range data {
+		trans := interfaceToArrayString(d.test)
+		arr := make([]string, len(trans))
+		for i, v := range trans {
+			arr[i] = v.(string)
+		}
+
+		assert.Equal(t, arr, d.result)
+	}
+}
+
+func Test_interfaceToString(t *testing.T) {
+	data := []struct {
+		test   interface{}
+		result string
+	}{
+		{"", ""},
+		{"test", "test"},
+		{"System Power Test", "System Power Test"},
+	}
+	for _, d := range data {
+		assert.Equal(t, interfaceToString(d.test), d.result)
+	}
+}
+
+func Test_interfaceToBool(t *testing.T) {
+	data := []struct {
+		test   interface{}
+		result bool
+	}{
+		{true, true},
+		{false, false},
+	}
+	for _, d := range data {
+		assert.Equal(t, interfaceToBool(d.test), d.result)
+	}
+}


### PR DESCRIPTION
*通过写文件判断/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor支持的相关模式；
*在dconfig配置的模式不支持时，按照ondemand > conservative > schedutil > performance写平衡模式
*仅装机第一次才会进行获取性能模式数据，后面根据写入的配置进行判断；

Log: 完善电源-性能模式逻辑，增加对可以模式判断
Bug: https://pms.uniontech.com/bug-view-152841.html
Bug: https://pms.uniontech.com/bug-view-152811.html
Influence: 性能模式切换
Change-Id: I522d81e94a6694231885012850feaa7789524d86