### PR TITLE
fix: 修复点击快捷方式的恢复默认按钮导致关闭窗口快捷键展示异常的问题

### DIFF
--- a/keybinding/shortcuts/shortcut_manager.go
+++ b/keybinding/shortcuts/shortcut_manager.go
@@ -1056,6 +1056,9 @@ func (sm *ShortcutManager) AddMedia(gsettings *gio.Settings, wmObj wm.Wm) {
 	logger.Debug("AddMedia")
 	idNameMap := getMediaIdNameMap()
 	for _, id := range gsettings.ListKeys() {
+		if id == "media-close" {
+			continue
+		}
 		name := idNameMap[id]
 		if name == "" {
 			name = id


### PR DESCRIPTION
x11逻辑中没有过滤掉media-close

Log: 修复点击快捷方式的恢复默认按钮导致关闭窗口快捷键展示异常的问题
Influence: 快捷键恢复
Bug: https://pms.uniontech.com/bug-view-155611.html
Change-Id: I3351d1ce74a9832be06689fa157699f993d7d263