### PR TITLE
fix: 用户添加删除壁纸，发送信号

### DIFF
--- a/bin/dde-system-daemon/main.go
+++ b/bin/dde-system-daemon/main.go
@@ -52,6 +52,11 @@ type Daemon struct {
 		HandleForSleep struct {
 			start bool
 		}
+		WallpaperChanged struct {
+			userName string
+			added    uint32
+			file     []string
+		}
 	}
 }
 


### PR DESCRIPTION
用户添加删除壁纸，发送信号

Log: 用户添加删除壁纸，发送信号
pms: BUG-309839

## Summary by Sourcery

Implement wallpaper change signal emission for user wallpaper add and delete operations

New Features:
- Add DBus signal emission for wallpaper addition and deletion events

Bug Fixes:
- Ensure wallpaper changes are properly signaled to the system daemon

Enhancements:
- Modify wallpaper management functions to return additional information about removed wallpapers
- Introduce constants to differentiate between wallpaper addition and deletion events