### PR TITLE
chore: modify README license information

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -41,7 +41,7 @@ License: CC0-1.0
 # sh
 Files: gen.sh _tool/prop_gen/gen.sh gen_test_report.sh
 Copyright: None
-License: CC0-1.0
+License: GPL-3.0-or-later
 
 # auto generation files
 Files: *_methods_auto.go *_dbusutil.go *_gen.go

--- a/README.md
+++ b/README.md
@@ -126,4 +126,4 @@ We encourage you to report issues and contribute changes.
 
 ## License
 
-DDE Daemon is licensed under [GPLv3](LICENSE).
+DDE Daemon is licensed under [GPL-3.0-or-later](LICENSE).

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -125,4 +125,4 @@ disable: Disable modules, ignore settings.
 
 ## 开源协议
 
-dde-daemon项目在LGPL-3.0-or-later开源协议下发布。
+dde-daemon项目在[GPL-3.0-or-later](LICENSE)开源协议下发布。


### PR DESCRIPTION
The protocol name in the README is written according to the standard specification

Log: modify README license information
Influence: none
Task: https://pms.uniontech.com/task-view-185215.html
Change-Id: Ic2bce0d39f4900b58e081635097430c0650d6eb9