### PR TITLE
fix: 修复手势翻译错误的问题

### DIFF
--- a/gesture1/gesture_action.go
+++ b/gesture1/gesture_action.go
@@ -50,7 +50,7 @@ func (m *Manager) initActions() {
 		{"MouseRightButtonUp", gettext.Tr("Mouse right button released"), m.doXdotoolsMouseUp},
 		{"ToggleClipboard", gettext.Tr("Show/hide clipboard"), m.doToggleClipboard},
 		{"ToggleGrandSearch", gettext.Tr("Show/hide grand search"), m.doToggleGrandSearch},
-		{"ToggleNotifications", gettext.Tr("Show/hide notificaion center"), m.doToggleNotifications},
+		{"ToggleNotifications", gettext.Tr("Show/hide notification center"), m.doToggleNotifications},
 		{"Disable", gettext.Tr("Disable"), nil},
 	}
 }

--- a/misc/po/zh_CN.po
+++ b/misc/po/zh_CN.po
@@ -241,7 +241,7 @@ msgstr "恢复窗口"
 
 #: ../../gesture1/gesture_action.go:40
 msgid "Current Window Left Split"
-msgstr "当前窗口右分屏"
+msgstr "当前窗口左分屏"
 
 #: ../../gesture1/gesture_action.go:41
 msgid "Current Window Right Split"


### PR DESCRIPTION
手势三指左右滑动的翻译错误

Log: 修复手势翻译错误的问题
pms: BUG-302543