### PR TITLE
feat: Provide osbuild properties

### DIFF
--- a/systeminfo1/info.go
+++ b/systeminfo1/info.go
@@ -51,6 +51,8 @@ type SystemInfo struct {
 	CurrentSpeed uint64
 	// Cpu Hardware
 	CPUHardware string
+	// Os Build
+	OsBuild string
 }
 
 type Daemon struct {
@@ -209,6 +211,11 @@ func (info *SystemInfo) init() {
 	info.MemoryCap, err = getMemoryFromFile("/proc/meminfo")
 	if err != nil {
 		logger.Warning("Get memory capacity failed:", err)
+	}
+
+	info.OsBuild, err = getOsBuild()
+	if err != nil {
+		logger.Warning("Get os build failed:", err)
 	}
 
 	if systemBit() == "64" {

--- a/systeminfo1/utils.go
+++ b/systeminfo1/utils.go
@@ -18,6 +18,12 @@ const (
 	lscpuKeyDelim = ":"
 )
 
+const (
+	osVersionFile      = "/etc/os-version"
+	osVersionSplitChar = "="
+	osBuildKey         = "OsBuild"
+)
+
 func getMemoryFromFile(file string) (uint64, error) {
 	ret, err := parseInfoFile(file, memKeyDelim)
 	if err != nil {
@@ -35,6 +41,14 @@ func getMemoryFromFile(file string) (uint64, error) {
 	}
 
 	return cap * 1024, nil
+}
+
+func getOsBuild() (string, error) {
+	content, err := parseInfoFile("/etc/os-version", osVersionSplitChar)
+	if err != nil {
+		return "", err
+	}
+	return content[osBuildKey], nil
 }
 
 // 执行命令：/usr/bin/getconf LONG_BIT 获取系统位数


### PR DESCRIPTION
as title

pms: BUG-313919

## Summary by Sourcery

Add functionality to retrieve the OS build information from the system

New Features:
- Introduce a method to extract OS build information from the '/etc/os-version' file

Enhancements:
- Extend the SystemInfo struct to include an OsBuild field
- Create a new utility function to parse OS build information