### PR TITLE
feat: lastore模块逻辑修改

### DIFF
--- a/system/power/battery_display.go
+++ b/system/power/battery_display.go
@@ -37,14 +37,16 @@ func (m *Manager) refreshBatteryDisplay() {
 		}
 
 		// copy from bat0
-		bat0.PropsMu.RLock()
-		percentage = bat0.Percentage
-		status = bat0.Status
-		timeToEmpty = bat0.TimeToEmpty
-		timeToFull = bat0.TimeToFull
-		energyFullTotal = bat0.EnergyFull
-		energyFullDesignTotal = bat0.EnergyFullDesign
-		bat0.PropsMu.RUnlock()
+		if bat0 != nil {
+			bat0.PropsMu.RLock()
+			percentage = bat0.Percentage
+			status = bat0.Status
+			timeToEmpty = bat0.TimeToEmpty
+			timeToFull = bat0.TimeToFull
+			energyFullTotal = bat0.EnergyFull
+			energyFullDesignTotal = bat0.EnergyFullDesign
+			bat0.PropsMu.RUnlock()
+		}
 	} else {
 		var energyTotal, energyRateTotal float64
 		statusSlice := make([]battery.Status, 0, batteryCount)
@@ -80,6 +82,7 @@ func (m *Manager) refreshBatteryDisplay() {
 			timeToFull = 0
 		}
 	}
+	// 更新manager的battery status
 	if status == battery.StatusUnknown {
 		if m.OnBattery {
 			status = battery.StatusDischarging
@@ -112,6 +115,10 @@ func (m *Manager) refreshBatteryDisplay() {
 		timeToEmpty,
 		time.Duration(timeToFull)*time.Second,
 		timeToFull)
+	// callback中修改所有电池的状态
+	for _, bat := range m.batteries {
+		bat.setPropStatus(status)
+	}
 }
 
 func (m *Manager) changeBatteryLowByBatteryPercentage(percentage float64) {


### PR DESCRIPTION
原有逻辑: lastore的通知都是dde-session-daemon去监听com.deepin.lastore.Job的状态,持续监听占用资源，而且交互不方便. 
逻辑优化: lastore-daemon定义一套agent接口,由dde-daemon的lastore模块实现相关接口并导出,需要发通知和需要获取系统代理时,lastore-daemon调用agent接口完成.

Log: lastore模块逻辑修改
Task: https://pms.uniontech.com/task-view-214983.html
Influence: 通知和apt代理获取
Change-Id: I27df48576528a5932e7263f3945e156dda53dc3b