### PR TITLE
Revert "fix: 修复调用IsX11SessionActive接口失败"

### DIFF
--- a/misc/services/com.deepin.LastoreSessionHelper.service
+++ b/misc/services/com.deepin.LastoreSessionHelper.service
@@ -1,4 +1,4 @@
 [D-BUS Service]
 Name=com.deepin.LastoreSessionHelper
-Exec=/usr/bin/dbus-send --session --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.RunCommand string:'/usr/lib/deepin-daemon/dde-session-daemon' array:string:''
+Exec=/usr/lib/deepin-daemon/dde-session-daemon
 

--- a/misc/services/com.deepin.api.XEventMonitor.service
+++ b/misc/services/com.deepin.api.XEventMonitor.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.api.XEventMonitor
-Exec=/usr/bin/dbus-send --session --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.RunCommand string:'/usr/lib/deepin-daemon/dde-session-daemon' array:string:''
+Exec=/usr/lib/deepin-daemon/dde-session-daemon

--- a/misc/services/com.deepin.daemon.Appearance.service
+++ b/misc/services/com.deepin.daemon.Appearance.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.daemon.Appearance
-Exec=/usr/bin/dbus-send --session --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.RunCommand string:'/usr/lib/deepin-daemon/dde-session-daemon' array:string:''
+Exec=/usr/lib/deepin-daemon/dde-session-daemon

--- a/misc/services/com.deepin.daemon.Audio.service
+++ b/misc/services/com.deepin.daemon.Audio.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.daemon.Audio
-Exec=/usr/bin/dbus-send --session --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.RunCommand string:'/usr/lib/deepin-daemon/dde-session-daemon' array:string:''
+Exec=/usr/lib/deepin-daemon/dde-session-daemon

--- a/misc/services/com.deepin.daemon.Bluetooth.service
+++ b/misc/services/com.deepin.daemon.Bluetooth.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.daemon.Bluetooth
-Exec=/usr/bin/dbus-send --session --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.RunCommand string:'/usr/lib/deepin-daemon/dde-session-daemon' array:string:''
+Exec=/usr/lib/deepin-daemon/dde-session-daemon

--- a/misc/services/com.deepin.daemon.EventLog.service
+++ b/misc/services/com.deepin.daemon.EventLog.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.daemon.EventLog
-Exec=/usr/bin/dbus-send --session --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.RunCommand string:'/usr/lib/deepin-daemon/dde-session-daemon' array:string:''
+Exec=/usr/lib/deepin-daemon/dde-session-daemon

--- a/misc/services/com.deepin.daemon.InputDevices.service
+++ b/misc/services/com.deepin.daemon.InputDevices.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.daemon.InputDevices
-Exec=/usr/bin/dbus-send --session --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.RunCommand string:'/usr/lib/deepin-daemon/dde-session-daemon' array:string:''
+Exec=/usr/lib/deepin-daemon/dde-session-daemon

--- a/misc/services/com.deepin.daemon.Keybinding.service
+++ b/misc/services/com.deepin.daemon.Keybinding.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.daemon.Keybinding
-Exec=/usr/bin/dbus-send --session --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.RunCommand string:'/usr/lib/deepin-daemon/dde-session-daemon' array:string:''
+Exec=/usr/lib/deepin-daemon/dde-session-daemon

--- a/misc/services/com.deepin.daemon.Mime.service
+++ b/misc/services/com.deepin.daemon.Mime.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.daemon.Mime
-Exec=/usr/bin/dbus-send --session --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.RunCommand string:'/usr/lib/deepin-daemon/dde-session-daemon' array:string:''
+Exec=/usr/lib/deepin-daemon/dde-session-daemon

--- a/misc/services/com.deepin.daemon.Network.service
+++ b/misc/services/com.deepin.daemon.Network.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.daemon.Network
-Exec=/usr/bin/dbus-send --session --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.RunCommand string:'/usr/lib/deepin-daemon/dde-session-daemon' array:string:''
+Exec=/usr/lib/deepin-daemon/dde-session-daemon

--- a/misc/services/com.deepin.daemon.Power.service
+++ b/misc/services/com.deepin.daemon.Power.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.daemon.Power
-Exec=dbus-send --session --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.RunCommand string:'/usr/lib/deepin-daemon/dde-session-daemon' array:string:''
+Exec=/usr/lib/deepin-daemon/dde-session-daemon

--- a/misc/services/com.deepin.daemon.SessionWatcher.service
+++ b/misc/services/com.deepin.daemon.SessionWatcher.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.daemon.SessionWatcher
-Exec=/usr/bin/dbus-send --session --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.RunCommand string:'/usr/lib/deepin-daemon/dde-session-daemon' array:string:''
+Exec=/usr/lib/deepin-daemon/dde-session-daemon

--- a/misc/services/com.deepin.daemon.SystemInfo.service
+++ b/misc/services/com.deepin.daemon.SystemInfo.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.daemon.SystemInfo
-Exec=/usr/bin/dbus-send --session --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.RunCommand string:'/usr/lib/deepin-daemon/dde-session-daemon' array:string:''
+Exec=/usr/lib/deepin-daemon/dde-session-daemon

--- a/misc/services/com.deepin.daemon.Timedate.service
+++ b/misc/services/com.deepin.daemon.Timedate.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.daemon.Timedate
-Exec=/usr/bin/dbus-send --session --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.RunCommand string:'/usr/lib/deepin-daemon/dde-session-daemon' array:string:''
+Exec=/usr/lib/deepin-daemon/dde-session-daemon

--- a/misc/services/com.deepin.daemon.Zone.service
+++ b/misc/services/com.deepin.daemon.Zone.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.daemon.Zone
-Exec=/usr/bin/dbus-send --session --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.RunCommand string:'/usr/lib/deepin-daemon/dde-session-daemon' array:string:''
+Exec=/usr/lib/deepin-daemon/dde-session-daemon

--- a/misc/services/com.deepin.dde.daemon.Dock.service
+++ b/misc/services/com.deepin.dde.daemon.Dock.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.dde.daemon.Dock
-Exec=/usr/bin/dbus-send --session --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.RunCommand string:'/usr/lib/deepin-daemon/dde-session-daemon' array:string:''
+Exec=/usr/lib/deepin-daemon/dde-session-daemon

--- a/misc/services/com.deepin.dde.daemon.Launcher.service
+++ b/misc/services/com.deepin.dde.daemon.Launcher.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.dde.daemon.Launcher
-Exec=/usr/bin/dbus-send --session --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.RunCommand string:'/usr/lib/deepin-daemon/dde-session-daemon' array:string:''
+Exec=/usr/lib/deepin-daemon/dde-session-daemon


### PR DESCRIPTION
This reverts commit 1a18d2b706b892bedab18ab06627667061d5ac02.

Reason for revert: 此修改会导致新用户进入桌面卡顿的问题
Log: 修复新建用户进入桌面卡顿的问题
Bug: https://pms.uniontech.com/bug-view-156243.html
     https://pms.uniontech.com/bug-view-155875.html
     https://pms.uniontech.com/bug-view-154713.html
Influence: 新用户桌面正常使用