### PR TITLE
feat: 快捷键切换屏幕时判断有效屏幕数量

### DIFF
--- a/keybinding1/shortcuts/system_shortcut.go
+++ b/keybinding1/shortcuts/system_shortcut.go
@@ -108,7 +108,7 @@ var defaultSysActionCmdMap = map[string]string{
 	"clipboard":              "dbus-send --print-reply --dest=org.deepin.dde.Clipboard1 /org/deepin/dde/Clipboard1 org.deepin.dde.Clipboard1.Toggle; dbus-send --print-reply --dest=org.deepin.dde.Launcher1 /org/deepin/dde/Launcher1 org.deepin.dde.Launcher1.Hide",
 	"global-search":          "/usr/libexec/dde-daemon/keybinding/shortcut-dde-grand-search.sh",
 	"switch-next-kbd-layout": "dbus-send --print-reply --dest=org.deepin.dde.Keybinding1 /org/deepin/dde/InputDevice1/Keyboard org.deepin.dde.InputDevice1.Keyboard.ToggleNextLayout",
-	"switch-monitors":        "dbus-send --print-reply --dest=org.deepin.dde.Osd1 / org.deepin.dde.Osd1.ShowOSD string:SwitchMonitors",
+	"switch-monitors":        "/usr/libexec/dde-daemon/keybinding/shortcut-dde-switch-monitors.sh",
 	// cmd
 	"calculator": "/usr/bin/deepin-calculator",
 	"search":     "/usr/libexec/dde-daemon/keybinding/shortcut-dde-grand-search.sh",

--- a/misc/libexec/dde-daemon/keybinding/shortcut-dde-switch-monitors.sh
+++ b/misc/libexec/dde-daemon/keybinding/shortcut-dde-switch-monitors.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if ! outputs=$(dbus-send --print-reply --dest=org.deepin.dde.Display1 /org/deepin/dde/Display1 org.deepin.dde.Display1.ListOutputNames | grep -oP 'string "\K[^"]+'); then
+    exit 1
+fi
+
+if [ $(echo "$outputs" | wc -l) -gt 1 ]; then
+    dbus-send --print-reply --dest=org.deepin.dde.Osd1 / org.deepin.dde.Osd1.ShowOSD string:SwitchMonitors
+fi


### PR DESCRIPTION
添加切换显示器的快捷方式脚本

Log: 快捷键切换屏幕时判断有效屏幕数量
pms: BUG-307575

## Summary by Sourcery

Introduce a script for the switch-monitors shortcut that checks for multiple connected displays before showing the OSD.

New Features:
- Add shortcut-dde-switch-monitors.sh to conditionally handle the switch-monitors action based on active output count.

Bug Fixes:
- Prevent the switch-monitors OSD from appearing when only one monitor is connected.

Enhancements:
- Update the switch-monitors keybinding in system_shortcut.go to invoke the new script instead of a direct DBus call.