### PR TITLE
feat: 关闭等保三级后解除用户的自动登录设置

### DIFF
--- a/accounts/handle_event.go
+++ b/accounts/handle_event.go
@@ -259,6 +259,10 @@ func (m *Manager) deleteUser(uid string) {
 		logger.Warningf("uid %s not found", uid)
 	}
 
+	if users.IsAutoLoginUser(user.UserName) {
+		_ = users.SetAutoLoginUser("", "")
+	}
+
 	userPath := userDBusPathPrefix + uid
 	m.stopExportUser(userPath)
 	err := m.service.Emit(m, "UserDeleted", userPath)

--- a/accounts/manager_ifc.go
+++ b/accounts/manager_ifc.go
@@ -176,10 +176,6 @@ func (m *Manager) DeleteUser(sender dbus.Sender,
 		return dbusutil.ToError(err)
 	}
 
-	if users.IsAutoLoginUser(name) {
-		_ = users.SetAutoLoginUser("", "")
-	}
-
 	//delete user config and icons
 	if rmFiles {
 		user.clearData()


### PR DESCRIPTION
在关闭等保三级时会执行删除用户的操作，在删除用户时会去更新/etc/passwd文件
如果删除的用户有开启自动登录选项，解除该用户的自动登录设置

Log: 关闭等保三级后解除用户的自动登录设置
Task: https://pms.uniontech.com/task-view-213563.html
Influence: 账户登录/控制中心账户页面正常显示
Change-Id: I0765d969adc49f78e7c0a206c660b96379bcbf4b