### PR TITLE
feat: change default lock wallpaper path

### DIFF
--- a/accounts1/user.go
+++ b/accounts1/user.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	defaultUserBackgroundDir = "/usr/share/wallpapers/deepin/"
+	defaultUserBackgroundDir = "/usr/share/backgrounds/"
 	defaultUserIcon          = "file:///var/lib/AccountsService/icons/default"
 
 	controlCenterPath = "/usr/bin/dde-control-center"
@@ -79,6 +79,9 @@ const (
 	themeGroupDefault       = "DefaultTheme"
 	themeGroupDark          = "DarkTheme"
 	configKeyLockBackground = "LockBackground"
+
+	defaultLockBackgroundFileName = "default_lock_background.jpg"
+	defaultBackgroundFileName     = "default_background.jpg"
 )
 
 func getThemeLockBackground(theme string) string {
@@ -102,11 +105,17 @@ func getThemeLockBackground(theme string) string {
 
 // 通过默认主题去获取壁纸
 func getDefaultUserBackground() string {
-	bg := "file://" + filepath.Join(defaultUserBackgroundDir, "deepin-default.jpg")
-	value := getThemeLockBackground(defaultTheme)
-	if value != "" {
-		bg = value
+	bg := "file://" + filepath.Join(defaultUserBackgroundDir, defaultLockBackgroundFileName)
+	if dutils.IsFileExist(bg) {
+		return bg
 	}
+	logger.Warning("default_lock_background.jpg not exist, try to get from default theme")
+	bg = getThemeLockBackground(defaultTheme)
+	if dutils.IsFileExist(bg) {
+		return bg
+	}
+	logger.Warning("default theme lock background not exist, use default background")
+	bg = "file://" + filepath.Join(defaultUserBackgroundDir, defaultBackgroundFileName)
 	return bg
 }
 

--- a/common/scale/screenscale.go
+++ b/common/scale/screenscale.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package scale
 
 import (

--- a/common/scale/screenscale_test.go
+++ b/common/scale/screenscale_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package scale
 
 import (

--- a/display1/main.go
+++ b/display1/main.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package display1
 
 import (

--- a/xsettings1/daemon.go
+++ b/xsettings1/daemon.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package xsettings
 
 import (

--- a/xsettings1/utils_dconfig.go
+++ b/xsettings1/utils_dconfig.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package xsettings
 
 import (

--- a/xsettings1/utils_gsettings.go
+++ b/xsettings1/utils_gsettings.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package xsettings
 
 import (


### PR DESCRIPTION
to: /usr/share/backgrounds/default_lock_background.jpg If it does not exist, fallback to the default theme wallpaper

pms: BUG-312123

## Summary by Sourcery

Change the default lock wallpaper path and add fallback mechanism for lock screen background

New Features:
- Implement a new fallback mechanism for selecting lock screen wallpaper

Bug Fixes:
- Provide a more robust method for selecting lock screen wallpaper when preferred images are not available

Enhancements:
- Modify default wallpaper directory from '/usr/share/wallpapers/deepin/' to '/usr/share/backgrounds/'
- Add logic to check for specific lock screen background file before falling back to theme or default background