### PR TITLE
fix: 解决安全加固导致image-blur创建不了文件的问题

### DIFF
--- a/misc/systemd/services/system/dde-system-daemon.service
+++ b/misc/systemd/services/system/dde-system-daemon.service
@@ -62,6 +62,7 @@ ReadWritePaths=-/var/lib/systemd/timesync
 ReadWritePaths=-/var/lib/dde-daemon/airplane_mode
 # com.deepin.daemon.ImageEffect
 ReadWritePaths=-/var/cache/deepin/dde-daemon/image-effect
+ReadWritePaths=-/var/cache/image-blur
 # com.deepin.daemon.Uadp
 ReadWritePaths=-/usr/share/uadp/
 # com.deepin.system.Network


### PR DESCRIPTION
解决安全加固导致image-blur创建不了文件的问题

Log: 解决安全加固导致image-blur创建不了文件的问题
pms: BUG-288537