### PR TITLE
fix: 修复快捷键恢复默认后，super+大键盘的数字 无法切换工作区的问题

### DIFF
--- a/keybinding/util/util.go
+++ b/keybinding/util/util.go
@@ -47,9 +47,6 @@ func (kwa *KWinAccel) fix() {
 		}
 		defaultKeystrokes = append(defaultKeystrokes, ks)
 	}
-	if len(defaultKeystrokes) > 1 {
-		defaultKeystrokes = defaultKeystrokes[len(defaultKeystrokes)-1:]
-	}
 
 	kwa.DefaultKeystrokes = defaultKeystrokes
 }


### PR DESCRIPTION
一个快捷键允许匹配多个键值

Log: 修复快捷键恢复默认后，super+大键盘的数字 无法切换工作区的问题
Bug: https://pms.uniontech.com/bug-view-174685.html
Influence: 快捷键