### PR TITLE
fix: 性能模式初始化优化

### DIFF
--- a/system/power/manager.go
+++ b/system/power/manager.go
@@ -155,8 +155,8 @@ func newManager(service *dbusutil.Service) (*Manager, error) {
 	availableArrGovernors := m.cpus.getAvailableArrGovernors()
 
 	setUseNormalBalance(useNormalBalance())
-	//  如果当前是 平衡模式, 且CpuGovernor不是performance, 则需要将m.CpuGovernor设置为performance
-	if m.Mode == "balance" && m.CpuGovernor != "performance" {
+	//  如果当前是 平衡模式, 且不走正常平衡模式，且CpuGovernor不是performance, 则需要将m.CpuGovernor设置为performance
+	if m.Mode == "balance" && !getUseNormalBalance() && m.CpuGovernor != "performance" {
 		err := m.doSetCpuGovernor("performance")
 		if err != nil {
 			logger.Warning(err)


### PR DESCRIPTION
在初始化的时候，增加getUseNormalBalance判断
只有返回false的时候，才需要在当前为balance将CpuGovernor设置为performance

Log: 性能模式初始化优化
Influence: 性能模式初始化
Task: https://pms.uniontech.com/task-view-200675.html
Change-Id: I4d9d2724246605658477e71d4e2a2511765d7f28