### PR TITLE
fix: 控制中心删除域账户异常

### DIFF
--- a/accounts/manager_ifc.go
+++ b/accounts/manager_ifc.go
@@ -150,6 +150,8 @@ func (m *Manager) DeleteUser(sender dbus.Sender,
 		// 删除账户前先删除生物特征，避免删除账户后，用户数据找不到
 		if rmFiles {
 			user.clearBiometricChara()
+			// 删除域用户家目录
+			os.RemoveAll(user.HomeDir)
 		}
 
 		// 删除服务，更新UserList


### PR DESCRIPTION
当控制中心勾选了删除账户目录，删除对应域账户家目录

Log: 修复控制中心删除域账户异常的问题
Bug: https://pms.uniontech.com/bug-view-183747.html
Influence: 控制中心删除账户
Change-Id: Ie7aabb09ec2aa647e1d5b0d730f371566a09676d