### PR TITLE
fix: 断开蓝牙暂停音乐，使用端口可能为空导致崩溃

### DIFF
--- a/audio/bluez_audio.go
+++ b/audio/bluez_audio.go
@@ -184,7 +184,7 @@ func (card *Card) BluezModeOpts() []string {
 		v := strings.ToLower(profile.Name)
 
 		if filterList.Contains(v) {
-			logger.Debugf("filter bluez mode", v)
+			logger.Debug("filter bluez mode", v)
 			continue
 		}
 


### PR DESCRIPTION
添加指针不为空判断

Log: 增强dde-session-daemon鲁棒性
Influence: 断开蓝牙音乐暂停
Bug: https://pms.uniontech.com/bug-view-161113.html
Change-Id: I421dd2f591033529d80e3ffc27da015f7cb45a06