### PR TITLE
fix: 解决降噪设置被重复触发的问题

### DIFF
--- a/audio1/audio_events.go
+++ b/audio1/audio_events.go
@@ -570,6 +570,9 @@ func (a *Audio) writeReduceNoise(write *dbusutil.PropertyWrite) *dbus.Error {
 	if !ok {
 		return dbusutil.ToError(errors.New("type is not bool"))
 	}
+	if a.ReduceNoise == reduce {
+		return nil
+	}
 
 	if reduce && isBluezAudio(a.defaultSource.Name) {
 		logger.Debug("bluetooth audio device cannot open reduce-noise")


### PR DESCRIPTION
解决降噪设置被重复触发的问题

Log: 解决降噪设置被重复触发的问题
pms: TASK-369021

## Summary by Sourcery

Bug Fixes:
- Add guard to skip redundant reduce-noise writes when state is unchanged