### PR TITLE
fix: 修复PGV系统自定义快捷键未生效的问题

### DIFF
--- a/keybinding/manager_ifc.go
+++ b/keybinding/manager_ifc.go
@@ -232,6 +232,7 @@ func (m *Manager) AddCustomShortcut(name, action, keystroke string) (id string,
 		return
 	}
 	if _useWayland {
+		name += "-cs"
 		keystrokeStrv := make([]string, 0)
 		keystrokeStrv = append(keystrokeStrv, keystroke)
 		accelJson, err := util.MarshalJSON(util.KWinAccel{
@@ -281,6 +282,7 @@ func (m *Manager) DeleteCustomShortcut(id string) *dbus.Error {
 	}
 	m.shortcutManager.Delete(shortcut)
 	if _useWayland {
+		id += "-cs"
 		logger.Debug("RemoveAccel id: ", id)
 		err := m.wm.RemoveAccel(0, id)
 		if err != nil {

--- a/keybinding/shortcuts/shortcut_manager.go
+++ b/keybinding/shortcuts/shortcut_manager.go
@@ -1091,7 +1091,7 @@ func (sm *ShortcutManager) AddCustom(csm *CustomShortcutManager, wmObj wm.Wm) {
 				logger.Warning("failed to setShortForWayland:", err)
 				continue
 			}
-			sm.WaylandCustomShortCutMap[id] = cmd
+			sm.WaylandCustomShortCutMap[id + "-cs"] = cmd
 			cs := newCustomShort(id, id, keystrokesStrv, wmObj, csm)
 			sm.addWithoutLock(cs)
 		}
@@ -1104,6 +1104,10 @@ func (sm *ShortcutManager) AddCustom(csm *CustomShortcutManager, wmObj wm.Wm) {
 
 func setShortForWayland(shortcut Shortcut, wmObj wm.Wm) (bool, error) {
 	id := shortcut.GetId()
+	isCustom := shortcut.GetType() == ShortcutTypeCustom
+	if isCustom {
+		id += "-cs"
+	}
 	keystrokesStrv := shortcut.getKeystrokesStrv()
 	logger.Debugf("Id: %+v, keystrokesStrv: %+v", id, keystrokesStrv)
 	accelJson, err := util.MarshalJSON(util.KWinAccel{
@@ -1118,7 +1122,7 @@ func setShortForWayland(shortcut Shortcut, wmObj wm.Wm) (bool, error) {
 		logger.Warning("failed to set KWin accels:", id, keystrokesStrv, err)
 		return false, err
 	}
-	if shortcut.GetType() == ShortcutTypeCustom {
+	if isCustom {
 		sessionBus, err := dbus.SessionBus()
 		if err != nil {
 			logger.Warning(err)


### PR DESCRIPTION
自定义快捷键命名如果和系统默认初始化的快捷键冲突，会导致注册失败，将自定义快捷键id加后缀在注册，避免冲突

Log: 修复PGV系统自定义快捷键未生效的问题
Bug: https://pms.uniontech.com/bug-view-166109.html
Influence: 自定义快捷键
Change-Id: I5637478e22f055c8a8b505e976c78956d6e7d58a