### PR TITLE
fix: starting with none screen, then inserted a screen, the screen…

### DIFF
--- a/display1/manager.go
+++ b/display1/manager.go
@@ -822,7 +822,11 @@ func (m *Manager) updateMonitorsId(options applyOptions) (changed bool) {
 		logger.Debugf("monitors id changed, old monitors id: %v, new monitors id: %v", oldMonitorsId.v1, newMonitorsId.v1)
 		m.markClean()
 
-		const delayApplyDuration = 1 * time.Second
+		delayApplyDuration := 10 * time.Millisecond
+		if strings.Contains(oldMonitorsId.v1, newMonitorsId.v1) {
+			// 提高延迟时间，避免毛刺（断开-重连现象）导致的问题。
+			delayApplyDuration = 1 * time.Second
+		}
 		if m.delayApplyTimer == nil {
 			m.delayApplyTimer = time.AfterFunc(delayApplyDuration, m.delayApplyConfig)
 		}

--- a/display1/xorg.go
+++ b/display1/xorg.go
@@ -160,11 +160,12 @@ type xMonitorManager struct {
 
 func newXMonitorManager(xConn *x.Conn, hasRandr1d2 bool) *xMonitorManager {
 	xmm := &xMonitorManager{
-		xConn:         xConn,
-		hasRandr1d2:   hasRandr1d2,
-		crtcs:         make(map[randr.Crtc]*CrtcInfo),
-		outputs:       make(map[randr.Output]*OutputInfo),
-		stdNamesCache: make(map[string]string),
+		xConn:                   xConn,
+		hasRandr1d2:             hasRandr1d2,
+		crtcs:                   make(map[randr.Crtc]*CrtcInfo),
+		outputs:                 make(map[randr.Output]*OutputInfo),
+		stdNamesCache:           make(map[string]string),
+		monitorChangedCbEnabled: true,
 	}
 	err := xmm.init()
 	if err != nil {


### PR DESCRIPTION
… cannot be lit

as title

Log: as title
Pms: BUG-300079

## Summary by Sourcery

Fix display monitor connection and enabling logic to handle screen insertion and connection scenarios more robustly

Bug Fixes:
- Improve handling of monitor connection states when a screen is inserted, preventing issues with screen lighting and connection detection
- Adjust delay mechanism when monitors change to reduce visual artifacts during connection/disconnection

Enhancements:
- Modify monitor enabling logic to check for available modes instead of just width and height
- Add a configurable delay mechanism to handle monitor connection state changes more gracefully