### PR TITLE
fix(power): 修复接通电源低电量屏保不消失问题

### DIFF
--- a/session/power/manager_events.go
+++ b/session/power/manager_events.go
@@ -159,7 +159,7 @@ func (m *Manager) handleBatteryDisplayUpdate() {
 		warnLevel = m.getWarnLevel(percentage, timeToEmpty)
 		// 当电池电量从1%->0%时，如果之前的warnLevel不为WarnLevelNone（电池的状态正常），此时不去做warnLevel改变处理
 		// 防止某些机器在电量变为0时低电量屏保被取消，进入锁屏界面
-		if m.warnLevelConfig.getWarnLevelConfig().UsePercentageForPolicy && percentage == 0.0 && m.WarnLevel != WarnLevelNone {
+		if m.warnLevelConfig.getWarnLevelConfig().UsePercentageForPolicy && percentage == 0.0 && m.WarnLevel != WarnLevelNone && m.OnBattery {
 			warnLevelChanged = false
 		} else {
 			warnLevelChanged = m.setPropWarnLevel(warnLevel)


### PR DESCRIPTION
某些机器 0% 的电量可以维持开机，并长时间处于 0% 电量，导致状态无法更新。

Log: 修复接通电源低电量屏保不消失问题
Bug: https://pms.uniontech.com/bug-view-174679.html
Influence: 电池
Change-Id: I981e50e954aab886b037a372034446c386a6a4a5