### PR TITLE
feat: add fallback NTP server support

### DIFF
--- a/misc/dsg-configs/org.deepin.dde.daemon.timedated.json
+++ b/misc/dsg-configs/org.deepin.dde.daemon.timedated.json
@@ -21,6 +21,16 @@
             "description": "current ntp server",
             "permissions": "readwrite",
             "visibility": "private"
+        },
+        "FallbackNTPServer": {
+            "value": "ntp.aliyun.com",
+            "serial": 0,
+            "flags": ["global"],
+            "name": "fallback ntp server",
+            "name[zh_CN]": "后备的NTP服务地址",
+            "description": "fallback ntp server",
+            "permissions": "readonly",
+            "visibility": "private"
         }
     }
 }


### PR DESCRIPTION
1. Added FallbackNTPServer configuration in dsg-configs with aliyun as default
2. Extended Manager struct to include fallbackNTPServer field
3. Implemented getDsgFallbackNTPServer method to retrieve fallback server
4. Modified setNTPServerToTimeSyncd to append fallback server when default NTP is used
5. Added logic to handle fallback server when primary NTP server fails

The changes provide redundancy for time synchronization by automatically falling back to a secondary NTP server (ntp.aliyun.com) when the primary server is unavailable or using default settings. This improves system time reliability.

feat: 添加后备NTP服务器支持

1. 在dsg-configs中添加FallbackNTPServer配置，默认使用阿里云服务器
2. 扩展Manager结构体包含fallbackNTPServer字段
3. 实现getDsgFallbackNTPServer方法获取后备服务器
4. 修改setNTPServerToTimeSyncd方法，在使用默认NTP时追加后备服务器
5. 添加处理逻辑在主NTP服务器不可用时使用后备服务器

这些修改通过在主NTP服务器不可用或使用默认设置时自动回退到备用NTP服务器
(ntp.aliyun.com)，为时间同步提供了冗余，提高了系统时间的可靠性。

pms: BUG-315181

## Summary by Sourcery

Add support for a secondary NTP server by introducing a fallback configuration and automatically appending and switching to it when the primary NTP server is unavailable or using default settings

New Features:
- Add FallbackNTPServer option in dsg-configs with default ntp.aliyun.com
- Extend Manager to retrieve and store the fallback NTP server
- Modify time-sync configuration to append the fallback server when using default NTP

Enhancements:
- Automatically switch to the fallback NTP server if the primary server fails