### PR TITLE
fix(network): s3,s4压测，nm扫描接口异常，不能提供ap热点数据

### DIFF
--- a/system/network/network.go
+++ b/system/network/network.go
@@ -476,6 +476,26 @@ func (n *Network) disableDevice(d *device) error {
 		return err
 	}
 
+	//TODO:
+	//cause of nm'bug, sometimes accessapoints list is nil
+	//so add a judge in system network, if get nil in GetAllAccessPoints func, set wirelessEnable down.
+	if d.type0 == nm.NM_DEVICE_TYPE_WIFI {
+		accessPointsList, err := d.nmDevice.Wireless().GetAllAccessPoints(0)
+		if err != nil {
+			logger.Debug("GetAllAccessPoints in system network ", err)
+		}
+		if len(accessPointsList) > 0 {
+			logger.Debug("have aplist existed!!!")
+		} else {
+			err = n.nmManager.WirelessEnabled().Set(0, false)
+			if err != nil {
+				logger.Debug("set WirelessEnabled in system network failed ", err)
+				return err
+			}
+			return nil
+		}
+	}
+
 	state, err := d.nmDevice.Device().State().Get(0)
 	if err != nil {
 		return err


### PR DESCRIPTION
在上层开关处做处理，可使其在上层开关操作中恢复

Log: 修复wifi列表为空，无法恢复问题
Bug: https://pms.uniontech.com/bug-view-162641.html
Influence: 网络-wifi
Change-Id: Ic76536a7378cbef9392a908cf080af837da53a06