### PR TITLE
fix: pressing the shortcut key will hide the launchpad

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-daemon (6.0.37) unstable; urgency=medium
+
+  * fix: pressing the shortcut key will hide the launchpad
+
+ -- zsien <quezhiyong@deepin.org>  Fri, 12 Apr 2024 14:14:27 +0800
+
 dde-daemon (6.0.36) unstable; urgency=medium
 
   * chore: update translations

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/linuxdeepin/go-dbus-factory v0.0.0-20231128020144-77ac5d6251aa
 	github.com/linuxdeepin/go-gir v0.0.0-20230331033513-a8d7a9e89f9b
 	github.com/linuxdeepin/go-lib v0.0.0-20240103033000-4fb70d4b858f
-	github.com/linuxdeepin/go-x11-client v0.0.0-20230329071904-56c906e1ab5d
+	github.com/linuxdeepin/go-x11-client v0.0.0-20240412020522-868786c7cd21
 	github.com/mdlayher/netlink v1.7.1
 	github.com/msteinert/pam v1.1.0
 	github.com/rickb777/date v1.20.1

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,8 @@ github.com/linuxdeepin/go-x11-client v0.0.0-20220830090948-78fe92b727bb/go.mod h
 github.com/linuxdeepin/go-x11-client v0.0.0-20230131052004-7503e2337ee1/go.mod h1:KwpmRZ47A/0a2l9V0V6aTlkuNaqy5j1fOqMFJONuIMY=
 github.com/linuxdeepin/go-x11-client v0.0.0-20230329071904-56c906e1ab5d h1:FYvSF95wgsMpah80xtLCOMqompAbjkaMRmn9RBMBzo8=
 github.com/linuxdeepin/go-x11-client v0.0.0-20230329071904-56c906e1ab5d/go.mod h1:KwpmRZ47A/0a2l9V0V6aTlkuNaqy5j1fOqMFJONuIMY=
+github.com/linuxdeepin/go-x11-client v0.0.0-20240412020522-868786c7cd21 h1:MEiOHxzvbIGwIXRhb4FReHO1wqaQMDlIl8FHMrveI2g=
+github.com/linuxdeepin/go-x11-client v0.0.0-20240412020522-868786c7cd21/go.mod h1:KwpmRZ47A/0a2l9V0V6aTlkuNaqy5j1fOqMFJONuIMY=
 github.com/mattn/go-sqlite3 v1.14.0/go.mod h1:JIl7NbARA7phWnGvh0LKTyg7S9BA+6gx71ShQilpsus=
 github.com/mattn/go-sqlite3 v1.14.16/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/mattn/goveralls v0.0.11/go.mod h1:gU8SyhNswsJKchEV93xRQxX6X3Ei4PJdQk/6ZHvrvRk=

--- a/keybinding/shortcuts/key.go
+++ b/keybinding/shortcuts/key.go
@@ -78,5 +78,5 @@ func (k Key) Ungrab(conn *x.Conn) {
 
 func (k Key) Grab(conn *x.Conn) error {
 	rootWin := conn.GetDefaultScreen().Root
-	return keybind.GrabChecked(conn, rootWin, uint16(k.Mods), x.Keycode(k.Code))
+	return keybind.GrabCheckedV2(conn, rootWin, uint16(k.Mods), x.Keycode(k.Code), x.GrabModeAsync, x.GrabModeSync)
 }

--- a/keybinding/shortcuts/shortcut_manager.go
+++ b/keybinding/shortcuts/shortcut_manager.go
@@ -775,6 +775,8 @@ func (sm *ShortcutManager) EventLoop() {
 	for ev := range eventChan {
 		switch ev.GetEventCode() {
 		case x.KeyPressEventCode:
+			x.UngrabKeyboardChecked(sm.conn, x.TimeCurrentTime).Check(sm.conn)
+
 			event, _ := x.NewKeyPressEvent(ev)
 			logger.Debug(event)
 			sm.handleKeyEvent(true, event.Detail, event.State)


### PR DESCRIPTION
grab key 的 keyboard mode 改为 sync mode

Deps: linuxdeepin/go-x11-client#36
Issues: linuxdeepin/developer-center#5989