### PR TITLE
fix: 解决蓝牙文件传输失败的问题

### DIFF
--- a/bluetooth1/obex_agent.go
+++ b/bluetooth1/obex_agent.go
@@ -7,10 +7,8 @@ package bluetooth
 import (
 	"errors"
 	"fmt"
-
 	"math"
 	"math/rand"
-	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -345,7 +343,7 @@ func moveTempFile(src, dest string) string {
 			count++
 			dest = fmt.Sprintf("%v(%v)%v", fileName, count, suffix)
 		} else {
-			err := os.Rename(src, dest)
+			err := dutils.MoveFile(src, dest)
 			if err != nil {
 				fmt.Println("failed to move file:", err)
 			}


### PR DESCRIPTION
接受文件后，转移文件时使用的rename，rename不支持跨设备，导致报错。改用copy的方式转移

Log: 解决蓝牙文件传输失败的问题
pms: BUG-310587