### PR TITLE
fix: 修复社区版【其他发行版】【debian】任务栏选择智能隐藏状态，任务栏一直闪烁的问题

### DIFF
--- a/dock/dock_manager_hide_state.go
+++ b/dock/dock_manager_hide_state.go
@@ -153,6 +153,14 @@ func (m *Manager) isWindowDockOverlap(win x.Window) (bool, error) {
 		return false, err
 	}
 
+	// 与dock区域完全重合的情况认为就是dock本身
+	if winRect.X == m.FrontendWindowRect.X &&
+		winRect.Y == m.FrontendWindowRect.Y &&
+		winRect.Height == m.FrontendWindowRect.Height &&
+		winRect.Width == m.FrontendWindowRect.Width {
+		logger.Warning("FrontendWindowRect' geometry is the same as winRect' geometry")
+		return false, nil
+	}
 	logger.Debug("window rect:", winRect)
 	logger.Debug("dock rect:", m.FrontendWindowRect)
 	return hasIntersection(winRect, m.FrontendWindowRect), nil


### PR DESCRIPTION
dock本身被识别成了桌面窗口，区域重合，导致隐藏状态判断错误

Log: 修复社区版【其他发行版】【debian】任务栏选择智能隐藏状态，任务栏一直闪烁的问题
Bug: https://pms.uniontech.com/bug-view-166193.html
Influence: 任务栏智能隐藏
Change-Id: I5c13c5b909d17e5ce9e922959071f84508661411