### PR TITLE
fix: add netdev group membership for deepin-daemon

### DIFF
--- a/archlinux/deepin-daemon.sysusers
+++ b/archlinux/deepin-daemon.sysusers
@@ -1,2 +1,3 @@
 u deepin-daemon - "Deepin Daemon"
+m deepin-daemon netdev
 g deepin-daemon -

--- a/debian/dde-daemon.sysusers
+++ b/debian/dde-daemon.sysusers
@@ -1,4 +1,5 @@
 # This file is part of dde-daemon
 #Type Name                      ID                  GECOS              Home directory Shell
 u     deepin-daemon             -                   ""                  -              -
+m     deepin-daemon             netdev
 u     deepin-admin-daemon       -                   ""                  -              -

--- a/rpm/deepin-daemon.sysusers
+++ b/rpm/deepin-daemon.sysusers
@@ -1,2 +1,3 @@
 u deepin-daemon - "Deepin Daemon"
+m deepin-daemon netdev
 g deepin-daemon -


### PR DESCRIPTION
Added deepin-daemon to the netdev group in sysusers configuration
to ensure proper network device access permissions. This change is
necessary because the daemon requires network interface management
capabilities for certain functions.

fix: 为 deepin-daemon 添加 netdev 组成员资格

在 sysusers 配置中将 deepin-daemon 加入 netdev 组，以确保正确的网络设
备访问权限。此变更是必要的，因为守护进程需要网络接口管理能力来实现某些
功能。
/usr/share/dbus-1/system.d/wpa_supplicant.conf中对netdev组
有dbus权限控制。

pms: BUG-311157

## Summary by Sourcery

Bug Fixes:
- Add deepin-daemon to netdev group in sysusers configuration to ensure proper network interface access permissions.