### PR TITLE
fix: 修复GetProxy接口传参异常导致崩溃问题

### DIFF
--- a/network/manager_proxy.go
+++ b/network/manager_proxy.go
@@ -167,7 +167,7 @@ func (m *Manager) SetProxyIgnoreHosts(ignoreHosts string) (busErr *dbus.Error) {
 func (m *Manager) GetProxy(proxyType string) (host, port string, busErr *dbus.Error) {
 	childSettings, err := getProxyChildSettings(proxyType)
 	if err != nil {
-		busErr = dbusutil.ToError(busErr)
+		busErr = dbusutil.ToError(err)
 		return
 	}
 	host = childSettings.GetString(gkeyProxyHost)


### PR DESCRIPTION
dbusutil.ToError传参错误

Log: 修复GetProxy接口传参异常导致崩溃问题
Influence: 崩溃修复
Change-Id: I63c4c7fb8e92703dea87a62eaeb3f11a06f4417c