### PR TITLE
fix: deepin-accounts1-daemon.service在标准输出中使用了废弃的"syslog"

### DIFF
--- a/misc/systemd/system-services/deepin-accounts1-daemon.service
+++ b/misc/systemd/system-services/deepin-accounts1-daemon.service
@@ -11,7 +11,7 @@ Wants=nss-user-lookup.target fprintd.service
 Type=dbus
 BusName=org.deepin.dde.Accounts1
 ExecStart=/usr/lib/deepin-daemon/dde-system-daemon
-StandardOutput=syslog
+StandardOutput=journal
 Environment=GVFS_DISABLE_FUSE=1
 Environment=GIO_USE_VFS=local
 Environment=GVFS_REMOTE_VOLUME_MONITOR_IGNORE=1


### PR DESCRIPTION
dmesg显示：
`[    6.494444] systemd[1]: /lib/systemd/system/deepin-accounts1-daemon.service:14: Standard output type syslog is obsolete, automatically updating to journal. Please update your unit file, and consider removing the setting altogether.`

所以修改[Service]中“StandardOutput”的值，由废弃的“syslog”改为“journal”。
