### PR TITLE
chore: remove dde-kwin runtime dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -70,7 +70,6 @@ Depends:
  deepin-installer-timezones,
  deepin-proxy,
  deepin-sound-theme,
- deepin-wm | deepin-metacity | dde-kwin,
  dmidecode,
  dnsmasq-base,
  gnome-keyring,


### PR DESCRIPTION
deepin-kwin provides the dde-kwin
