### PR TITLE
fix: ddcci调节亮度优化

### DIFF
--- a/bin/backlight_helper/ddcci/manager.go
+++ b/bin/backlight_helper/ddcci/manager.go
@@ -27,7 +27,7 @@ type Manager struct {
 	configTimestamp x.Timestamp
 
 	// 亮度调节方式，策略组配置
-	supportDdcci bool
+	GsSupportDdcci bool
 
 	configManagerPath dbus.ObjectPath
 }
@@ -41,9 +41,9 @@ func NewManager(service *dbusutil.Service) (*Manager, error) {
 	if err != nil {
 		logger.Warning(err)
 	}
-	m.supportDdcci = m.getSupportDdcci()
+	m.GsSupportDdcci = m.getSupportDdcci()
 
-	if m.supportDdcci {
+	if m.GsSupportDdcci {
 		var err error
 		m.ddcci, err = newDDCCI()
 		if err != nil {

--- a/bin/backlight_helper/main.go
+++ b/bin/backlight_helper/main.go
@@ -126,7 +126,8 @@ func main() {
 	if err != nil {
 		logger.Fatal("failed to request name:", err)
 	}
-
-	service.SetAutoQuitHandler(time.Second*30, nil)
+	if !ddcciManager.GsSupportDdcci {
+		service.SetAutoQuitHandler(time.Second*30, nil)
+	}
 	service.Wait()
 }

--- a/keybinding/shortcuts/shortcut_manager.go
+++ b/keybinding/shortcuts/shortcut_manager.go
@@ -1056,9 +1056,6 @@ func (sm *ShortcutManager) AddMedia(gsettings *gio.Settings, wmObj wm.Wm) {
 	logger.Debug("AddMedia")
 	idNameMap := getMediaIdNameMap()
 	for _, id := range gsettings.ListKeys() {
-		if id == "media-close" {
-			continue
-		}
 		name := idNameMap[id]
 		if name == "" {
 			name = id


### PR DESCRIPTION
ddcci初始化较慢,如果支持ddcci调节, 将backlight-helper常驻

Log: ddcci调节亮度优化
Bug: https://pms.uniontech.com/bug-view-155827.html
Influence: backlight-helper