### PR TITLE
fix: 移除eventlog对dock的依赖

### DIFF
--- a/bin/dde-session-daemon/daemon.go
+++ b/bin/dde-session-daemon/daemon.go
@@ -192,7 +192,6 @@ func (s *SessionDaemon) register(service *dbusutil.Service) error {
 func (s *SessionDaemon) initModules() {
 	part1ModuleNames := []string{
 		"dock",
-		"eventlog",
 		"trayicon",
 		"launcher",
 		"x-event-monitor",
@@ -220,6 +219,7 @@ func (s *SessionDaemon) initModules() {
 		//"miracast", // need network
 		"systeminfo",
 		"lastore",
+		"eventlog",
 		"calltrace",
 		"debug",
 	}

--- a/session/eventlog/module.go
+++ b/session/eventlog/module.go
@@ -57,7 +57,7 @@ type Module struct {
 }
 
 func (m *Module) GetDependencies() []string {
-	return []string{"dock"}
+	return []string{}
 }
 
 func newModule(logger *log.Logger) *Module {


### PR DESCRIPTION
dock在part1中启动，eventlog无需对其依赖

Log: 移除eventlog对dock的依赖
Bug: https://pms.uniontech.com/bug-view-154713.html
Influence: dde-session-daemon 模块加载顺序
Change-Id: I4df2900c6edb79d77a10b7a6b6e14ab3b511e91a