### PR TITLE
udev: fix warning reported by udevadm verify

### DIFF
--- a/misc/udev-rules/80-deepin-fprintd.rules
+++ b/misc/udev-rules/80-deepin-fprintd.rules
@@ -1,1 +1,1 @@
-SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_interface", ACTION=="add|remove", ENV{LIBFPRINT_DRIVER}!="" RUN+="/usr/bin/dbus-send --system --dest=org.deepin.dde.Fprintd1 --print-reply /org/deepin/dde/Fprintd1 org.deepin.dde.Fprintd1.TriggerUDevEvent"
+SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_interface", ACTION=="add|remove", ENV{LIBFPRINT_DRIVER}!="", RUN+="/usr/bin/dbus-send --system --dest=org.deepin.dde.Fprintd1 --print-reply /org/deepin/dde/Fprintd1 org.deepin.dde.Fprintd1.TriggerUDevEvent"


### PR DESCRIPTION
Fix the following warning reported by udevadm verify:

```
misc/udev-rules/80-deepin-fprintd.rules:1 A comma between tokens is expected.
misc/udev-rules/80-deepin-fprintd.rules: udev rules check failed
```