### PR TITLE
fix(audio): 处理蓝牙profile为off的特殊情况

### DIFF
--- a/audio/audio.go
+++ b/audio/audio.go
@@ -946,7 +946,8 @@ func (a *Audio) setPort(cardId uint32, portName string, direction int) error {
 		return a.setDefaultSourceWithPort(cardId, portName)
 	}
 
-	if targetPortInfo.Profiles.Exists(card.ActiveProfile.Name) {
+	// 蓝牙特殊情况下会出错，导致profile为off, 需要重新寻找合适的
+	if targetPortInfo.Profiles.Exists(card.ActiveProfile.Name) && card.ActiveProfile.Name != "off" {
 		// no need to change profile
 		return setDefaultPort()
 	}

--- a/audio/audio_events.go
+++ b/audio/audio_events.go
@@ -605,6 +605,12 @@ func (a *Audio) notifyBluezCardPortInsert(card *Card) {
 		logger.Warning(err)
 	}
 
+	// 蓝牙模式配置出错情况过滤通知
+	if card.ActiveProfile.Name == "off" {
+		logger.Debugf("filter bluez notify, beacuse profile is off")
+		return
+	}
+
 	// 蓝牙会根据模式过滤端口，因此忽略unknown状态
 	for _, port := range card.Ports {
 		if port.Available == pulse.AvailableTypeNo {

--- a/audio/card.go
+++ b/audio/card.go
@@ -100,12 +100,6 @@ func (c *Card) update(card *pulse.Card) {
 					logger.Debugf("filter bluez input port %s", port.Name)
 					port.Available = pulse.AvailableTypeNo
 				}
-
-				if c.ActiveProfile.Name == "off" {
-					// off模式过滤所有端口
-					logger.Debugf("filter bluez input port %s", port.Name)
-					port.Available = pulse.AvailableTypeNo
-				}
 			}
 		}
 		c.Ports = append(c.Ports, port)


### PR DESCRIPTION
蓝牙 profile 为 off 并不一定是蓝牙断开的情况，过滤掉端口会导致蓝牙无法
重新选择，只能断开再重连。

Log: 修复蓝牙出错无法使用的问题
Task: https://pms.uniontech.com/task-view-210273.html
Influence: 声音-蓝牙
Change-Id: I7ce8d8e90300fb584289d5404079f585b45731f1