### PR TITLE
chore: modify the startup order of session daemon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,7 @@ install: build install-dde-data install-icons
 
 	mkdir -pv ${DESTDIR}/lib/systemd/user/
 	cp -f misc/systemd/services/* ${DESTDIR}/lib/systemd/user/
+	ln -s ${PREFIX}/lib/systemd/user/org.dde.session.Daemon1.service ${DESTDIR}${PREFIX}/lib/systemd/user/dde-session-initialized.target.wants/org.dde.session.Daemon1.service
 
 	mkdir -pv ${DESTDIR}/lib/systemd/system/
 	cp -f misc/systemd/system-services/* ${DESTDIR}/lib/systemd/system/

--- a/misc/systemd/services/org.dde.session.Daemon1.service
+++ b/misc/systemd/services/org.dde.session.Daemon1.service
@@ -4,9 +4,19 @@ RefuseManualStart=no
 RefuseManualStop=no
 CollectMode=inactive-or-failed
 
+Requisite=dde-session-pre.target
+After=dde-session-pre.target
+
+Requisite=dde-session-initialized.target
+PartOf=dde-session-initialized.target
+Before=dde-session-initialized.target
+
 [Service]
 Type=dbus
 BusName=org.deepin.dde.XEventMonitor1
 ExecStart=/usr/lib/deepin-daemon/dde-session-daemon
 Slice=app.slice
 Restart=on-failure
+
+[Install]
+WantedBy=graphical-session.target


### PR DESCRIPTION
修改 session-daemon 的启动顺序，添加到
dde-session-initialized.target.wants 中

Log: modify the startup order