### PR TITLE
fix: 禁用监听进程创建后的优先级调度

### DIFF
--- a/misc/usr/share/deepin/scheduler/config.json
+++ b/misc/usr/share/deepin/scheduler/config.json
@@ -1,6 +1,6 @@
 {
   "enabled": true,
-  "procMonitorEnabled": true,
+  "procMonitorEnabled": false,
   "processes": {
     "/usr/bin/deepin-anything-tool": {
       "cpu": 19


### PR DESCRIPTION
由于影响性能，禁用监听进程创建后的优先级调度

Log: 禁用监听进程创建后的优先级调度
Bug: https://pms.uniontech.com/bug-view-138923.html
Influence: 跑分性能
Change-Id: Iea8b61c385422f2e6d156122bc4923a14b0dc6af