### PR TITLE
fix(housekeeping): send space warning erery 5 mins

### DIFF
--- a/housekeeping/init.go
+++ b/housekeeping/init.go
@@ -50,7 +50,7 @@ func (d *Daemon) Start() error {
 		return nil
 	}
 
-	d.ticker = time.NewTicker(time.Minute * 1)
+	d.ticker = time.NewTicker(time.Minute * 10)
 	d.stopChan = make(chan struct{})
 	go func() {
 		for {


### PR DESCRIPTION
This housekeeping module is added
because X-org has a problem in XSession script,
which cause XSession failed to start
when user's home directory is full.

Basically, XSession fails because
the script redirect std error to ~/.xerrors
and failed to write to that file.

This bug is fixed in UOS and deepin,
by update the XSession script to ignore that write failure.

So full of user home directory is not such a big issue now.

We can send this warning not that frequently as we used to be,
as some users may consider this warning annoying.

Related: linuxdeepin/developer-center#4685
Signed-off-by: black-desk <me@black-desk.cn>
