### PR TITLE
fix: bash is not default SHELL for new user

### DIFF
--- a/accounts1/users/manager.go
+++ b/accounts1/users/manager.go
@@ -24,6 +24,7 @@ const (
 	cmdChAge    = "chage"
 
 	defaultConfigShell = "/etc/adduser.conf"
+	defaultShell = "/bin/bash"
 )
 
 const (
@@ -38,6 +39,9 @@ func CreateUser(username, fullname, shell string) error {
 
 	if len(shell) == 0 {
 		shell, _ = getDefaultShell(defaultConfigShell)
+		if len(shell) == 0 {
+			shell = defaultShell
+		}
 	}
 
 	mockUserInfo := UserInfo{


### PR DESCRIPTION
在未传入shell参数，并且从/etc/adduser.conf配置文件中未获取到DSHELL配置时，将"/bin/bash"作为新建用户的默认SHELL，以确保终端中能够正常展示当前用户名、机器名称、当前路径信息。

Log: 修复新建用户默认SHELL为"/bin/sh"，导致的终端中未展示当前用户名、机器名称、当前路径信息的问题，
Issue: https://github.com/linuxdeepin/developer-center/issues/5744
          https://github.com/linuxdeepin/developer-center/issues/5745