### PR TITLE
fix: 添加pkg-config绝对路径,解决backlight_helper 调用refresh崩溃问题

### DIFF
--- a/bin/backlight_helper/ddcci/ddcci.go
+++ b/bin/backlight_helper/ddcci/ddcci.go
@@ -113,7 +113,7 @@ func newDDCCI() (*ddcci, error) {
 		return nil, err
 	}
 
-	content, err := exec.Command("pkg-config", "ddcutil", "--variable=libdir").Output()
+	content, err := exec.Command("/usr/bin/pkg-config", "ddcutil", "--variable=libdir").Output()
 	if err != nil {
 		logger.Warning(err)
 	} else {


### PR DESCRIPTION
添加pgk-config绝对路径

Log: 添加pkg-config绝对路径,解决backlight_helper 调用refresh崩溃问题
Influence: ddcci