### PR TITLE
fix(network): WEP 认证类型错误

### DIFF
--- a/network/nm_setting_wireless_security.go
+++ b/network/nm_setting_wireless_security.go
@@ -73,7 +73,6 @@ func logicSetSettingVkWirelessSecurityKeyMgmt(data connectionData, value string)
 			nm.NM_SETTING_WIRELESS_SECURITY_WEP_KEY_TYPE,
 		)
 		setSettingWirelessSecurityKeyMgmt(data, "none")
-		setSettingWirelessSecurityAuthAlg(data, "open")
 		setSettingWirelessSecurityWepKeyFlags(data, nm.NM_SETTING_SECRET_FLAG_NONE)
 		setSettingWirelessSecurityWepKeyType(data, nm.NM_WEP_KEY_TYPE_KEY)
 	case "wpa-psk":


### PR DESCRIPTION
静态WEP，支持共享密钥（shared）和开放系统（open）。默认settings中不应
该设置为open，否则部分设置为 shared 认证的路由可能会导致连接不成功。

Log: WEP 连接问题
Task: https://pms.uniontech.com/task-view-232863.html
Influence: 无线网络-WEP
Change-Id: Icb3155626ddb327f53329346774a92acd55af47d