### PR TITLE
fix: 对DisplayPinCode和DisplayPasskey进行处理，主动调用弹窗

### DIFF
--- a/bluetooth/utils_notify.go
+++ b/bluetooth/utils_notify.go
@@ -102,7 +102,7 @@ func notify(icon, summary, body string) {
 
 // notify pc initiative connect to device
 // so do not need to show notification window
-func notifyInitiativeConnect(dev *DeviceInfo, pinCode string) error {
+func notifyInitiativeConnect(dev *DeviceInfo, pinCode string, needCancel string) error {
 	if checkProcessExists(bluetoothDialog) {
 		logger.Info("initiative already exist")
 		return nil
@@ -111,7 +111,7 @@ func notifyInitiativeConnect(dev *DeviceInfo, pinCode string) error {
 	timestamp := strconv.FormatInt(time.Now().UnixNano(), 10)
 	//use command to open osd window to show pin code
 	// #nosec G204
-	cmd := exec.Command(notifyDdeDialogPath, pinCode, string(dev.Path), timestamp)
+	cmd := exec.Command(notifyDdeDialogPath, pinCode, string(dev.Path), timestamp, needCancel)
 	err := cmd.Start()
 	if err != nil {
 		logger.Infof("execute cmd command failed,err:%v", err)


### PR DESCRIPTION
由于以上两种情况目前只有控制中心实现了对应的信号监听，任务栏插件未实现，因此在daemon中统一调用dde-session-ui中的弹窗显示

Log: 对DisplayPinCode和DisplayPasskey进行处理，主动调用弹窗
Bug: https://pms.uniontech.com/bug-view-155417.html
Influence: 蓝牙连接
Change-Id: I254a1974e20e4a972e3c19f6cdde0bfa87894b1c