### PR TITLE
fix: 修复关闭触摸板开关，重启后触摸板开关打开的问题

### DIFF
--- a/misc/dsg-configs/org.deepin.dde.daemon.inputdevices.json
+++ b/misc/dsg-configs/org.deepin.dde.daemon.inputdevices.json
@@ -12,6 +12,17 @@
         "description": "",
         "permissions": "readwrite",
         "visibility": "private"
+      },
+      "toupadEnabled": {
+        "value": true,
+        "serial": 0,
+        "flags": ["global"],
+        "name": "touchpad_Enabled",
+        "name[zh_CN]": "触控板启用状态",
+        "description[zh_CN]": "记录触控板状态，保证重启后和上次状态一致",
+        "description": "",
+        "permissions": "readwrite",
+        "visibility": "private"
       }
   }
 }

--- a/system/inputdevices/inputdevices.go
+++ b/system/inputdevices/inputdevices.go
@@ -23,6 +23,7 @@ const (
 	_dsettingsAppID                 = "org.deepin.dde.daemon"
 	_dsettingsInputdevicesName      = "org.deepin.dde.daemon.inputdevices"
 	_dsettingsDeviceWakeupStatusKey = "deviceWakeupStatus"
+	_dsettingsTouchpadEnabledKey    = "toupadEnabled"
 )
 
 //go:generate dbusutil-gen -type InputDevices,Touchpad inputdevices.go touchpad.go
@@ -84,6 +85,15 @@ func (m *InputDevices) init() {
 		m.updateSupportWakeupDevices()
 		if err := TouchpadExist(touchpadSwitchFile); err == nil {
 			m.newTouchpad()
+			v, err := m.dsgInputDevices.Value(0, _dsettingsTouchpadEnabledKey)
+			if err != nil {
+				logger.Warning(err)
+				return
+			}
+			err = m.touchpad.setTouchpadEnable(v.Value().(bool))
+			if err != nil {
+				logger.Warning(err)
+			}
 		}
 	}()
 }
@@ -353,7 +363,6 @@ func (m *InputDevices) newTouchpad() {
 	err := t.export(dbus.ObjectPath(touchpadDBusPath))
 	if err != nil {
 		logger.Warning(err)
-		return
 	}
 
 	m.touchpad = t


### PR DESCRIPTION
内核文件在每次重启之后会重置，由daemon来保存重启之前的状态

Log: 修复关闭触摸板开关，重启后触摸板开关打开的问题
Bug: https://pms.uniontech.com/bug-view-178817.html
Influence: 触控板开关
Change-Id: Ib7835b7149ddc76c506b0fcfe01a720c329d9f2c