### PR TITLE
perf: 优化eventlog启动过程中的资源占用

### DIFF
--- a/dock/dock_manager.go
+++ b/dock/dock_manager.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2018 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/godbus/dbus"
-	"github.com/linuxdeepin/dde-daemon/common/dsync"
 	libApps "github.com/linuxdeepin/go-dbus-factory/com.deepin.daemon.apps"
 	kwayland "github.com/linuxdeepin/go-dbus-factory/com.deepin.daemon.kwayland"
 	launcher "github.com/linuxdeepin/go-dbus-factory/com.deepin.dde.daemon.launcher"
@@ -27,6 +26,8 @@ import (
 	"github.com/linuxdeepin/go-lib/dbusutil/gsprop"
 	"github.com/linuxdeepin/go-lib/dbusutil/proxy"
 	x "github.com/linuxdeepin/go-x11-client"
+
+	"github.com/linuxdeepin/dde-daemon/common/dsync"
 )
 
 type Manager struct {

--- a/session/eventlog/event_sdk.cpp
+++ b/session/eventlog/event_sdk.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2018 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -37,7 +37,9 @@ void CloseEventLog() {
     dlclose(handler);
 }
 
-void writeEventLog(const char *log) {
-    cout << log << endl;
+void writeEventLog(const char *log,int isDebug) {
+    if (isDebug) {
+        cout << log << endl;
+    }
     if (fp_writeEventLog) fp_writeEventLog(log);
 }

--- a/session/eventlog/event_sdk.h
+++ b/session/eventlog/event_sdk.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2018 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -10,7 +10,7 @@ extern "C" {
 #endif
 
 int InitEventSDK();
-void writeEventLog(const char *log);
+void writeEventLog(const char *log, int isDebug);
 void CloseEventLog();
 
 

--- a/session/eventlog/module.go
+++ b/session/eventlog/module.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2018 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -16,9 +16,10 @@ import (
 	"sync"
 	"unsafe"
 
-	"github.com/linuxdeepin/dde-daemon/loader"
 	"github.com/linuxdeepin/go-lib/dbusutil"
 	"github.com/linuxdeepin/go-lib/log"
+
+	"github.com/linuxdeepin/dde-daemon/loader"
 )
 
 var logger = log.NewLogger("daemon/session/eventlog")
@@ -45,7 +46,7 @@ type Module struct {
 }
 
 func (m *Module) GetDependencies() []string {
-	return []string{}
+	return []string{"dock"}
 }
 
 func newModule(logger *log.Logger) *Module {
@@ -131,10 +132,16 @@ func stop() error {
 	return nil
 }
 
-func (m *Module) writeEventLog(log string) {
+func (m *Module) writeEventLog(msg string) {
 	m.writeMu.Lock()
 	defer m.writeMu.Unlock()
-	cStr := C.CString(log)
+	cStr := C.CString(msg)
 	defer C.free(unsafe.Pointer(cStr))
-	C.writeEventLog(cStr)
+	var isDebug int
+	if logger.GetLogLevel() == log.LevelDebug {
+		isDebug = 1
+	} else {
+		isDebug = 0
+	}
+	C.writeEventLog(cStr, C.int(isDebug))
 }


### PR DESCRIPTION
旧逻辑: 启动时会遍历所有entry,然后通过dpkg -S获取对应的包名,比较占用登录过程中的资源; 新逻辑: 启动时只会遍历已经激活的entry(自启动应用),后续如果有window创建再获取包名;

Log: 优化eventlog启动过程中的资源占用
Influence: 性能优化
Change-Id: I59693e8022010b1e948d7ed65b6648fec9c65bee