### PR TITLE
fix: supportCpuGovernors被人为修改后，就获取本机可用的设置模式，进行对比，若不同则设置成本机支持的模式

### DIFF
--- a/system/power/cpu_handler.go
+++ b/system/power/cpu_handler.go
@@ -36,6 +36,7 @@ type CpuHandlers []CpuHandler
 var _scalingAvailableGovernors = []string {"performance", "powersave", "userspace", "ondemand", "conservative", "schedutil"}
 var _scalingBalanceAvailableGovernors = []string {"ondemand", "conservative", "schedutil", "performance"}
 var _supportGovernors []string
+var _localAvailableGovernors []string
 
 func getScalingAvailableGovernors() []string {
 	return _scalingAvailableGovernors
@@ -47,6 +48,15 @@ func getScalingBalanceAvailableGovernors() []string {
 
 func getSupportGovernors() []string {
 	return _supportGovernors
+}
+
+func getLocalAvailableGovernors() []string {
+	return _localAvailableGovernors
+}
+
+func setLocalAvailableGovernors(value []string) []string {
+	_localAvailableGovernors = value
+	return _localAvailableGovernors
 }
 
 func setSupportGovernors(value []string) []string {
@@ -190,6 +200,16 @@ func (cpus *CpuHandlers) getAvailableGovernors() (ret string, err error) {
 	}
 
 	return ret, err
+}
+
+// 获取可用的Governor数组
+func (cpus *CpuHandlers) getAvailableArrGovernors() []string {
+	value, err := cpus.getAvailableGovernors()
+	if err != nil {
+		logger.Warning(err)
+		return nil
+	}
+	return strings.Split(strings.TrimSpace(string(value)), " ")
 }
 
 func (cpus *CpuHandlers) getCpuGovernorPath() string {

--- a/system/power/cpu_handler_test.go
+++ b/system/power/cpu_handler_test.go
@@ -110,9 +110,36 @@ func Test_getSupportGovernors(t *testing.T) {
 	assert.Equal(t, len(cpuGovernors), 0)
 }
 
+func Test_getLocalAvailableGovernors(t *testing.T) {
+	cpuGovernors := getLocalAvailableGovernors()
+	assert.NotEqual(t, len(cpuGovernors), 10)
+}
+
+func Test_setLocalAvailableGovernors(t *testing.T) {
+	var governors []string = []string{"aaaa", "bbbb", "cccc"}
+	setLocalAvailableGovernors(governors)
+	cpuGovernors := getLocalAvailableGovernors()
+	assert.Equal(t, len(cpuGovernors), 3)
+	assert.Equal(t, cpuGovernors[0], governors[0])
+	assert.Equal(t, cpuGovernors[1], governors[1])
+	assert.Equal(t, cpuGovernors[2], governors[2])
+}
+
 func Test_setSupportGovernors(t *testing.T) {
 	var lines = []string {"1", "2", "3"}
 	assert.NotEqual(t, len(setSupportGovernors(lines)), 10)
+}
+
+func Test_getAvailableGovernors(t *testing.T) {
+	cpus := CpuHandlers{}
+	govs, _ := cpus.getAvailableGovernors()
+	assert.NotEqual(t, govs, "/a/b/c/d")
+}
+
+func Test_getAvailableArrGovernors(t *testing.T) {
+	cpus := CpuHandlers{}
+	govs := cpus.getAvailableArrGovernors()
+	assert.NotEqual(t, len(govs), 10)
 }
 
 func Test_trySetBalanceCpuGovernor(t *testing.T)  {


### PR DESCRIPTION
手动修改supportCpuGovernors后，会出现dconfig配置与实际机器支持的配置不匹配 将本机实际支持的配置，设置到dconfig；即不允许随意修改supportCpuGovernors

Log: supportCpuGovernors必须与机器实际支持的模式匹配，不允许修改成不支持的模式
Influence: supportCpuGovernors修改成不支持的模式
Bug: https://pms.uniontech.com/bug-view-160227.html
Change-Id: I88dd83f3c5f975b9bcf6b2b6c4624e826186c4e3