### PR TITLE
fix: the dock entry of deepin-system-monitor is incorrect

### DIFF
--- a/keybinding/shortcuts/system_shortcut.go
+++ b/keybinding/shortcuts/system_shortcut.go
@@ -86,7 +86,7 @@ var defaultSysActionCmdMap = map[string]string{
 	"lock-screen":            "/usr/lib/deepin-daemon/dde-lock.sh",
 	"logout":                 "dbus-send --print-reply --dest=org.deepin.dde.ShutdownFront1 /org/deepin/dde/ShutdownFront1 org.deepin.dde.ShutdownFront1.Show",
 	"deepin-screen-recorder": "dbus-send --print-reply --dest=com.deepin.ScreenRecorder /com/deepin/ScreenRecorder com.deepin.ScreenRecorder.stopRecord",
-	"system-monitor":         "deepin-system-monitor",
+	"system-monitor":         "dde-am deepin-system-monitor",
 	"color-picker":           "dbus-send --print-reply --dest=com.deepin.Picker /com/deepin/Picker com.deepin.Picker.Show",
 	// screenshot actions:1
 	"screenshot":            screenshotCmdPrefix + "StartScreenshot",

--- a/misc/dde-daemon/keybinding/system_actions.json
+++ b/misc/dde-daemon/keybinding/system_actions.json
@@ -13,8 +13,8 @@
             "Action": "dbus-send --print-reply --dest=com.deepin.ScreenRecorder /com/deepin/ScreenRecorder com.deepin.ScreenRecorder.stopRecord"
         },
         {
-            "Action": "deepin-system-monitor",
-            "Key": "system-monitor"
+            "Key": "system-monitor",
+            "Action": "dde-am deepin-system-monitor"
         },
         {
             "Key": "deepin-picker",


### PR DESCRIPTION
使用 dde-am 打开系统监视器

Issues: linuxdeepin/developer-center#8093