### PR TITLE
feat: 新增在收到PrepareForSleep信号为true时，关闭屏幕。

### DIFF
--- a/session/power/manager_events.go
+++ b/session/power/manager_events.go
@@ -86,6 +86,7 @@ func (m *Manager) initOnBatteryChangedHandler() {
 
 func (m *Manager) handleBeforeSuspend() {
 	m.setPrepareSuspend(suspendStatePrepare)
+	m.setDPMSModeOff()
 	logger.Debug("before sleep")
 }
 


### PR DESCRIPTION
规避系统在调用 systemctl hibernate 过程中屏幕熄灭后突然亮起。

Log: 新增在收到PrepareForSleep信号为true时，关闭屏幕。
Bug: https://pms.uniontech.com/bug-view-153183.html
Influence: 使用系统命令行休眠 systemctl hibernate