### PR TITLE
fix: 唤醒时终结掉重置密码流程

### DIFF
--- a/accounts/manager.go
+++ b/accounts/manager.go
@@ -145,6 +145,22 @@ func NewManager(service *dbusutil.Service) *Manager {
 		}
 	})
 
+	_, _ = m.login1Manager.ConnectPrepareForSleep(func(before bool) {
+		if before {
+			return
+		}
+
+		pwdChangerLock.Lock()
+		defer pwdChangerLock.Unlock()
+
+		if pwdChangerProcess != nil {
+			err := syscall.Kill(-pwdChangerProcess.Pid, syscall.SIGTERM)
+			if err != nil {
+				logger.Warning(err)
+			}
+		}
+	})
+
 	return m
 }
 


### PR DESCRIPTION
唤醒时终结掉重置密码流程

Log: 修复待机唤醒后，进入桌面，重置密码框没有消失
Bug: https://pms.uniontech.com/bug-view-151905.html
Influence: 重置密码
Change-Id: I62a4d58ea0d5d08a3cce03a50b1cf0e23ff6b670