### PR TITLE
fix: 创建配置目录: /var/lib/dde-daemon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,6 +155,9 @@ print_gopath: prepare
 	GOPATH="${CURDIR}/${GOPATH_DIR}:${GOPATH}"
 
 install: build install-dde-data install-icons
+	# 创建配置文件夹
+	mkdir -pv ${DESTDIR}/var/lib/dde-daemon/
+
 	mkdir -pv ${DESTDIR}${PREFIX}/lib/deepin-daemon
 	cp -f out/bin/* ${DESTDIR}${PREFIX}/lib/deepin-daemon/
 


### PR DESCRIPTION
由于系统目录只读，无法创建dde-daemon的配置目录。

Log: 创建dde-daemon的配置目录
Bug: https://pms.uniontech.com/bug-view-281709.html
Influence: backlight