### PR TITLE
fix: set the default value of statusNotifierHost to true

### DIFF
--- a/misc/systemd/services/org.dde.session.Daemon1.service
+++ b/misc/systemd/services/org.dde.session.Daemon1.service
@@ -17,3 +17,4 @@ BusName=org.deepin.dde.XEventMonitor1
 ExecStart=/usr/lib/deepin-daemon/dde-session-daemon
 Slice=app.slice
 Restart=on-failure
+NotifyAccess=main


### PR DESCRIPTION
Issue: https://github.com/linuxdeepin/developer-center/issues/4431

由于dock在daemon检查时可能未启动，导致托盘协议回退。根据 @tsic404 的建议
，在确定一定会有支持SNI规范的应用(dde-dock)启动的情况下，取消该检查。