### PR TITLE
fix: launch incorrect pipewire service

### DIFF
--- a/audio1/audio.go
+++ b/audio1/audio.go
@@ -209,7 +209,7 @@ func newAudio(service *dbusutil.Service) *Audio {
 
 func startAudioServer(service *dbusutil.Service) error {
 	var serverPath dbus.ObjectPath
-	audioServers := []string{"pipewire.service", "pluseaudio.service"}
+	audioServers := []string{"pipewire-pulse.service", "pulseaudio.service"}
 
 	systemd := systemd1.NewManager(service.Conn())
 
@@ -244,15 +244,6 @@ func startAudioServer(service *dbusutil.Service) error {
 				}
 			}()
 		}
-	}
-
-	has, err := service.NameHasOwner(dbusPulseaudioServer)
-	if err != nil {
-		logger.Warningf("failed to get dbus pulseaudio server owner, err: %v", err)
-	}
-
-	if !has {
-		return errors.New("failed to start audio server")
 	}
 
 	return nil


### PR DESCRIPTION
use pipewire audio backend need to start pipewire-pulse service

Log: 修复注销后重新登录音频模块启动失败的问题
Resolve: https://github.com/linuxdeepin/developer-center/issues/5193