### PR TITLE
feat: 白盒密码创建WB_UFile优化

### DIFF
--- a/accounts/keyring/common.c
+++ b/accounts/keyring/common.c
@@ -15,25 +15,6 @@ void *dalloc(size_t size) {
     return p;
 }
 
-char *generate_random_str() {
-    static int inited = 0;
-    static char *str =
-        "1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
-    int len = strlen(str);
-    char *masterkey = dalloc(MASTER_KEY_LEN + 1);
-
-    if (!inited) {
-        inited = 1;
-        srand((unsigned)time(NULL));
-    }
-
-    for (int i = 0; i < MASTER_KEY_LEN; i++) {
-        masterkey[i] = str[rand() % len];
-    }
-    masterkey[MASTER_KEY_LEN] = '\0';
-    return masterkey;
-}
-
 char *generate_random_len(unsigned int length) {
     static int inited = 0;
     static char *str = "1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";

--- a/accounts/keyring/common.h
+++ b/accounts/keyring/common.h
@@ -12,9 +12,6 @@
 #include <locale.h>
 #include <pthread.h>
 #include <pwd.h>
-#include <security/_pam_types.h>
-#include <security/pam_ext.h>
-#include <security/pam_modules.h>
 #include <signal.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -29,15 +26,10 @@
 #include <sys/time.h>
 
 #define MASTER_KEY_LEN 16
-#define FILE_PATH_BUF_SIZE 128
-#define MAX_BUF_SIZE 256
-#define LIMITS_BUF_SIZE 1024
-
 #define ENCRYPT_MODE 1
 #define DECRYPT_MODE 0
 
 void *dalloc(size_t size);
-char *generate_random_str();
 char *generate_random_len(unsigned int length);
 unsigned char* deepin_wb_encrypt(unsigned char* IN, unsigned char* key, bool flag);
 unsigned char* sm4_crypt(unsigned char* IN, unsigned char* key, int mode);

--- a/accounts/manager_ifc.go
+++ b/accounts/manager_ifc.go
@@ -45,8 +45,7 @@ func (*Manager) GetInterfaceName() string {
 }
 
 func createWhiteBoxUFile(name string) error {
-	keyring.CreateWhiteBoxUFile(name)
-	return nil
+	return keyring.CreateWhiteBoxUFile(name)
 }
 
 func getUserNameList() (list []string) {
@@ -67,7 +66,11 @@ func (*Manager) createExistAccountWbUFile() {
 		dir := fmt.Sprintf("/var/lib/keyring/%s", name)
 		filename := path.Join(dir, "WB_UFile")
 		if !dutils.IsFileExist(dir) || !dutils.IsFileExist(filename) {
-			keyring.CreateWhiteBoxUFile(name)
+			err := keyring.CreateWhiteBoxUFile(name)
+			if err != nil {
+				logger.Warning("Keyring crypto so not exist.")
+				return
+			}
 		}
 	}
 }
@@ -128,7 +131,6 @@ func (m *Manager) CreateUser(sender dbus.Sender,
 
 	if err = createWhiteBoxUFile(name); err != nil {
 		logger.Warningf("createWhiteBoxUFile: create user '%s' failed: %v\n", name, err)
-		return nilObjPath, dbusutil.ToError(err)
 	}
 
 	// create user success

--- a/debian/control
+++ b/debian/control
@@ -95,7 +95,7 @@ Depends:
  xdotool,
  xkb-data,
  dde-dconfig-daemon,
- dde-crypto,
+ dde-crypto(>= 1.0.2-1~),
  ${dist:Depends},
  ${misc:Depends},
  ${shlibs:Depends},


### PR DESCRIPTION
当string转[]byte时，如果string转成hex后存在00,byte就会直接被截断，导致数据不全

Log: 优化WB_UFile创建
Influence: 白盒密码创建WB_UFile
Task: https://pms.uniontech.com/task-view-212895.html
Change-Id: I3df1e5638e9573bddccaea53f258f9a61a0c7ae9