### PR TITLE
fix: 三指滑动，最大化和恢复窗口分开设置

### DIFF
--- a/clipboard1/manager.go
+++ b/clipboard1/manager.go
@@ -7,6 +7,7 @@ package clipboard
 import (
 	"bytes"
 	"errors"
+	"flag"
 	"fmt"
 	"strings"
 	"sync"
@@ -770,7 +771,8 @@ func (m *Manager) finishSelectionRequest(ev *x.SelectionRequestEvent, success bo
 		logger.Warning(err)
 	}
 
-	if logger.GetLogLevel() == log.LevelDebug {
+	// debug环境中，单元测试不执行下面的逻辑
+	if logger.GetLogLevel() == log.LevelDebug && flag.Lookup("test.v") == nil {
 		successStr := "success"
 		if !success {
 			successStr = "fail"

--- a/gesture1/gesture_action.go
+++ b/gesture1/gesture_action.go
@@ -36,7 +36,7 @@ const (
 func (m *Manager) initActions() {
 	actions = []*actionInfo{
 		{"MaximizeWindow", gettext.Tr("Maximize Window"), m.doToggleMaximize},
-		{"RestoreWindow", gettext.Tr("Restore Window"), m.doToggleMaximize},
+		{"RestoreWindow", gettext.Tr("Restore Window"), m.doToggleRestore},
 		{"SplitWindowLeft", gettext.Tr("Current Window Left Split"), m.doTileActiveWindowLeft},
 		{"SplitWindowRight", gettext.Tr("Current Window Right Split"), m.doTileActiveWindowRight},
 		{"ShowMultiTask", gettext.Tr("Show multitasking view"), m.doShowMultiTasking},
@@ -108,7 +108,13 @@ func (m *Manager) doHandle4Or5FingersSwipeDown() error {
 }
 
 func (m *Manager) doToggleMaximize() error {
-	return m.wm.PerformAction(0, wmActionToggleMaximize)
+	setActiveWindowMaxMin(true)
+	return nil
+}
+
+func (m *Manager) doToggleRestore() error {
+	setActiveWindowMaxMin(false)
+	return nil
 }
 
 func (m *Manager) doMinimize() error {


### PR DESCRIPTION
最大化和恢复窗口，窗管是一个接口，使用x11重写这块逻辑，目前存在问题：左右分屏，不能恢复窗管

Log: 三指滑动，最大化和恢复窗口分开设置
pms: BUG-302527