### PR TITLE
fix: 修复部分机器监控不到开合盖信号问题

### DIFF
--- a/system/power/lid_switch.go
+++ b/system/power/lid_switch.go
@@ -12,7 +12,11 @@ func (m *Manager) initLidSwitch() {
 	if arch.Get() == arch.Sunway && isSWLidStateFileExist() {
 		m.initLidSwitchSW()
 	} else {
-		m.initLidSwitchCommon()
+		err := m.initLidSwitchByUPower()
+		if err != nil {
+			logger.Warningf("failed to init watch lid switch by upower(%v),start init watch by gudev", err)
+			m.initLidSwitchCommon()
+		}
 	}
 	logger.Debug("hasLidSwitch:", m.HasLidSwitch)
 }


### PR DESCRIPTION
部分机型有多个设备节点可以被认为是lidswitch设备,修改前dde只会监控获取到的第一个设备;upower监控和过滤设备的逻辑和dde一致,但是可以监控多个设备信号,因此修改为使用upower的dbus属性完成该逻辑.

Log: 修复部分机器监控不到开合盖信号问题
Bug: https://pms.uniontech.com/bug-view-170577.html
Influence: 监听开合盖信号
Change-Id: Ia00e7ed2d8ad9890e64f8105d321e48ca90ec871