### PR TITLE
fix: 解决dde-session-daemon启动慢的问题

### DIFF
--- a/bin/dde-session-daemon/main.go
+++ b/bin/dde-session-daemon/main.go
@@ -158,10 +158,6 @@ func init() {
 
 func main() {
 	logger.SetLogLevel(log.LevelInfo)
-	if !allowRun() {
-		logger.Warning("session manager does not allow me to run")
-		os.Exit(1)
-	}
 
 	if isInShutdown() {
 		logger.Warning("system is in shutdown, no need to run")


### PR DESCRIPTION
解决dde-session-daemon启动慢的问题

Log: 解决dde-session-daemon启动慢的问题
pms: BUG-313421

## Summary by Sourcery

Bug Fixes:
- Remove unnecessary startup check that was potentially causing delays in the daemon's initialization