### PR TITLE
fix: missing modifications to deepin terminal quake mode shortcut exec

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-daemon (6.0.40) unstable; urgency=medium
+
+  * chore(deps): bump golang.org/x/net from 0.17.0 to 0.23.0
+    fix: the dock icon of deepin-terminal quake mode is missing
+
+ -- Yutao Meng <mengyutao@deepin.org>  Tue, 04 Jun 2024 13:11:52 +0800
+
 dde-daemon (6.0.39) unstable; urgency=medium
 
   * fix: fix a crash

--- a/misc/dde-daemon/keybinding/system_actions.json
+++ b/misc/dde-daemon/keybinding/system_actions.json
@@ -29,7 +29,7 @@
             "Key": "logout"
         },
         {
-            "Action": "deepin-terminal --quake-mode",
+            "Action": "dde-am deepin-terminal quake-mode",
             "Key": "terminal-quake"
         },
         {


### PR DESCRIPTION
system_actions should also be modified.

Issue: https://github.com/linuxdeepin/developer-center/issues/8881 
https://github.com/linuxdeepin/developer-center/issues/8596 
https://github.com/linuxdeepin/developer-center/issues/8042 
https://github.com/linuxdeepin/developer-center/issues/7852 
https://github.com/linuxdeepin/developer-center/issues/7853 
https://github.com/linuxdeepin/developer-center/issues/7856 
Log: missing modifications to deepin terminal quake mode shortcut exec