### PR TITLE
chore: Bump version to 6.1.27

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-daemon (6.1.27) unstable; urgency=medium
+
+  * fix: 解决屏保没有同步的问题
+  * fix: 解决kwin升级后导致快捷键的问题
+
+ -- fuleyi <fuleyi@uniontech.com>  Thu, 17 Apr 2025 20:48:57 +0800
+
 dde-daemon (6.1.26) unstable; urgency=medium
 
   * chore: display & xsettings moved to dde-daemon


### PR DESCRIPTION
Bump version to 6.1.27

## Summary by Sourcery

Chores:
- Increment project version number to 6.1.27