### PR TITLE
fix: 第一次进入登陆界面界面缩放异常

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,9 +215,6 @@ install: build install-dde-data install-icons
 	mkdir -pv ${DESTDIR}/etc/NetworkManager/conf.d
 	cp -f misc/etc/NetworkManager/conf.d/* ${DESTDIR}/etc/NetworkManager/conf.d/
 
-	mkdir -pv ${DESTDIR}/etc/lightdm/deepin/
-	cp -f misc/xsettings/xsettingsd.conf ${DESTDIR}/etc/lightdm/deepin/
-
 	mkdir -pv ${DESTDIR}${PREFIX}/libexec/dde-daemon/
 	cp -r misc/libexec/dde-daemon/* ${DESTDIR}${PREFIX}/libexec/dde-daemon/
 

--- a/misc/xsettings/xsettingsd.conf
+++ b/misc/xsettings/xsettingsd.conf
@@ -1,2 +1,0 @@
-Xft/DPI 98304
-Qt/FontName "Noto Sans CJK SC 10.5"


### PR DESCRIPTION
dde-daemon 通过xsettingsd.conf提供了默认的缩放(xft/DPI 98304->缩放比1.0) 导致lightdm-deepin-greeter不会去自己计算缩放比, 导致界面缩放比异常

Log: 解决第一次进入登陆界面界面缩放异常的问题
Resolve: https://github.com/linuxdeepin/developer-center/issues/3594