### PR TITLE
chore: 优化dde-daemon用户图片加载方式

### DIFF
--- a/accounts/accounts.go
+++ b/accounts/accounts.go
@@ -11,8 +11,9 @@ import (
 )
 
 var (
-	_imageBlur *ImageBlur
-	logger     = log.NewLogger("daemon/accounts")
+	_imageBlur         *ImageBlur
+	_userStandardIcons []string
+	logger             = log.NewLogger("daemon/accounts")
 )
 
 func init() {
@@ -57,6 +58,7 @@ func (d *Daemon) Start() error {
 
 	d.imageBlur = newImageBlur(service)
 	_imageBlur = d.imageBlur
+	_userStandardIcons = getUserStandardIcons()
 	err = service.Export(imageBlurDBusPath, d.imageBlur)
 	if err != nil {
 		d.imageBlur = nil

--- a/accounts/user.go
+++ b/accounts/user.go
@@ -231,7 +231,7 @@ func (u *User) updateIconList() {
 }
 
 func (u *User) getAllIcons() []string {
-	icons := getUserStandardIcons()
+	icons := _userStandardIcons
 	if u.customIcon != "" {
 		icons = append(icons, u.customIcon)
 	}


### PR DESCRIPTION
用户图片在daemon启动时去加载一次，后面统一使用此缓存的图片列表
防止每次新建用户时均去加载一次（多用户下会加载多次）

Log: 优化dde-daemon用户图片加载方式
Bug: https://pms.uniontech.com/bug-view-158339.html
Influence: 控制中心用户图片显示
Change-Id: Ia38af9f2c5e95cbd6b9afd41f0e57107999cce4b