### PR TITLE
fix: improve timezone management and display service configuration

### DIFF
--- a/timedate1/manager_ifc.go
+++ b/timedate1/manager_ifc.go
@@ -207,8 +207,15 @@ func (m *Manager) DeleteUserTimezone(zone string) *dbus.Error {
 	oldList, hasNil := filterNilString(m.UserTimezones)
 	newList, deleted := deleteItemFromList(zone, oldList)
 	if deleted || hasNil {
+		m.PropsMu.Lock()
 		m.UserTimezones = newList
+		m.PropsMu.Unlock()
 		m.service.EmitPropertyChanged(m, "UserTimezones", m.UserTimezones)
+		err = m.dConfigManager.SetValue(dbus.Flags(0), dSettingsKeyTimezoneList, dbus.MakeVariant(m.UserTimezones))
+		if err != nil {
+			logger.Warning(err)
+			return dbusutil.ToError(err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
- Add proper mutex locking for timezone list updates
- Implement configuration persistence for timezone changes
- Add display manager service configuration

Log: improve timezone management and display service configuration
pms: BUG-286869

## Summary by Sourcery

Improve timezone management by adding mutex protection and configuration persistence for timezone list updates

Bug Fixes:
- Add proper mutex locking to prevent race conditions when updating user timezones
- Implement persistent storage for timezone list changes

Enhancements:
- Add configuration persistence for timezone changes using dbus settings manager