### PR TITLE
fix(network): 修复IP变化时，前端无法获取到通知

### DIFF
--- a/network/manager.go
+++ b/network/manager.go
@@ -107,6 +107,8 @@ type Manager struct {
 	checkAPStrengthTimer    *time.Timer
 	protalAuthBrowserOpened bool // PORTAL认证中状态
 
+	acinfosJSON string
+
 	// to identify if vpn support multi connections
 	multiVpn map[string]bool
 


### PR DESCRIPTION
由于原先设计并没监听活跃连接相关的子内容，因而当子项属性变化时，
前端无法感知

Log: IP有变化时，控制中心可以获取变化通知，来刷新信息
Bug: https://pms.uniontech.com/zentao/bug-view-82320.html
Influence: 网络
Change-Id: Iac8434144bbdf35ea97184d4ebc54769440a6084