### PR TITLE
fix: 增加权限管控

### DIFF
--- a/grub2/grub2.go
+++ b/grub2/grub2.go
@@ -592,3 +592,26 @@ func getOSNum(entries []Entry) uint32 {
 	}
 	return systemNum
 }
+
+func checkInvokePermission(service *dbusutil.Service, sender dbus.Sender) error {
+	pid, err := service.GetConnPID(string(sender))
+	if err != nil {
+		return err
+	}
+	p := procfs.Process(pid)
+	cmd, err := p.Exe()
+	if err != nil {
+		return err
+	}
+	if cmd == "/usr/bin/dde-control-center" {
+		return nil
+	}
+	uid, err := service.GetConnUID(string(sender))
+	if err != nil {
+		return err
+	}
+	if uid != 0 {
+		return fmt.Errorf("not allow %v call this method", sender)
+	}
+	return nil
+}

--- a/grub2/grub2_ifc.go
+++ b/grub2/grub2_ifc.go
@@ -32,7 +32,11 @@ func (*Grub2) GetInterfaceName() string {
 
 // GetSimpleEntryTitles return entry titles only in level one and will
 // filter out some useless entries such as sub-menus and "memtest86+".
-func (grub *Grub2) GetSimpleEntryTitles() (titles []string, busErr *dbus.Error) {
+func (grub *Grub2) GetSimpleEntryTitles(sender dbus.Sender) (titles []string, busErr *dbus.Error) {
+	err := checkInvokePermission(grub.service, sender)
+	if err != nil {
+		return nil, dbusutil.ToError(err)
+	}
 	grub.service.DelayAutoQuit()
 
 	for _, entry := range grub.entries {
@@ -50,6 +54,10 @@ func (grub *Grub2) GetSimpleEntryTitles() (titles []string, busErr *dbus.Error) 
 }
 
 func (g *Grub2) GetAvailableGfxmodes(sender dbus.Sender) (gfxModes []string, busErr *dbus.Error) {
+	err := checkInvokePermission(g.service, sender)
+	if err != nil {
+		return nil, dbusutil.ToError(err)
+	}
 	pid, err := g.service.GetConnPID(string(sender))
 	if err != nil {
 		return nil, dbusutil.ToError(err)
@@ -85,9 +93,13 @@ func (g *Grub2) GetAvailableGfxmodes(sender dbus.Sender) (gfxModes []string, bus
 }
 
 func (g *Grub2) SetDefaultEntry(sender dbus.Sender, entry string) *dbus.Error {
+	err := checkInvokePermission(g.service, sender)
+	if err != nil {
+		return dbusutil.ToError(err)
+	}
 	g.service.DelayAutoQuit()
 
-	err := g.checkAuth(sender, polikitActionIdCommon)
+	err = g.checkAuth(sender, polikitActionIdCommon)
 	if err != nil {
 		return dbusutil.ToError(err)
 	}
@@ -108,9 +120,13 @@ func (g *Grub2) SetDefaultEntry(sender dbus.Sender, entry string) *dbus.Error {
 var errInGfxmodeDetect = errors.New("in gfxmode detection mode")
 
 func (g *Grub2) SetEnableTheme(sender dbus.Sender, enabled bool) *dbus.Error {
+	err := checkInvokePermission(g.service, sender)
+	if err != nil {
+		return dbusutil.ToError(err)
+	}
 	g.service.DelayAutoQuit()
 
-	err := g.checkAuth(sender, polikitActionIdCommon)
+	err = g.checkAuth(sender, polikitActionIdCommon)
 	if err != nil {
 		return dbusutil.ToError(err)
 	}
@@ -142,9 +158,13 @@ func (g *Grub2) SetEnableTheme(sender dbus.Sender, enabled bool) *dbus.Error {
 }
 
 func (g *Grub2) SetGfxmode(sender dbus.Sender, gfxmode string) *dbus.Error {
+	err := checkInvokePermission(g.service, sender)
+	if err != nil {
+		return dbusutil.ToError(err)
+	}
 	g.service.DelayAutoQuit()
 
-	err := g.checkAuth(sender, polikitActionIdCommon)
+	err = g.checkAuth(sender, polikitActionIdCommon)
 	if err != nil {
 		return dbusutil.ToError(err)
 	}
@@ -173,6 +193,10 @@ func (g *Grub2) SetGfxmode(sender dbus.Sender, gfxmode string) *dbus.Error {
 }
 
 func (g *Grub2) SetTimeout(sender dbus.Sender, timeout uint32) *dbus.Error {
+	err := checkInvokePermission(g.service, sender)
+	if err != nil {
+		return dbusutil.ToError(err)
+	}
 	g.service.DelayAutoQuit()
 
 	/*

--- a/grub2/theme_ifc.go
+++ b/grub2/theme_ifc.go
@@ -27,10 +27,14 @@ func (*Theme) GetInterfaceName() string {
 }
 
 func (theme *Theme) SetBackgroundSourceFile(sender dbus.Sender, filename string) *dbus.Error {
+	err := checkInvokePermission(theme.service, sender)
+	if err != nil {
+		return dbusutil.ToError(err)
+	}
 	theme.service.DelayAutoQuit()
 
 	logger.Debugf("SetBackgroundSourceFile: %q", filename)
-	err := theme.g.checkAuth(sender, polikitActionIdCommon)
+	err = theme.g.checkAuth(sender, polikitActionIdCommon)
 	if err != nil {
 		return dbusutil.ToError(err)
 	}
@@ -48,7 +52,11 @@ func (theme *Theme) SetBackgroundSourceFile(sender dbus.Sender, filename string)
 	return nil
 }
 
-func (theme *Theme) GetBackground() (background string, busErr *dbus.Error) {
+func (theme *Theme) GetBackground(sender dbus.Sender) (background string, busErr *dbus.Error) {
+	err := checkInvokePermission(theme.service, sender)
+	if err != nil {
+		return "", dbusutil.ToError(err)
+	}
 	theme.service.DelayAutoQuit()
 
 	theme.g.PropsMu.RLock()


### PR DESCRIPTION
设置仅允许root用户和dde-control-center调用相关接口

Log: 增加权限管控
Task: https://pms.uniontech.com/task-view-220827.html 
Influence: grub2接口调用权限管控
(cherry picked from commit ccb68ea1d1d327f2890d8a5c562e61061c220f0c)