### PR TITLE
fix: wayland环境下任务栏应用图标显示异常

### DIFF
--- a/dock/dock_manager.go
+++ b/dock/dock_manager.go
@@ -70,9 +70,10 @@ type Manager struct {
 	smartHideModeTimer *time.Timer
 	smartHideModeMutex sync.Mutex
 
-	entryCount         uint
-	identifyWindowFuns []*IdentifyWindowFunc
-	windowPatterns     WindowPatterns
+	entryCount          uint
+	identifyWindowFuns  []*IdentifyWindowFunc
+	identifyKWindowFuns []*IdentifyKWindowFunc
+	windowPatterns      WindowPatterns
 
 	forceQuitAppStatus forceQuitAppType
 	windowActMu        sync.Mutex

--- a/dock/dock_manager_init.go
+++ b/dock/dock_manager_init.go
@@ -297,7 +297,12 @@ func (m *Manager) init() error {
 		logger.Warning("startBAMFDaemon failed")
 	}
 
-	m.registerIdentifyWindowFuncs()
+	if m.isWaylandSession {
+		m.registerIdentifyKWindowFuncs()
+	} else {
+		m.registerIdentifyWindowFuncs()
+	}
+
 	m.initEntries()
 	m.pluginSettings = newPluginSettingsStorage(m)
 


### PR DESCRIPTION
wayland环境下增加一种窗口识别机制，对于一个应用对应多个pid（应用pid，应用窗口对应的pid，应用ppid都不相同）的情况 根据process中的可执行文件名和该应用的appId去识别窗口

Log: 修复wayland环境下任务栏应用图标显示异常的问题
Bug: https://pms.uniontech.com/bug-view-166111.html
Influence: 任务栏应用图标正常显示
Change-Id: Id1078b3125fef7f2236e58527da371e1084049d5