### PR TITLE
fix:修复1129内测环境,小米平板5、rk3588 开发板等设备上使用快捷键后键盘失灵问题

### DIFF
--- a/system/systeminfo1/systeminfo.go
+++ b/system/systeminfo1/systeminfo.go
@@ -61,9 +61,9 @@ func (m *Module) Start() error {
 		info, err := dmi.GetDMI()
 		if err != nil {
 			logger.Warning(err)
-		} else {
-			m.m.setPropDMIInfo(info)
+			info = &dmi.DMI{}
 		}
+		m.m.setPropDMIInfo(info)
 
 	}()
 	return nil


### PR DESCRIPTION
由于内核没有导出dmi信息,导致systeminfo1指针异常

Log: 修复快捷键问题
pms: BUG-298139