### PR TITLE
fix(audio): 修复前后都插入设备，插拔前置耳机设备不暂停问题

### DIFF
--- a/audio/audio.go
+++ b/audio/audio.go
@@ -443,9 +443,9 @@ func (a *Audio) autoPause() {
 	} else if card.ActiveProfile.Name == "off" {
 		pauseAllPlayers()
 	} else if port.Available == pulse.AvailableTypeNo {
-		// 先不暂停，后面根据sink信息判断是否需要暂停
+		// 使用优先级并且未开启自动切换时，先不暂停，后面根据sink信息判断是否需要暂停
 		a.misc = port.Priority
-		if a.misc == 0 {
+		if a.misc == 0 || a.canAutoSwitchPort() {
 			pauseAllPlayers()
 		}
 	}


### PR DESCRIPTION
优先级算法和主线逻辑冲突

Log: 修复前后都插入设备，插拔前置耳机设备不暂停问题
Bug: https://pms.uniontech.com/bug-view-162427.html
Influence: 声音-播放暂停
Change-Id: I794508a72daaaef30438e48f8aa7eb54997889ac