### PR TITLE
fix(audio): 修复蓝牙音频设备断开时播放不暂停问题

### DIFF
--- a/audio/audio.go
+++ b/audio/audio.go
@@ -440,9 +440,14 @@ func (a *Audio) autoPause() {
 	if err != nil {
 		logger.Warning(err)
 		pauseAllPlayers()
-	} else if port.Available == pulse.AvailableTypeNo || card.ActiveProfile.Name == "off" {
+	} else if card.ActiveProfile.Name == "off" {
+		pauseAllPlayers()
+	} else if port.Available == pulse.AvailableTypeNo {
 		// 先不暂停，后面根据sink信息判断是否需要暂停
 		a.misc = port.Priority
+		if a.misc == 0 {
+			pauseAllPlayers()
+		}
 	}
 }
 


### PR DESCRIPTION
未对优先级为0的port进行特殊处理

Log: 修复蓝牙音频设备断开时播放不暂停问题
Bug: https://pms.uniontech.com/bug-view-161113.html
Influence: 声音-播放暂停
Change-Id: I14c9f68950e7d930f187d35dbdcd70bdf32f545b