### PR TITLE
chore: 解决壁纸没有保存的问题

### DIFF
--- a/misc/systemd/services/system/dde-system-daemon.service
+++ b/misc/systemd/services/system/dde-system-daemon.service
@@ -106,8 +106,7 @@ ReadWritePaths=-/var/lib/dde-daemon/power/
 # com.deepin.daemon.Daemon
 # ReadWritePaths=-/etc/NetworkManager/system-connections
 # ReadWritePaths=-/etc/systemd/logind.conf.d
-ReadWritePaths=-/usr/share/wallpapers/custom-wallpapers/
-ReadWritePaths=-/usr/share/wallpapers/custom-solidwallpapers/
+ReadWritePaths=-/usr/share/wallpapers
 # 执行plymouth-set-default-theme
 ReadWritePaths=-/usr/share/plymouth/
 # ReadWritePaths=-/etc/plymouth/


### PR DESCRIPTION
安全管控导致/usr/share/wallpapers下没有权限创建custom的文件夹

Log: 解决壁纸没有保存的问题
pms: BUG-294645