### PR TITLE
fix: 将greeter的默认字号改为10.5

### DIFF
--- a/misc/xsettings/xsettingsd.conf
+++ b/misc/xsettings/xsettingsd.conf
@@ -1,1 +1,2 @@
 Xft/DPI 98304
+Qt/FontName "Noto Sans CJK SC 10.5"


### PR DESCRIPTION
将greeter的默认字号改为10.5（对应控制中心的14号字体），与系统的默认字号保持一致

Log: 将登录界面的字号改为和系统默认字号一致
Bug: https://pms.uniontech.com/bug-view-166353.html
Influence: 登录界面字号