### PR TITLE
feat: bluetooth default enabled

### DIFF
--- a/misc/dsg-configs/org.deepin.dde.daemon.bluetooth.json
+++ b/misc/dsg-configs/org.deepin.dde.daemon.bluetooth.json
@@ -33,7 +33,7 @@
           "visibility": "private"
       },
       "adapterPowerd": {
-          "value": false,
+          "value": true,
           "serial": 0,
           "flags": ["global"],
           "name": "adapterPowerd",


### PR DESCRIPTION
bluetooth default enabled

Log: bluetooth default enabled
pms: TASK-369021

## Summary by Sourcery

New Features:
- Set Bluetooth daemon configuration to be enabled by default