### PR TITLE
fix: wayland下切换电源屏幕不能点亮

### DIFF
--- a/keybinding/utils.go
+++ b/keybinding/utils.go
@@ -219,13 +219,7 @@ func (m *Manager) systemTurnOffScreen() {
 
 	doPrepareSuspend()
 	if useWayland {
-		if m.dpmsIsOff == false {
-			err = exec.Command("dde_wldpms", "-s", "Off").Run()
-			m.dpmsIsOff = true
-		} else {
-			err = exec.Command("dde_wldpms", "-s", "On").Run()
-			m.dpmsIsOff = false
-		}
+		err = exec.Command("dde_wldpms", "-s", "Off").Run()
 	} else {
 		err = dpms.ForceLevelChecked(m.conn, dpms.DPMSModeOff).Check(m.conn)
 	}


### PR DESCRIPTION
当监听到有鼠标或者键盘按键事件，进行系统唤醒处理（HandleIdleOff)，该操作统一放到电源模块处理

Log: 修复wayland下切换电源屏幕不能点亮的问题
Bug: https://pms.uniontech.com/bug-view-158673.html
     https://pms.uniontech.com/bug-view-170613.html
Influence: 系统正常唤醒（屏幕正常点亮和关闭）
Change-Id: I9ac4c89d4dc55c61c280ce06b0e4e852973e2140