### PR TITLE
fix: 修复调用IsX11SessionActive接口失败

### DIFF
--- a/misc/services/com.deepin.LastoreSessionHelper.service
+++ b/misc/services/com.deepin.LastoreSessionHelper.service
@@ -1,4 +1,4 @@
 [D-BUS Service]
 Name=com.deepin.LastoreSessionHelper
-Exec=/usr/lib/deepin-daemon/dde-session-daemon
+Exec=/usr/bin/dbus-send --session --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.RunCommand string:'/usr/lib/deepin-daemon/dde-session-daemon' array:string:''
 

--- a/misc/services/com.deepin.api.XEventMonitor.service
+++ b/misc/services/com.deepin.api.XEventMonitor.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.api.XEventMonitor
-Exec=/usr/lib/deepin-daemon/dde-session-daemon
+Exec=/usr/bin/dbus-send --session --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.RunCommand string:'/usr/lib/deepin-daemon/dde-session-daemon' array:string:''

--- a/misc/services/com.deepin.daemon.Appearance.service
+++ b/misc/services/com.deepin.daemon.Appearance.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.daemon.Appearance
-Exec=/usr/lib/deepin-daemon/dde-session-daemon
+Exec=/usr/bin/dbus-send --session --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.RunCommand string:'/usr/lib/deepin-daemon/dde-session-daemon' array:string:''

--- a/misc/services/com.deepin.daemon.Audio.service
+++ b/misc/services/com.deepin.daemon.Audio.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.daemon.Audio
-Exec=/usr/lib/deepin-daemon/dde-session-daemon
+Exec=/usr/bin/dbus-send --session --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.RunCommand string:'/usr/lib/deepin-daemon/dde-session-daemon' array:string:''

--- a/misc/services/com.deepin.daemon.Bluetooth.service
+++ b/misc/services/com.deepin.daemon.Bluetooth.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.daemon.Bluetooth
-Exec=/usr/lib/deepin-daemon/dde-session-daemon
+Exec=/usr/bin/dbus-send --session --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.RunCommand string:'/usr/lib/deepin-daemon/dde-session-daemon' array:string:''

--- a/misc/services/com.deepin.daemon.EventLog.service
+++ b/misc/services/com.deepin.daemon.EventLog.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.daemon.EventLog
-Exec=/usr/lib/deepin-daemon/dde-session-daemon
+Exec=/usr/bin/dbus-send --session --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.RunCommand string:'/usr/lib/deepin-daemon/dde-session-daemon' array:string:''

--- a/misc/services/com.deepin.daemon.InputDevices.service
+++ b/misc/services/com.deepin.daemon.InputDevices.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.daemon.InputDevices
-Exec=/usr/lib/deepin-daemon/dde-session-daemon
+Exec=/usr/bin/dbus-send --session --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.RunCommand string:'/usr/lib/deepin-daemon/dde-session-daemon' array:string:''

--- a/misc/services/com.deepin.daemon.Keybinding.service
+++ b/misc/services/com.deepin.daemon.Keybinding.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.daemon.Keybinding
-Exec=/usr/lib/deepin-daemon/dde-session-daemon
+Exec=/usr/bin/dbus-send --session --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.RunCommand string:'/usr/lib/deepin-daemon/dde-session-daemon' array:string:''

--- a/misc/services/com.deepin.daemon.Mime.service
+++ b/misc/services/com.deepin.daemon.Mime.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.daemon.Mime
-Exec=/usr/lib/deepin-daemon/dde-session-daemon
+Exec=/usr/bin/dbus-send --session --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.RunCommand string:'/usr/lib/deepin-daemon/dde-session-daemon' array:string:''

--- a/misc/services/com.deepin.daemon.Network.service
+++ b/misc/services/com.deepin.daemon.Network.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.daemon.Network
-Exec=/usr/lib/deepin-daemon/dde-session-daemon
+Exec=/usr/bin/dbus-send --session --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.RunCommand string:'/usr/lib/deepin-daemon/dde-session-daemon' array:string:''

--- a/misc/services/com.deepin.daemon.Power.service
+++ b/misc/services/com.deepin.daemon.Power.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.daemon.Power
-Exec=/usr/lib/deepin-daemon/dde-session-daemon
+Exec=dbus-send --session --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.RunCommand string:'/usr/lib/deepin-daemon/dde-session-daemon' array:string:''

--- a/misc/services/com.deepin.daemon.SessionWatcher.service
+++ b/misc/services/com.deepin.daemon.SessionWatcher.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.daemon.SessionWatcher
-Exec=/usr/lib/deepin-daemon/dde-session-daemon
+Exec=/usr/bin/dbus-send --session --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.RunCommand string:'/usr/lib/deepin-daemon/dde-session-daemon' array:string:''

--- a/misc/services/com.deepin.daemon.SystemInfo.service
+++ b/misc/services/com.deepin.daemon.SystemInfo.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.daemon.SystemInfo
-Exec=/usr/lib/deepin-daemon/dde-session-daemon
+Exec=/usr/bin/dbus-send --session --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.RunCommand string:'/usr/lib/deepin-daemon/dde-session-daemon' array:string:''

--- a/misc/services/com.deepin.daemon.Timedate.service
+++ b/misc/services/com.deepin.daemon.Timedate.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.daemon.Timedate
-Exec=/usr/lib/deepin-daemon/dde-session-daemon
+Exec=/usr/bin/dbus-send --session --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.RunCommand string:'/usr/lib/deepin-daemon/dde-session-daemon' array:string:''

--- a/misc/services/com.deepin.daemon.Zone.service
+++ b/misc/services/com.deepin.daemon.Zone.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.daemon.Zone
-Exec=/usr/lib/deepin-daemon/dde-session-daemon
+Exec=/usr/bin/dbus-send --session --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.RunCommand string:'/usr/lib/deepin-daemon/dde-session-daemon' array:string:''

--- a/misc/services/com.deepin.dde.daemon.Dock.service
+++ b/misc/services/com.deepin.dde.daemon.Dock.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.dde.daemon.Dock
-Exec=/usr/lib/deepin-daemon/dde-session-daemon
+Exec=/usr/bin/dbus-send --session --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.RunCommand string:'/usr/lib/deepin-daemon/dde-session-daemon' array:string:''

--- a/misc/services/com.deepin.dde.daemon.Launcher.service
+++ b/misc/services/com.deepin.dde.daemon.Launcher.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.dde.daemon.Launcher
-Exec=/usr/lib/deepin-daemon/dde-session-daemon
+Exec=/usr/bin/dbus-send --session --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.RunCommand string:'/usr/lib/deepin-daemon/dde-session-daemon' array:string:''


### PR DESCRIPTION
如果dde-session-daemon通过dbus拉起时,dde-session-daemon不属于任何一个session,
导致获取self session失败,将最终拉起方式改完startdde,使得dde-session-daemon属于某一session

Log: 修复接口获取错误
Influence: dde-session-daemon启动方式
Bug: https://pms.uniontech.com/bug-view-155293.html
Change-Id: I0d44bce9aa6445bb8480f63927c1658c5a1f80cd