### PR TITLE
fix: 当BalanceCpuGovernor设置为空或错误的值,将设置模式重新设置成一个支持的值

### DIFF
--- a/system/power/cpu_handler.go
+++ b/system/power/cpu_handler.go
@@ -82,6 +82,10 @@ func getIsPowerSaveSupported() bool {
 	return strv.Strv(getSupportGovernors()).Contains("powersave")
 }
 
+func isSystemSupportMode(mode string) bool {
+	return strv.Strv(_scalingBalanceAvailableGovernors).Contains(mode) && strv.Strv(_supportGovernors).Contains(mode)
+}
+
 func trySetBalanceCpuGovernor(balanceScalingGovernor string) (error, string) {
 	if "" == balanceScalingGovernor {
 		return nil, ""

--- a/system/power/cpu_handler_test.go
+++ b/system/power/cpu_handler_test.go
@@ -115,6 +115,10 @@ func Test_getLocalAvailableGovernors(t *testing.T) {
 	assert.NotEqual(t, len(cpuGovernors), 10)
 }
 
+func Test_isSystemSupportMode(t *testing.T) {
+	assert.Equal(t, isSystemSupportMode("powersave"), false)
+}
+
 func Test_setLocalAvailableGovernors(t *testing.T) {
 	var governors []string = []string{"aaaa", "bbbb", "cccc"}
 	setLocalAvailableGovernors(governors)


### PR DESCRIPTION
1.如果人为将BalanceCpuGovernor dconfig的值设置为空或者错误的值,会导致设置平衡模式设置过去而写入内核的值不变现在增加对异常值的处理,如果存在以上情况则将正确的值设置回去,并设置到dconfig
2. 删除isFirstGetCpuGovernor设置完后就设置成false, 改成使用默认值true, 但支持手动设置

Log: 增强平衡模式设置鲁棒性
Influence: 将BalanceCpuGovernor的配置设置为空或者错误的值
Bug: https://pms.uniontech.com/bug-view-161163.html
Change-Id: I1dc895f1c2f45482d2a14066fbd1df8511715105