### PR TITLE
fix: 将恢复配置逻辑放到设置所有性能模式的后面

### DIFF
--- a/system/power/manager.go
+++ b/system/power/manager.go
@@ -130,11 +130,7 @@ func newManager(service *dbusutil.Service) (*Manager, error) {
 		BatteryPercentage: 100,
 		cpus:              NewCpuHandlers(),
 	}
-	err := m.init()
-	if err != nil {
-		m.destroy()
-		return nil, err
-	}
+
 	systemBus, err := dbus.SystemBus()
 	if err != nil {
 		return nil, err
@@ -238,6 +234,12 @@ func newManager(service *dbusutil.Service) (*Manager, error) {
 	}
 
 	logger.Info(" init end. getSupportGovernors ： ", getSupportGovernors(), " , m.balanceScalingGovernor : ", m.balanceScalingGovernor)
+
+	err = m.init()
+	if err != nil {
+		m.destroy()
+		return nil, err
+	}
 
 	return m, nil
 }


### PR DESCRIPTION
存在一种特殊情况：当前设置的性能模式，是/sys/devices/system/cpu/cpu0/cpufreq/scaling_available_governors最初不支持的，而通过设置6个性能模式后才支持；而重启会导致该文件又丢失默认支持数据，系统的恢复配置就会认为当前设置的模式是系统不支持的

修改方案：
将恢复配置放到设置性能模式后面

Log: 将恢复配置逻辑放到设置所有性能模式后面
Influence: 设置的模式为scaling_available_governors最初不支持的
Task: https://pms.uniontech.com/task-view-200675.html
Change-Id: Iaff242b40f35b5d348db8be783307971d9bcbbef