### PR TITLE
ref: 使用override的方式规避规避fonts-gb-st-super字体不显示问题

### DIFF
--- a/appearance/manager.go
+++ b/appearance/manager.go
@@ -105,10 +105,11 @@ const (
 	dbusInterface   = dbusServiceName
 )
 
+// TODO 后续需要设计成用 subpath + 独立的 dconfig 配置来实现,增加可读性
 const (
-	dsettingsAppID                     = "org.deepin.dde.daemon"
-	dsettingsAppearanceName            = "org.deepin.dde.daemon.appearance"
-	dsettingsIrregularFontWhiteListKey = "irregularFontWhiteList"
+	dsettingsAppID                    = "org.deepin.dde.daemon"
+	dsettingsAppearanceName           = "org.deepin.dde.daemon.appearance"
+	dsettingsIrregularFontOverrideKey = "irregularFontOverride"
 )
 
 var wsConfigFile = filepath.Join(basedir.GetUserConfigDir(), "deepin/dde-daemon/appearance/wallpaper-slideshow.json")
@@ -1640,24 +1641,26 @@ func (m *Manager) initAppearanceDSettings() {
 	}
 
 	getIrregularFontWhiteListKey := func() {
-		v, err := dsAppearance.Value(0, dsettingsIrregularFontWhiteListKey)
+		v, err := dsAppearance.Value(0, dsettingsIrregularFontOverrideKey)
 		if err != nil {
 			logger.Warning(err)
 			return
 		}
-		var irregularFontWhiteListKey strv.Strv
-		itemList := v.Value().([]dbus.Variant)
-		for _, i := range itemList {
-			irregularFontWhiteListKey = append(irregularFontWhiteListKey, i.Value().(string))
+		var overrideMap fonts.IrregularFontOverrideMap
+		overrideMapString := v.Value().(string)
+		err = json.Unmarshal([]byte(overrideMapString), &overrideMap)
+		if err != nil {
+			logger.Warning(err)
+			return
 		}
-		fonts.SetIrregularFontWhiteList(irregularFontWhiteListKey)
+		fonts.SetIrregularFontWhiteList(overrideMap)
 	}
 
 	getIrregularFontWhiteListKey()
 
 	dsAppearance.InitSignalExt(m.sysSigLoop, true)
 	_, err = dsAppearance.ConnectValueChanged(func(key string) {
-		if key == dsettingsIrregularFontWhiteListKey {
+		if key == dsettingsIrregularFontOverrideKey {
 			getIrregularFontWhiteListKey()
 		}
 	})

--- a/misc/dsg-configs/org.deepin.dde.daemon.appearance.json
+++ b/misc/dsg-configs/org.deepin.dde.daemon.appearance.json
@@ -2,14 +2,14 @@
   "magic": "dsg.config.meta",
   "version": "1.0",
   "contents": {
-    "irregularFontWhiteList": {
-      "value": ["GB_SS_GB18030_Extended"],
+    "irregularFontOverride": {
+      "value": "{\"GB_SS_GB18030_Extended\":{\"AppendLang\":[\"zh-cn\",\"zh-sg\"]}}",
       "serial": 0,
       "flags": [],
       "global": true,
-      "name": "IrregularFontWhiteList",
-      "name[zh_CN]": "不规范字体白名单",
-      "description": "不规范字体白名单,白名单中字体show字段为true",
+      "name": "IrregularFontOverride",
+      "name[zh_CN]": "不规范字体参数override",
+      "description": "不规范字体override",
       "permissions": "read",
       "visibility": "private"
     }


### PR DESCRIPTION
使用{"GB_SS_GB18030_Extended":{"AppendLang":["zh-cn","zh-sg"]}}的map对原有解析的ttf文件数据进行override,从而达到规避效果

Log: 使用override的方式规避规避fonts-gb-st-super字体不显示问题
Bug: https://pms.uniontech.com/bug-view-182839.html
Influence: 字体过滤条件
Change-Id: I1bf95ea846ec4920ba3ce7aa5be36dd99a60a24c