### PR TITLE
chore: dont set PATH env

### DIFF
--- a/bin/dde-system-daemon/main.go
+++ b/bin/dde-system-daemon/main.go
@@ -73,15 +73,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	// fix no PATH when was launched by dbus
-	if os.Getenv("PATH") == "" {
-		logger.Warning("No PATH found, manual special")
-		err = os.Setenv("PATH", "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
-		if err != nil {
-			logger.Warning(err)
-		}
-	}
-
 	// 系统级服务，无需设置LANG和LANGUAGE，保证翻译不受到影响
 	_ = os.Setenv("LANG", "")
 	_ = os.Setenv("LANGUAGE", "")

--- a/grub2/modify_manger.go
+++ b/grub2/modify_manger.go
@@ -21,7 +21,7 @@ const (
 )
 
 func init() {
-	_ = os.Setenv("PATH", "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
+
 }
 
 type modifyManager struct {


### PR DESCRIPTION
Log: dbus 环境缺失环境变量应该由 dbus-update-activation-environment 处理 ,不应该由 dde-daemon 设置 PATH