### PR TITLE
fix: property is not valid, dbus close

### DIFF
--- a/audio1/audio.go
+++ b/audio1/audio.go
@@ -216,6 +216,11 @@ func newAudio(service *dbusutil.Service) *Audio {
 		AudioServerState: AudioStateChanged,
 	}
 
+	// TODO: here should check the exported property
+	// when is piepwire, sometimes something error with golib
+	// cannot get the defaultSink and defaultSource
+	a.DefaultSource = "/fakesource"
+	a.DefaultSink = "/fakesink"
 	a.settings = gio.NewSettings(gsSchemaAudio)
 	a.settings.Reset(gsKeyInputVolume)
 	a.settings.Reset(gsKeyOutputVolume)


### PR DESCRIPTION
because some important fuction is on this interface, so this interface must be exported. so now give a face dbus path at first.

something error in golib

Log: