### PR TITLE
fix: 修复/etc/deepin/deepin-user-experience状态未被继承问题

### DIFF
--- a/session/eventlog/event_collector.go
+++ b/session/eventlog/event_collector.go
@@ -43,7 +43,7 @@ const (
 
 var (
 	userExpPath    = "/var/public/deepin-user-experience/user"
-	defaultExpPath = "/etc/deepin/deepin-user-experience "
+	defaultExpPath = "/etc/deepin/deepin-user-experience"
 )
 
 type EventLog struct {


### PR DESCRIPTION
由于文件路径后无意加了空格,导致该问题

Log: 修复/etc/deepin/deepin-user-experience状态未被继承问题
Bug: https://pms.uniontech.com/bug-view-155197.html
Influence: 用户体验计划
Change-Id: I5cf7e971cb77ffee6b2f813cb22cd54ae12ed64f