### PR TITLE
fix: 解决磐石系统下设置不了壁纸的问题

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,11 +155,6 @@ print_gopath: prepare
 	GOPATH="${CURDIR}/${GOPATH_DIR}:${GOPATH}"
 
 install: build install-dde-data install-icons
-	# 创建配置文件夹
-	mkdir -pv ${DESTDIR}/var/lib/dde-daemon/
-	mkdir -pv ${DESTDIR}/var/cache/image-blur
-	mkdir -pv ${DESTDIR}/var/cache/deepin/dde-daemon/
-
 	mkdir -pv ${DESTDIR}${PREFIX}/lib/deepin-daemon
 	cp -f out/bin/* ${DESTDIR}${PREFIX}/lib/deepin-daemon/
 

--- a/bin/dde-system-daemon/wallpaper.go
+++ b/bin/dde-system-daemon/wallpaper.go
@@ -24,8 +24,8 @@ import (
 
 const maxCount = 5
 const maxSize = 32 * 1024 * 1024
-const wallPaperDir = "/usr/share/wallpapers/custom-wallpapers/"
-const solidWallPaperPath = "/usr/share/wallpapers/custom-solidwallpapers/"
+const wallPaperDir = "/var/cache/wallpapers/custom-wallpapers/"
+const solidWallPaperPath = "/var/cache/wallpapers/custom-solidwallpapers/"
 const solidPrefix = "solid::"
 const polkitActionUserAdministration = "org.deepin.dde.accounts.user-administration"
 

--- a/debian/dde-daemon.tmpfiles
+++ b/debian/dde-daemon.tmpfiles
@@ -1,0 +1,7 @@
+#Type Path                                          Mode    User    Group   Age     Argument
+d     /var/lib/dde-daemon/                          0755    root    root    -       -
+d     /var/cache/image-blur/                        0755    root    root    -       -
+d     /var/cache/deepin/dde-daemon/                 0755    root    root    -       -
+d     /var/cache/wallpapers/                        0755    root    root    -       -
+d     /var/cache/wallpapers/custom-wallpapers/      0755    root    root    -       -
+d     /var/cache/wallpapers/custom-solidwallpapers/ 0755    root    root    -       -

--- a/debian/rules
+++ b/debian/rules
@@ -27,6 +27,7 @@ endif
 override_dh_auto_install:
 	dh_auto_install
 	dh_installsysusers  dde-daemon.sysusers
+	dh_installtmpfiles dde-daemon.tmpfiles
 
 ifeq ($(DEB_BUILD_ARCH), mipsel)
 override_dh_auto_configure:
@@ -43,6 +44,7 @@ override_dh_auto_install:
 	rm debian/dde-daemon/etc/default/grub.d/10_deepin.cfg
 	rm debian/dde-daemon/etc/grub.d/35_deepin_gfxmode
 	dh_installsysusers  dde-daemon.sysusers
+	dh_installtmpfiles dde-daemon.tmpfiles
 endif
 
 ifeq ($(DEB_BUILD_ARCH), mips64el)
@@ -52,6 +54,7 @@ override_dh_auto_install:
 	install -d debian/dde-daemon/lib/systemd/system-sleep/
 	install misc/scripts/dde-system-daemon-power-refresh.sh debian/dde-daemon/lib/systemd/system-sleep/
 	dh_installsysusers  dde-daemon.sysusers
+	dh_installtmpfiles dde-daemon.tmpfiles
 endif
 
 override_dh_installsystemd:

--- a/misc/systemd/services/system/dde-system-daemon.service
+++ b/misc/systemd/services/system/dde-system-daemon.service
@@ -107,6 +107,7 @@ ReadWritePaths=-/var/lib/dde-daemon/power/
 # ReadWritePaths=-/etc/NetworkManager/system-connections
 # ReadWritePaths=-/etc/systemd/logind.conf.d
 ReadWritePaths=-/usr/share/wallpapers
+ReadWritePaths=-/var/cache/wallpapers
 # 执行plymouth-set-default-theme
 ReadWritePaths=-/usr/share/plymouth/
 # ReadWritePaths=-/etc/plymouth/


### PR DESCRIPTION
磐石系统,/usr/目录是只读的，导致壁纸缓存不了

Log: 解决磐石系统下设置不了壁纸的问题
pms: BUG-294645