### PR TITLE
chore: bump version to 6.1.28

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-daemon (6.1.28) unstable; urgency=medium
+
+  * feat: change default lock wallpaper path
+
+ -- zhangkun <zhangkun2@uniontech.com>  Tue, 22 Apr 2025 20:32:29 +0800
+
 dde-daemon (6.1.27) unstable; urgency=medium
 
   * fix: 解决屏保没有同步的问题


### PR DESCRIPTION
as title

Log:

## Summary by Sourcery

Chores:
- Update Debian changelog to reflect the new version number