### PR TITLE
fix: treeland适配，调用login1 的session lock触发锁屏

### DIFF
--- a/bin/dde-session-daemon/main.go
+++ b/bin/dde-session-daemon/main.go
@@ -41,7 +41,7 @@ var logger = log.NewLogger("daemon/dde-session-daemon")
 var hasDDECookie bool
 var hasTreeLand bool
 
-var treeLandNotAllowModules = []string{"x-event-monitor", "keybinding", "trayicon", "screensaver", "inputdevices", "power"}
+var treeLandNotAllowModules = []string{"x-event-monitor", "keybinding", "trayicon", "screensaver", "inputdevices"}
 
 func isInShutdown() bool {
 	bus, err := dbus.SystemBus()

--- a/keybinding1/manager_handlers.go
+++ b/keybinding1/manager_handlers.go
@@ -142,7 +142,7 @@ func (m *Manager) initHandlers() {
 	m.handlers[ActionTypeTouchpadCtrl] = buildHandlerFromController(m.touchPadController)
 
 	m.handlers[ActionTypeSystemSuspend] = func(ev *KeyEvent) {
-		if m.gsPower.GetBoolean("sleep-lock") {
+		if m.gsPower.GetBoolean("sleep-lock") && !isTreeLand() {
 			m.systemSuspendByFront()
 		} else {
 			m.systemSuspend()

--- a/keybinding1/special_keycode.go
+++ b/keybinding1/special_keycode.go
@@ -351,9 +351,17 @@ func (m *Manager) handlePower() {
 	case powerActionShutdown:
 		m.systemShutdown()
 	case powerActionSuspend:
-		m.systemSuspendByFront()
+		if isTreeLand() {
+			m.systemSuspend()
+		} else {
+			m.systemSuspendByFront()
+		}
 	case powerActionHibernate:
-		m.systemHibernateByFront()
+		if isTreeLand() {
+			m.systemHibernate()
+		} else {
+			m.systemHibernateByFront()
+		}
 	case powerActionTurnOffScreen:
 		if screenBlackLock {
 			systemLock()

--- a/session/power1/daemon.go
+++ b/session/power1/daemon.go
@@ -7,6 +7,7 @@ package power
 import (
 	"github.com/linuxdeepin/dde-daemon/loader"
 	"github.com/linuxdeepin/go-lib/log"
+	"os"
 )
 
 var logger = log.NewLogger("daemon/session/power")
@@ -27,6 +28,10 @@ func NewDaemon(logger *log.Logger) *Daemon {
 }
 
 func (d *Daemon) GetDependencies() []string {
+	// TODO: Idle在treeland暂时有问题
+	if os.Getenv("XDG_SESSION_TYPE") == "wayland" {
+		return []string{"sessionwatcher"}
+	}
 	return []string{"screensaver", "sessionwatcher"}
 }
 

--- a/session/power1/helper.go
+++ b/session/power1/helper.go
@@ -8,6 +8,7 @@ import (
 	"github.com/godbus/dbus/v5"
 	notifications "github.com/linuxdeepin/go-dbus-factory/session/org.freedesktop.notifications"
 	"github.com/linuxdeepin/go-lib/dbusutil/proxy"
+	"os"
 
 	// system bus
 	shutdownfront "github.com/linuxdeepin/go-dbus-factory/session/com.deepin.dde.shutdownfront"
@@ -70,9 +71,11 @@ func (h *Helper) init(sysBus, sessionBus *dbus.Conn) error {
 	h.ShutdownFront = shutdownfront.NewShutdownFront(sessionBus)
 
 	// init X conn
-	h.xConn, err = x.NewConn()
-	if err != nil {
-		return err
+	if os.Getenv("XDG_SESSION_TYPE") != "wayland" {
+		h.xConn, err = x.NewConn()
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/session/power1/lid_switch.go
+++ b/session/power1/lid_switch.go
@@ -102,9 +102,17 @@ func (h *LidSwitchHandler) doLidStateChanged(state bool) {
 		case powerActionShutdown:
 			m.doShutdown()
 		case powerActionSuspend:
-			m.doSuspendByFront()
+			if m.UseWayland {
+				m.doSuspend()
+			} else {
+				m.doSuspendByFront()
+			}
 		case powerActionHibernate:
-			m.doHibernateByFront()
+			if m.UseWayland {
+				m.doHibernate()
+			} else {
+				m.doHibernateByFront()
+			}
 		case powerActionTurnOffScreen:
 			m.doTurnOffScreen()
 		case powerActionDoNothing:

--- a/session/power1/manager.go
+++ b/session/power1/manager.go
@@ -354,7 +354,7 @@ func (m *Manager) init() {
 	m.sessionSigLoop.Start()
 	m.systemSigLoop.Start()
 
-	if len(os.Getenv("WAYLAND_DISPLAY")) != 0 {
+	if os.Getenv("XDG_SESSION_TYPE") == "wayland" {
 		m.UseWayland = true
 	} else {
 		m.UseWayland = false
@@ -534,32 +534,33 @@ func (m *Manager) init() {
 		})
 	}
 
-	if m.UseWayland {
-		m.kwinHanleIdleOffCh = make(chan bool, 10)
-		go m.listenEventToHandleIdleOff()
-
-		go func() {
-			for ch := range m.kwinHanleIdleOffCh {
-				if ch {
-					m.prepareSuspendLocker.Lock()
-					// 如果系统处于suspend状态，不需要在上层通过鼠标键盘事件唤醒系统
-					if m.prepareSuspend >= suspendStatePrepare {
-						m.prepareSuspendLocker.Unlock()
-						continue
-					}
-					m.prepareSuspendLocker.Unlock()
-
-					logger.Info("kwin handle idle off")
-
-					if v := m.submodules[submodulePSP]; v != nil {
-						if psp := v.(*powerSavePlan); psp != nil {
-							psp.HandleIdleOff()
-						}
-					}
-				}
-			}
-		}()
-	}
+	// TODO: treeland 上idle暂未实现
+	//if m.UseWayland {
+	//	m.kwinHanleIdleOffCh = make(chan bool, 10)
+	//	go m.listenEventToHandleIdleOff()
+	//
+	//	go func() {
+	//		for ch := range m.kwinHanleIdleOffCh {
+	//			if ch {
+	//				m.prepareSuspendLocker.Lock()
+	//				// 如果系统处于suspend状态，不需要在上层通过鼠标键盘事件唤醒系统
+	//				if m.prepareSuspend >= suspendStatePrepare {
+	//					m.prepareSuspendLocker.Unlock()
+	//					continue
+	//				}
+	//				m.prepareSuspendLocker.Unlock()
+	//
+	//				logger.Info("kwin handle idle off")
+	//
+	//				if v := m.submodules[submodulePSP]; v != nil {
+	//					if psp := v.(*powerSavePlan); psp != nil {
+	//						psp.HandleIdleOff()
+	//					}
+	//				}
+	//			}
+	//		}
+	//	}()
+	//}
 }
 
 func (m *Manager) destroy() {

--- a/session/power1/manager_events.go
+++ b/session/power1/manager_events.go
@@ -72,6 +72,15 @@ func (m *Manager) initOnBatteryChangedHandler() {
 func (m *Manager) handleBeforeSuspend() {
 	m.setPrepareSuspend(suspendStatePrepare)
 	m.setDDEBlackScreenActive(true)
+	if m.UseWayland {
+		// 如果是treeland，并且待机休眠唤醒是需要解锁，则将session 给lock
+		if m.SleepLock.Get() {
+			err := m.currentSession.Lock(0)
+			if err != nil {
+				logger.Warning("set session lock failed:", err)
+			}
+		}
+	}
 	logger.Debug("before sleep")
 }
 

--- a/session/power1/power_save_plan.go
+++ b/session/power1/power_save_plan.go
@@ -68,15 +68,17 @@ func newPowerSavePlan(manager *Manager) (string, submodule, error) {
 	p := new(powerSavePlan)
 	p.manager = manager
 
-	conn := manager.helper.xConn
 	var err error
-	p.atomNetWMStateFullscreen, err = conn.GetAtom("_NET_WM_STATE_FULLSCREEN")
-	if err != nil {
-		return submodulePSP, nil, err
-	}
-	p.atomNetWMStateFocused, err = conn.GetAtom("_NET_WM_STATE_FOCUSED")
-	if err != nil {
-		return submodulePSP, nil, err
+	if !manager.UseWayland {
+		conn := manager.helper.xConn
+		p.atomNetWMStateFullscreen, err = conn.GetAtom("_NET_WM_STATE_FULLSCREEN")
+		if err != nil {
+			return submodulePSP, nil, err
+		}
+		p.atomNetWMStateFocused, err = conn.GetAtom("_NET_WM_STATE_FOCUSED")
+		if err != nil {
+			return submodulePSP, nil, err
+		}
 	}
 
 	p.fullscreenWorkaroundAppList = manager.settings.GetStrv(
@@ -544,9 +546,11 @@ func (psp *powerSavePlan) stopScreensaver() {
 func (psp *powerSavePlan) makeSystemSleep() {
 	logger.Info("sleep")
 	psp.stopScreensaver()
-	// psp.manager.setDPMSModeOn()
-	// psp.resetBrightness()
-	psp.manager.doSuspendByFront()
+	if psp.manager.UseWayland {
+		psp.manager.doSuspend()
+	} else {
+		psp.manager.doSuspendByFront()
+	}
 }
 
 func (psp *powerSavePlan) lock() {

--- a/session/power1/utils.go
+++ b/session/power1/utils.go
@@ -248,6 +248,14 @@ func (m *Manager) tryChangeDeepinWM() bool {
 }
 
 func (m *Manager) doLock(autoStartAuth bool) {
+	// 如果是treeland，直接执行login1 的session lock
+	if m.UseWayland {
+		err := m.currentSession.Lock(0)
+		if err != nil {
+			logger.Warning("set session lock failed:", err)
+		}
+		return
+	}
 	locked, err := m.sessionManager.Locked().Get(0)
 	if err != nil {
 		logger.Warning(err)


### PR DESCRIPTION
treeland适配，调用login1 的session lock触发锁屏

Log: treeland适配，调用login1 的session lock触发锁屏
pms: BUG-281261