### PR TITLE
fix: 修复自定义快捷键冲突修改不成功的问题

### DIFF
--- a/keybinding/manager_ifc.go
+++ b/keybinding/manager_ifc.go
@@ -240,7 +240,7 @@ func (m *Manager) AddCustomShortcut(name, action, keystroke string) (id string,
 		return
 	}
 
-	shortcut, err := m.customShortcutManager.Add(name, action, []*shortcuts.Keystroke{ks})
+	shortcut, err := m.customShortcutManager.Add(name, action, []*shortcuts.Keystroke{ks}, m.wm)
 	if err != nil {
 		logger.Warning(err)
 		busErr = dbusutil.ToError(err)

--- a/keybinding/shortcuts/custom_shortcut.go
+++ b/keybinding/shortcuts/custom_shortcut.go
@@ -176,7 +176,7 @@ func (csm *CustomShortcutManager) Save() error {
 	return csm.kfile.SaveToFile(csm.file)
 }
 
-func (csm *CustomShortcutManager) Add(name, action string, keystrokes []*Keystroke) (Shortcut, error) {
+func (csm *CustomShortcutManager) Add(name, action string, keystrokes []*Keystroke, wm wm.Wm) (Shortcut, error) {
 	id := name
 	csm.kfile.SetString(id, kfKeyName, name)
 	csm.kfile.SetString(id, kfKeyAction, action)
@@ -196,6 +196,7 @@ func (csm *CustomShortcutManager) Add(name, action string, keystrokes []*Keystro
 		},
 		manager: csm,
 		Cmd:     action,
+		wm:      wm,
 	}
 	return shortcut, csm.Save()
 }


### PR DESCRIPTION
缺少参数,导致修改时调用了空指针

Log: 修复自定义快捷键冲突修改不成功的问题
Influence: 自定义快捷键冲突
Bug: https://pms.uniontech.com/bug-view-155183.html
Change-Id: I5cea855244002ccb99f73203a54cbda23fafa934