### PR TITLE
fix(audio): 修复忽略蓝牙设备，音频播放概率无法暂停问题

### DIFF
--- a/audio/sink.go
+++ b/audio/sink.go
@@ -51,6 +51,9 @@ type Sink struct {
 	Card uint32
 
 	props map[string]string
+
+	// 当前是否是可插拔sink
+	pluggable bool
 }
 
 func newSink(sinkInfo *pulse.Sink, audio *Audio) *Sink {


### PR DESCRIPTION
音频调用为异步，时序问题概率导致判断条件失效，需缓存上下文信息判断。

Log: 修复忽略蓝牙设备，音频播放概率无法暂停问题
Bug: https://pms.uniontech.com/bug-view-161113.html
Influence: 音频播放
Change-Id: I08dd099e651cb05810228186c89d4cc5571b8439