### PR TITLE
fix: 控制中心域账户类型显示错误

### DIFF
--- a/accounts/handle_event.go
+++ b/accounts/handle_event.go
@@ -152,6 +152,11 @@ func (m *Manager) handleFileGroupChanged() {
 	m.usersMapMu.Lock()
 	defer m.usersMapMu.Unlock()
 	for _, u := range m.usersMap {
+		// 域管用户的组由域管服务器统一管理，本地账户修改用户组文件后不应该更新域管相关账户属性
+		if m.isUdcpUserID(u.Uid) {
+			continue
+		}
+
 		u.updatePropAccountType()
 		u.updatePropCanNoPasswdLogin()
 		u.updatePropGroups()

--- a/accounts/user.go
+++ b/accounts/user.go
@@ -353,10 +353,13 @@ func (u *User) writeUserConfig() error {
 	return u.writeUserConfigWithChanges(nil)
 }
 
-func (u *User) updatePropAccountType() {
-	newVal := u.getAccountType()
+func (u *User) updatePropAccountType(accountType int32) {
+	if accountType == u.AccountType {
+		return
+	}
+
 	u.PropsMu.Lock()
-	u.setPropAccountType(newVal)
+	u.setPropAccountType(accountType)
 	u.PropsMu.Unlock()
 }
 


### PR DESCRIPTION
域管用户的组由域管服务器统一管理，本地账户修改用户组文件后不去更新域管用户的相关账户属性

Log: 修复控制中心域账户类型显示错误的问题
Bug: https://pms.uniontech.com/bug-view-166345.html
Influence: 控制中心账户类型显示
Change-Id: Id524052eafadce3bb6de16305e57f96f536edfd4