### PR TITLE
fix: 控制中心域账户类型显示错误

### DIFF
--- a/accounts/handle_event.go
+++ b/accounts/handle_event.go
@@ -151,10 +151,28 @@ func (m *Manager) updatePropUserList() {
 func (m *Manager) handleFileGroupChanged() {
 	m.usersMapMu.Lock()
 	defer m.usersMapMu.Unlock()
+	accountType := int32(users.UserTypeStandard)
+	var groups []string
+
 	for _, u := range m.usersMap {
-		u.updatePropAccountType()
+		if m.isUdcpUserID(u.Uid) {
+			groups, err := m.udcpCache.GetUserGroups(0, u.UserName)
+			if err != nil {
+				logger.Warningf("Udcp cache getUserGroups failed: %v", err)
+				return
+			}
+
+			if strv.Strv(groups).Contains("sudo") {
+				accountType = users.UserTypeAdmin
+			}
+		} else {
+			accountType = u.getAccountType()
+			groups = u.getGroups()
+		}
+
+		u.updatePropAccountType(accountType)
 		u.updatePropCanNoPasswdLogin()
-		u.updatePropGroups()
+		u.updatePropGroups(groups)
 	}
 }
 

--- a/accounts/user.go
+++ b/accounts/user.go
@@ -353,10 +353,9 @@ func (u *User) writeUserConfig() error {
 	return u.writeUserConfigWithChanges(nil)
 }
 
-func (u *User) updatePropAccountType() {
-	newVal := u.getAccountType()
+func (u *User) updatePropAccountType(accountType int32) {
 	u.PropsMu.Lock()
-	u.setPropAccountType(newVal)
+	u.setPropAccountType(accountType)
 	u.PropsMu.Unlock()
 }
 
@@ -367,10 +366,9 @@ func (u *User) updatePropCanNoPasswdLogin() {
 	u.PropsMu.Unlock()
 }
 
-func (u *User) updatePropGroups() {
-	newVal := u.getGroups()
+func (u *User) updatePropGroups(groups []string) {
 	u.PropsMu.Lock()
-	u.setPropGroups(newVal)
+	u.setPropGroups(groups)
 	u.PropsMu.Unlock()
 }
 


### PR DESCRIPTION
域管用户的组由域管服务器统一管理，当本地账户修改用户组文件后
重新从域管服务器获取用户组,根据当前用户的状态(是否在sudo组中)判断其是否为管理员类型

Log: 修复控制中心域账户类型显示错误的问题
Bug: https://pms.uniontech.com/bug-view-166345.html
Influence: 控制中心账户类型显示
Change-Id: Id524052eafadce3bb6de16305e57f96f536edfd4