### PR TITLE
fix: sends hashed wallpaper path when add wallpaper

### DIFF
--- a/bin/dde-system-daemon/wallpaper.go
+++ b/bin/dde-system-daemon/wallpaper.go
@@ -296,7 +296,7 @@ func (d *Daemon) SaveCustomWallPaper(sender dbus.Sender, username string, file s
 		logger.Warning(err)
 		return "", dbusutil.ToError(err)
 	}
-	err = d.service.Emit(d, "WallpaperChanged", username, uint32(wallpaperAdd), []string{file})
+	err = d.service.Emit(d, "WallpaperChanged", username, uint32(wallpaperAdd), []string{destFile})
 	if err != nil {
 		logger.Warning("failed to emit WallpaperChanged signal:", err)
 	}


### PR DESCRIPTION
as title

pms: BUG-314271

## Summary by Sourcery

Bug Fixes:
- Corrected the wallpaper changed signal to emit the destination (hashed) file path instead of the original file path