### PR TITLE
fix: 无线网络快捷键会影响飞行模式的使能

### DIFF
--- a/keybinding/manager.go
+++ b/keybinding/manager.go
@@ -735,6 +735,18 @@ func (m *Manager) handleKeyEventByWayland(changKey string) {
 		}
 
 	} else if action.Type == shortcuts.ActionTypeToggleWireless {
+		// 如果已经开启了飞行模式，则不能通过快捷键去控制wifi的使能
+		enabled, err := m.airplane.Enabled().Get(0)
+		if err != nil {
+			logger.Warningf("get airplane enabled failed, err: %v", err)
+			return
+		}
+
+		if enabled {
+			logger.Debugf("airplane mode enabled, can not enable wireless by key")
+			return
+		}
+
 		// check if allow set wireless
 		// and check if Wifi shortcut effected by DDE software
 		if m.gsMediaKey.GetBoolean(gsKeyUpperLayerWLAN) && m.wifiControlEnable {


### PR DESCRIPTION
当打开飞行模式后，不能通过快捷键去控制无线网络的使能

Log: 修复无线网络快捷键会影响飞行模式的使能的问题
Bug: https://pms.uniontech.com/bug-view-161421.html
Influence: 飞行模式功能正常使用
Change-Id: I6fb029c55fe2e5084adda466852f97a69f160a0d