### PR TITLE
fix: 删除log中账户名的信息

### DIFF
--- a/accounts/user.go
+++ b/accounts/user.go
@@ -691,7 +691,7 @@ func updateConfigPath(username string) {
 	oldConfig := path.Join(actConfigDir, "users", username)
 	err = dutils.CopyFile(oldConfig, config)
 	if err != nil {
-		logger.Warning("Failed to update config:", username)
+		logger.Warning("Failed to update config.")
 	}
 }
 

--- a/accounts/users/passwd.go
+++ b/accounts/users/passwd.go
@@ -30,6 +30,7 @@ package users
 import "C"
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"math"
@@ -95,7 +96,7 @@ func getSpwd(username string) (*originShadowInfo, error) {
 	defer C.free(unsafe.Pointer(cname))
 	spwd := C.getspnam(cname)
 	if spwd == nil {
-		return &originShadowInfo{}, fmt.Errorf("no such user name: %v", username)
+		return &originShadowInfo{}, errors.New("no such user name")
 	}
 	sInfo := originShadowInfo{
 		Name:       C.GoString(spwd.sp_namp),

--- a/bin/dde-system-daemon/wallpaper.go
+++ b/bin/dde-system-daemon/wallpaper.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -27,7 +28,7 @@ func GetUserDir(username string) (string, error) {
 	}
 
 	if !strings.HasPrefix(dir, wallPaperDir) {
-		return "", fmt.Errorf("%s is not in %s", username, wallPaperDir)
+		return "", fmt.Errorf("UserName is not in %s", wallPaperDir)
 	}
 
 	info, err := os.Stat(dir)
@@ -37,7 +38,7 @@ func GetUserDir(username string) (string, error) {
 	}
 
 	if info != nil && !info.IsDir() {
-		return "", fmt.Errorf("%s is not a dir", username)
+		return "", errors.New("UsernName is not a dir")
 	}
 
 	return dir, nil

--- a/fprintd/huawei_device.go
+++ b/fprintd/huawei_device.go
@@ -153,9 +153,9 @@ func (dev *HuaweiDevice) doClose() error {
 func (dev *HuaweiDevice) Claim(sender dbus.Sender, username string) *dbus.Error {
 	err := dev.claim(string(sender), username)
 	if err != nil {
-		logger.Debugf("claim() sender: %q, username: %q, err %v", sender, username, err)
+		logger.Debugf("claim() sender: %q, UserName, err %v", sender, err)
 	} else {
-		logger.Debugf("claim() sender: %q, username: %q, ok", sender, username)
+		logger.Debugf("claim() sender: %q, UserName, ok", sender)
 	}
 	return dbusutil.ToError(err)
 }
@@ -163,9 +163,9 @@ func (dev *HuaweiDevice) Claim(sender dbus.Sender, username string) *dbus.Error 
 func (dev *HuaweiDevice) ClaimForce(sender dbus.Sender, username string) *dbus.Error {
 	err := dev.claimForce(string(sender), username)
 	if err != nil {
-		logger.Debugf("claimForce() sender: %q, username: %q, err %v", sender, username, err)
+		logger.Debugf("claimForce() sender: %q, UserName, err %v", sender, err)
 	} else {
-		logger.Debugf("claimForce() sender: %q, username: %q, ok", sender, username)
+		logger.Debugf("claimForce() sender: %q, UserName, ok", sender)
 	}
 	return dbusutil.ToError(err)
 }


### PR DESCRIPTION
删除log中账户名的信息

Log: 删除log中关于账户名的信息
Influence: 账户名信息打印
Bug: https://pms.uniontech.com/bug-view-150921.html
Change-Id: If5eced63878166837a5b276850ecdf61084f7481