### PR TITLE
fix: 新用户登录桌面会长时间卡顿

### DIFF
--- a/bin/dde-session-daemon/daemon.go
+++ b/bin/dde-session-daemon/daemon.go
@@ -192,6 +192,7 @@ func (s *SessionDaemon) register(service *dbusutil.Service) error {
 func (s *SessionDaemon) initModules() {
 	part1ModuleNames := []string{
 		"dock",
+		"eventlog",
 		"trayicon",
 		"launcher",
 		"x-event-monitor",
@@ -221,7 +222,6 @@ func (s *SessionDaemon) initModules() {
 		"lastore",
 		"calltrace",
 		"debug",
-		"eventlog",
 	}
 
 	allModules := loader.List()


### PR DESCRIPTION
埋点模块(eventlog)依赖dock模块，而dock模块是在第一阶段加载的（dde-session-daemon）
因此，埋点模块也应该放到第一阶段去加载，防止放到第二阶段(startdde)去加载时造成桌面卡顿的问题

Log: 解决新用户登录桌面会长时间卡顿的问题
Bug: https://pms.uniontech.com/bug-view-155875.html
     https://pms.uniontech.com/bug-view-156243.html
     https://pms.uniontech.com/bug-view-154713.html
Influence: 新用户桌面正常使用
Change-Id: I3cf9d33e5e0789bb5c5d96868e8bf6f90f0fd4ec