### PR TITLE
fix: cannot set cstate

### DIFF
--- a/misc/systemd/services/system/dde-system-daemon.service
+++ b/misc/systemd/services/system/dde-system-daemon.service
@@ -126,6 +126,11 @@ ReadWritePaths=-/boot
 ReadWritePaths=-/var/lib/dde-daemon/apps
 ReadWritePaths=-/tmp
 ReadWritePaths=-/home
+
+# TLP
+ReadWritePaths=-/usr/share/tlp/deepin-system-power-control/
+ReadWritePaths=-/etc/tlp.d/
+
 [Install]
 # We pull this in by graphical.target instead of waiting for the bus
 # activation, to speed things up a little: gdm uses this anyway so it is nice


### PR DESCRIPTION
允许写入 /usr/share/tlp/deepin-system-power-control/
和 /etc/tlp.d/

Task: https://pms.uniontech.com/task-view-362041.html