### PR TITLE
fix: 控制中心域管用户账户类型显示错误

### DIFF
--- a/accounts/user.go
+++ b/accounts/user.go
@@ -199,8 +199,14 @@ func NewUdcpUser(usrId uint32, service *dbusutil.Service, groups []string) (*Use
 		PasswordLastChange: 18737,
 	}
 
-	u.AccountType = users.UserTypeUdcp
 	u.Groups = groups
+
+	// 解析对应域管用户是否有添加到sudo组里面，有为管理员用户，否则为标准用户
+	if strv.Strv(groups).Contains("sudo") {
+		u.AccountType = users.UserTypeAdmin
+	} else {
+		u.AccountType = users.UserTypeStandard
+	}
 
 	loadUserConfigInfo(u)
 	return u, err

--- a/accounts/users/manager.go
+++ b/accounts/users/manager.go
@@ -29,7 +29,6 @@ const (
 const (
 	UserTypeStandard = iota
 	UserTypeAdmin
-	UserTypeUdcp
 )
 
 func CreateUser(username, fullname, shell string) error {


### PR DESCRIPTION
通过解析域管是否有加入sudo组，判断该域用户是否是管理员用户

Log: 修复控制中心域管用户账户类型显示错误问题
Bug: https://pms.uniontech.com/bug-view-163513.html
Influence: 控制中心域账户类型显示
Change-Id: I194e411bd3ef550f216990fc9a6cc90b90c6e18c