### PR TITLE
feat: 申威平台新增 deepin_gfxmode 支持

### DIFF
--- a/grub_common/common.go
+++ b/grub_common/common.go
@@ -224,7 +224,7 @@ func IsGfxmodeDetectFailed(params map[string]string) bool {
 
 func HasDeepinGfxmodeMod() bool {
 	dir := "/boot/grub"
-	for _, platform := range []string{"i386-pc", "x86_64-efi", "arm64-efi"} {
+	for _, platform := range []string{"i386-pc", "x86_64-efi", "arm64-efi", "sw64-efi"} {
 		modFile := filepath.Join(dir, platform, "deepin_gfxmode.mod")
 		_, err := os.Stat(modFile)
 		if err == nil {


### PR DESCRIPTION
申威桌面平台（SW831）近期会迁移到新的 grub2，支持标准EFI，支持 grub 模块。

Signed-off-by: Changwei Miao <miaochangwei@uniontech.com>