### PR TITLE
fix: 后台用户不处理开盒盖信号

### DIFF
--- a/session/power/lid_switch.go
+++ b/session/power/lid_switch.go
@@ -58,6 +58,9 @@ func (h *LidSwitchHandler) onLidOpened() {
 }
 
 func (h *LidSwitchHandler) onLidDelayOperate(state bool) {
+	if _manager != nil && !_manager.sessionActive { // session未激活状态不处理
+		return
+	}
 	if h.cookie != nil {
 		h.cookie <- struct{}{}
 		close(h.cookie)


### PR DESCRIPTION
由于后台用户响应信号，导致部分机器切换至后台用户时产生异常情况

Log: 后台用户不处理开盒盖信号
Bug: https://pms.uniontech.com/bug-view-162475.html
Influence: 开盒盖处理
Change-Id: Id81c04bfe4a032489bede72e87cdc2893a5cfb8e