### PR TITLE
fix: 修复windows蓝牙传输小文件问题

### DIFF
--- a/bluetooth/bluetooth.go
+++ b/bluetooth/bluetooth.go
@@ -633,6 +633,13 @@ func (b *Bluetooth) getConnectedDeviceByAddress(address string) *DeviceInfo {
 	return devInfo
 }
 
+func (b *Bluetooth) getDeviceByAddress(address string) *DeviceInfo {
+	devInfo := b.devices.findFirst(func(devInfo *DeviceInfo) bool {
+		return devInfo.Address == address
+	})
+	return devInfo
+}
+
 func (b *Bluetooth) sendFiles(dev *DeviceInfo, files []string) (dbus.ObjectPath, error) {
 	var totalSize uint64
 


### PR DESCRIPTION
问题1: 小文件传输显示报错，实际成功
问题2: 小文件完成传输后路径在~/.cache/obexd目录下
原因: obexd发送complete信号时，dde无法获取到正确路径，导致不显示以及文件未移动到Downloads目录 解决方案: 手动拼接文件路径

Log: 修复windows蓝牙传输小文件问题
Bug: https://pms.uniontech.com/bug-view-116169.html,https://pms.uniontech.com/bug-view-157505.html
Influence: windows蓝牙传输小文件
Change-Id: I7dc2163ea6a5601a24527f5490f628908aba4c3b