### PR TITLE
fix: 修复重置密码框kill后无法再点击进入

### DIFF
--- a/accounts/user_chpwd_union_id.go
+++ b/accounts/user_chpwd_union_id.go
@@ -618,7 +618,7 @@ func doSetPwdWithUnionID(u *User, sender dbus.Sender, count int) error {
 	pwdChangerLock.Lock()
 
 	if pwdChangerProcess != nil {
-		err := syscall.Kill(-pwdChangerProcess.Pid, syscall.SIGKILL)
+		err := syscall.Kill(-pwdChangerProcess.Pid, syscall.SIGTERM)
 		if err != nil {
 			logger.Warning(err)
 		}


### PR DESCRIPTION
改用SIGTERM信号

Log: 修复重置密码框kill后无法再点击进入
Bug: https://pms.uniontech.com/bug-view-159321.html
Influence: 账户-重置密码
Change-Id: I8a3fd14db1831cdb69a01306d62e60ff9ab92c96