### PR TITLE
chore: bump version to 6.1.32

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-daemon (6.1.32) unstable; urgency=medium
+
+  * feat: add fallback NTP server support
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Tue, 13 May 2025 21:20:26 +0800
+
 dde-daemon (6.1.31) unstable; urgency=medium
 
   * fix: 修改噪音抑制脚本


### PR DESCRIPTION
update changelog to 6.1.32

## Summary by Sourcery

Build:
- Update Debian changelog to reflect version 6.1.32