### PR TITLE
fix: 用户设置自定义头像后重启系统失效

### DIFF
--- a/accounts1/accounts.go
+++ b/accounts1/accounts.go
@@ -13,6 +13,7 @@ import (
 var (
 	_imageBlur         *ImageBlur
 	_userStandardIcons []string
+	_userCustomIcons   []string
 	logger             = log.NewLogger("daemon/accounts")
 )
 
@@ -42,7 +43,7 @@ func (d *Daemon) Start() error {
 		return nil
 	}
 
-	_userStandardIcons = getUserStandardIcons()
+	_userStandardIcons, _userCustomIcons = getUserIcons()
 	service := loader.GetService()
 	d.manager = NewManager(service)
 

--- a/accounts1/manager_ifc.go
+++ b/accounts1/manager_ifc.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/godbus/dbus/v5"
+	"github.com/linuxdeepin/dde-daemon/accounts/keyring"
 	"github.com/linuxdeepin/dde-daemon/accounts1/checkers"
 	"github.com/linuxdeepin/dde-daemon/accounts1/users"
 	"github.com/linuxdeepin/go-lib/dbusutil"
@@ -30,7 +31,6 @@ import (
 	"github.com/linuxdeepin/go-lib/procfs"
 	"github.com/linuxdeepin/go-lib/users/passwd"
 	dutils "github.com/linuxdeepin/go-lib/utils"
-	"github.com/linuxdeepin/dde-daemon/accounts/keyring"
 )
 
 const (
@@ -272,14 +272,13 @@ func (m *Manager) FindUserByName(name string) (user string, busErr *dbus.Error) 
 //
 // ret0：头像路径，为空则表示获取失败
 func (m *Manager) RandUserIcon() (iconFile string, busErr *dbus.Error) {
-	icons := getUserStandardIcons()
-	if len(icons) == 0 {
+	if len(_userStandardIcons) == 0 {
 		return "", dbusutil.ToError(errors.New("Did not find any user icons"))
 	}
 
 	rand.Seed(time.Now().UnixNano())
-	idx := rand.Intn(len(icons)) // #nosec G404
-	return icons[idx], nil
+	idx := rand.Intn(len(_userStandardIcons)) // #nosec G404
+	return _userStandardIcons[idx], nil
 }
 
 // 检查用户名是否有效

--- a/accounts1/user.go
+++ b/accounts1/user.go
@@ -251,7 +251,8 @@ func (u *User) updateIconList() {
 }
 
 func (u *User) initCustomIcons() {
-	icons := _userStandardIcons
+	icons := _userCustomIcons
+
 	customIconPre := u.UserName + "-"
 	for _, icon := range icons {
 		if strings.Contains(icon, customIconPre) {
@@ -717,7 +718,8 @@ func updateConfigPath(username string) {
 }
 
 func isOldCustomIcon(u *User) bool {
-	if _, err := os.Stat(u.IconFile); os.IsNotExist(err) {
+	iconFile := dutils.DecodeURI(u.IconFile)
+	if _, err := os.Stat(iconFile); os.IsNotExist(err) {
 		if !isStrInArray(u.IconFile, u.IconList) {
 			return true
 		}

--- a/accounts1/utils.go
+++ b/accounts1/utils.go
@@ -76,9 +76,10 @@ func (code ErrCodeType) String() string {
 }
 
 // return icons uris
-func getUserStandardIcons() []string {
+func getUserIcons() ([]string, []string) {
 	var paths []string
 	var icons []string
+	var customIcons []string
 
 	if err := filepath.Walk(userIconsDir,
 		func(path string, info os.FileInfo, err error) error {
@@ -86,7 +87,7 @@ func getUserStandardIcons() []string {
 				return err
 			}
 
-			subPaths := []string{"dimensional", "flat"}
+			subPaths := []string{"dimensional", "flat", "local"}
 
 			if info.IsDir() && strv.Strv(subPaths).Contains(info.Name()) {
 				paths = append(paths, path)
@@ -96,23 +97,27 @@ func getUserStandardIcons() []string {
 		},
 	); err != nil {
 		logger.Warning("failed to walk usr icon path", err)
-		return icons
+		return icons, customIcons
 	}
 
 	for _, path := range paths {
 		imgs, err := graphic.GetImagesInDir(path)
 		if err != nil {
 			logger.Warning("failed to get user icon images", err)
-			return nil
+			return nil, nil
 		}
 
 		for _, img := range imgs {
 			img = utils.EncodeURI(img, utils.SCHEME_FILE)
-			icons = append(icons, img)
+			if strings.Contains(img, userCustomIconsDir) {
+				customIcons = append(customIcons, img)
+			} else {
+				icons = append(icons, img)
+			}
 		}
 	}
 
-	return icons
+	return icons, customIcons
 }
 
 // 从系统的用户头像中随机获取一张用户图片


### PR DESCRIPTION
系统重启后用户自定义头像需要从系统目录下重新读取,
防止用户自定义头像列表为空导致用户头像设置错误

Log: 修复用户设置自定义头像后重启系统失效的问题