### PR TITLE
chore: set upower CriticalPowerAction to ignore

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -35,6 +35,14 @@ prepareGfxmodeDetect () {
     /usr/lib/deepin-daemon/grub2 -prepare-gfxmode-detect && update-grub || true
 }
 
+modifyUPowerConfig () {
+    if [ -f /etc/UPower/UPower.conf ]; then
+        sed -ibak '/^\[UPower]/,/^\[/{s/^AllowRiskyCriticalPowerAction=false/AllowRiskyCriticalPowerAction=true/};/^\[UPower]/,/^\[/{s/^CriticalPowerAction=.*/CriticalPowerAction=Ignore/}' /etc/UPower/UPower.conf
+
+        deb-systemd-invoke reload upower.service
+    fi
+}
+
 case "$1" in
     configure)
     if [ -x /usr/lib/deepin-daemon/default-terminal ];then
@@ -43,6 +51,7 @@ case "$1" in
     fi
     linkJavaFallbackFont
     prepareGfxmodeDetect
+    modifyUPowerConfig
     ;;
     triggered)
     linkJavaFallbackFont


### PR DESCRIPTION
防止 upower 操作覆盖 dde-daemon 操作

Bug: https://pms.uniontech.com/bug-view-290345.html,
     https://pms.uniontech.com/bug-view-290333.html