### PR TITLE
fix: 解决dconfig属性类型不对导致崩溃的问题

### DIFF
--- a/session/power1/manager.go
+++ b/session/power1/manager.go
@@ -666,7 +666,7 @@ func (m *Manager) initDsg() {
 		case dsettingCustomShutdownWeekDays:
 			res := []byte{}
 			for _, v := range data.Value().([]dbus.Variant) {
-				res = append(res, byte(v.Value().(float64)))
+				res = append(res, byte(v.Value().(int64)))
 			}
 			if init {
 				m.CustomShutdownWeekDays = res


### PR DESCRIPTION
解决dconfig属性类型不对导致崩溃的问题

Log: 解决dconfig属性类型不对导致崩溃的问题
pms: BUG-288537