### PR TITLE
fix: Unable to switch performance mode

### DIFF
--- a/misc/systemd/services/system/dde-system-daemon.service
+++ b/misc/systemd/services/system/dde-system-daemon.service
@@ -131,6 +131,7 @@ ReadWritePaths=-/home
 # TLP
 ReadWritePaths=-/usr/share/tlp/deepin-system-power-control/
 ReadWritePaths=-/etc/tlp.d/
+ReadWritePaths=-/run/tlp/
 
 [Install]
 # We pull this in by graphical.target instead of waiting for the bus


### PR DESCRIPTION
Add /run/tlp/ read-write permissions

Log: as title
Pms: BUG-309477

## Summary by Sourcery

Bug Fixes:
- Fix inability to switch performance modes (BUG-309477).