### PR TITLE
fix(bluetooth): 修复飞行模式解除后，蓝牙状态与配置状态不一致问题。

### DIFF
--- a/system/bluetooth/bluetooth_ifc.go
+++ b/system/bluetooth/bluetooth_ifc.go
@@ -3,6 +3,7 @@ package bluetooth
 import (
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/godbus/dbus"
 	sysbtagent "github.com/linuxdeepin/go-dbus-factory/com.deepin.system.bluetooth.agent"
@@ -203,6 +204,7 @@ func (b *SysBluetooth) SetAdapterPowered(adapterPath dbus.ObjectPath,
 	// 当先收到 discovering，后收到power时
 	// 在discovering改变时，此时power状态依旧为true，当时此时power是false状态，导致闪开后关闭
 	// Note: BUG102434
+	adapter.poweredActionTime = time.Now()
 	adapter.Powered = powered
 	adapter.discoveringFinished = false
 


### PR DESCRIPTION
bluez 响应来激活动作，与dde配置状态相冲突。

Log: 修复飞行模式解除后，蓝牙状态与配置状态不一致问题。
Bug: https://pms.uniontech.com/bug-view-154029.html
Influence: 蓝牙
Change-Id: Ia9f9a969aef9c19d56ad67cc88098714c48d6ab3