### PR TITLE
fix: 控制中心新建用户LDAP账户消失

### DIFF
--- a/accounts/handle_event.go
+++ b/accounts/handle_event.go
@@ -103,7 +103,7 @@ func (m *Manager) handleFilePasswdChanged() {
 			u.updatePropsPasswd(uInfo)
 		} else {
 			// 域账户没有保存在本地，无需删除
-			if !m.isUdcpUserID(u.Uid) {
+			if !m.isDomainUser(u.Uid) {
 				uidsDelete = append(uidsDelete, u.Uid)
 			}
 		}
@@ -221,6 +221,10 @@ func (m *Manager) addDomainUser(uId uint32) error {
 		logger.Warning(err)
 	}
 	return err
+}
+
+func (m *Manager) isDomainUser(uid string) bool {
+	return m.isUdcpUserID(uid) || users.IsLDAPDomainUserID(uid)
 }
 
 // 判断用户缓存UID列表中是否有域账户，域账户信息只能由web端设置，本地没有保存。

--- a/accounts/manager.go
+++ b/accounts/manager.go
@@ -311,7 +311,7 @@ func (m *Manager) initDomainUsers() {
 	}
 
 	for _, v := range m.userConfig {
-		if users.IsDomainUserID(v.Uid) && (v.IsLogined == true) {
+		if users.IsLDAPDomainUserID(v.Uid) && (v.IsLogined == true) {
 			domainUserList = append(domainUserList, v.Uid)
 		}
 	}
@@ -385,7 +385,7 @@ func (m *Manager) exportUserByUid(uId string) error {
 		}
 
 		// LDAP 域用户
-		if users.IsDomainUserID(uId) {
+		if users.IsLDAPDomainUserID(uId) {
 			userGroups, err = users.GetADUserGroupsByUID(uint32(id))
 			if err != nil {
 				logger.Warningf("get domain user groups failed: %v", err)
@@ -398,7 +398,7 @@ func (m *Manager) exportUserByUid(uId string) error {
 
 		u, err = NewDomainUser(uint32(id), m.service, userGroups)
 
-		if users.IsDomainUserID(uId) {
+		if users.IsLDAPDomainUserID(uId) {
 			var config = &domainUserConfig{
 				Name:      u.UserName,
 				Uid:       u.Uid,

--- a/accounts/manager_ifc.go
+++ b/accounts/manager_ifc.go
@@ -132,7 +132,7 @@ func (m *Manager) DeleteUser(sender dbus.Sender,
 		return dbusutil.ToError(err)
 	}
 
-	if m.isUdcpUserID(user.Uid) || users.IsDomainUserID(user.Uid) {
+	if m.isDomainUser(user.Uid) {
 		id, _ := strconv.Atoi(user.Uid)
 
 		if m.udcpCache != nil && m.isUdcpUserID(user.Uid) {

--- a/accounts/user_ifc.go
+++ b/accounts/user_ifc.go
@@ -222,7 +222,7 @@ func (u *User) SetMaxPasswordAge(sender dbus.Sender, nDays int32) *dbus.Error {
 
 func (u *User) IsPasswordExpired() (bool, *dbus.Error) {
 	// LDAP 域用户密码由域服务器控制，系统不去做密码过期检测
-	if users.IsDomainUserID(u.Uid) {
+	if users.IsLDAPDomainUserID(u.Uid) {
 		return false, nil
 	}
 

--- a/accounts/users/passwd.go
+++ b/accounts/users/passwd.go
@@ -94,7 +94,7 @@ func GetADUserGroupsByUID(uid uint32) ([]string, error) {
 }
 
 // 判断用户是否是LDAP网络账户，LDAP域账户信息只能由服务端设置，本地没有保存
-func IsDomainUserID(uid string) bool {
+func IsLDAPDomainUserID(uid string) bool {
 	id, _ := strconv.Atoi(uid)
 
 	domainUserGroups, err := GetADUserGroupsByUID(uint32(id))


### PR DESCRIPTION
LDAP账户没有保存到本地，在/etc/passwd文件更新时无需删除

Log: 修复控制中心新建用户LDAP账户消失的问题
Bug: https://pms.uniontech.com/bug-view-183531.html
Influence: 控制中心新建用户
Change-Id: I71564d2493fca94a36edb515c7d6b3545cfc77c5