### PR TITLE
fix(airplane_mode): 修复飞行模式状态不正确问题

### DIFF
--- a/system/airplane_mode/manager.go
+++ b/system/airplane_mode/manager.go
@@ -230,6 +230,11 @@ func (mgr *Manager) listenWirelessEnabled() {
 		// 仅保存 soft block 的状态
 		btSoftBlocked := mgr.config.GetBlocked(rfkillTypeBT)
 		mgr.config.SetBlocked(rfkillTypeAll, btSoftBlocked && wifiAirplaneMode)
+		err := mgr.config.SaveConfig()
+		if err != nil {
+			logger.Warningf("save rfkill config file failed, err: %v", err)
+		}
+		logger.Debugf("rfkill state, bluetooth: %v, wifi: %v, airplane: %v", mgr.BluetoothEnabled, mgr.WifiEnabled, mgr.Enabled)
 	})
 }
 


### PR DESCRIPTION
wifi 状态变更时未保存状态，rfkill block 事件可能发生在 wifi 事件之前
导致 wifi 状态配置文件与实际状态不一致。

Log: 修复飞行模式状态不正确问题
Bug:
https: //pms.uniontech.com/bug-view-178543.html,https://pms.uniontech.com/bug-view-176849.html
Influence: 无
Change-Id: I16ef534819933061a98658671ee5266317719f5a