### PR TITLE
feat: integrate keyboard management with dsg configuration

### DIFF
--- a/inputdevices1/kwayland.go
+++ b/inputdevices1/kwayland.go
@@ -129,6 +129,19 @@ func doHandleKWinDeviceAdded(sysName string) {
 			}
 		}
 		_manager.tpad.handleDeviceChanged()
+	case common.DevTypeKeyboard:
+		v, _ := dxinput.NewKeyboardDevInfo(info)
+		if len(_keyboardnfos) == 0 {
+			_keyboardnfos = append(_keyboardnfos, v)
+		} else {
+			for _, tmp := range _keyboardnfos {
+				if tmp.Id == v.Id {
+					continue
+				}
+				_keyboardnfos = append(_keyboardnfos, v)
+			}
+		}
+		_manager.kbd.handleDeviceChanged()
 	}
 }
 

--- a/inputdevices1/manager.go
+++ b/inputdevices1/manager.go
@@ -23,6 +23,9 @@ const (
 	gsSchemaInputDevices = "com.deepin.dde.inputdevices"
 	gsKeyWheelSpeed      = "wheel-speed"
 	imWheelBin           = "imwheel"
+
+	dsettingsAppID        = "org.deepin.dde.daemon"
+	dsettingsInputdevices = "org.deepin.dde.daemon.inputdevices"
 )
 
 type devicePathInfo struct {

--- a/inputdevices1/touchpad.go
+++ b/inputdevices1/touchpad.go
@@ -43,9 +43,7 @@ const (
 	tpadKeyPalmMinWidth       = "palm-min-width"
 	tpadKeyPalmMinZ           = "palm-min-pressure"
 
-	dsettingsAppID        = "org.deepin.dde.daemon"
-	dsettingsInputdevices = "org.deepin.dde.daemon.inputdevices"
-	dsettingsData         = "ps2MouseAsTouchPadEnabled"
+	dsettingsData = "ps2MouseAsTouchPadEnabled"
 )
 
 const (

--- a/inputdevices1/wrapper.go
+++ b/inputdevices1/wrapper.go
@@ -39,13 +39,15 @@ type touchpadInfo struct {
 type Mouses []*mouseInfo
 type Touchpads []*touchpadInfo
 type dxWacoms []*dxinput.Wacom
+type Keyboards []*dxinput.Keyboard
 
 var (
-	_devInfos    common.DeviceInfos
-	_mouseInfos  Mouses
-	_tpadInfos   Touchpads
-	_wacomInfos  dxWacoms
-	_gudevClient = gudev.NewClient([]string{"input"})
+	_devInfos     common.DeviceInfos
+	_mouseInfos   Mouses
+	_tpadInfos    Touchpads
+	_wacomInfos   dxWacoms
+	_keyboardnfos Keyboards
+	_gudevClient  = gudev.NewClient([]string{"input"})
 )
 
 func startDeviceListener() {
@@ -69,6 +71,8 @@ func handleDeviceChanged() {
 	getMouseInfos(false)
 	_wacomInfos = dxWacoms{}
 	getWacomInfos(false)
+	_keyboardnfos = Keyboards{}
+	getKeyboardInfos(false)
 
 	if _manager == nil {
 		logger.Warning("_manager is nil")
@@ -309,4 +313,29 @@ func (info mouseInfo) isVirtual() bool {
 
 func (info touchpadInfo) isVirtual() bool {
 	return strings.Contains(info.sysfsPath, "virtual")
+}
+
+func getKeyboardInfos(force bool) Keyboards {
+	if !force && len(_keyboardnfos) != 0 {
+		return _keyboardnfos
+	}
+
+	_keyboardnfos = Keyboards{}
+	for _, info := range getDeviceInfos(false) {
+		if info.Type == common.DevTypeKeyboard {
+			tmp, _ := dxinput.NewKeyboardDevInfo(info)
+			_keyboardnfos = append(_keyboardnfos, tmp)
+		}
+	}
+
+	return _keyboardnfos
+}
+
+func (infos Keyboards) get(id int32) *dxinput.Keyboard {
+	for _, info := range infos {
+		if info.Id == id {
+			return info
+		}
+	}
+	return nil
 }

--- a/misc/dsg-configs/org.deepin.dde.daemon.inputdevices.json
+++ b/misc/dsg-configs/org.deepin.dde.daemon.inputdevices.json
@@ -34,6 +34,17 @@
         "description": "",
         "permissions": "readwrite",
         "visibility": "private"
+      },
+      "keyboardEnabled": {
+        "value": true,
+        "serial": 0,
+        "flags": [],
+        "name": "keyboard_Enabled",
+        "name[zh_CN]": "键盘启用状态",
+        "description[zh_CN]": "用户级别键盘开关",
+        "description": "",
+        "permissions": "readwrite",
+        "visibility": "public"
       }
   }
 }


### PR DESCRIPTION
Added functionality to manage keyboard settings through the dsg configuration system. This includes initializing the configuration manager, updating keyboard states based on user settings, and handling device changes effectively. The keyboardEnabled key is now part of the configuration, allowing for user-level control over keyboard activation.

Log: integrate keyboard management with dsg configuration
pms: BUG-315763

## Summary by Sourcery

Integrate keyboard management with the DSG configuration system, allowing user-level control of keyboard activation via a new configuration key. Initialize and connect to the config manager on startup, discover keyboards through the device wrapper, and automatically enable or disable them in response to both hotplug events and configuration changes.

New Features:
- Integrate DSG configuration for keyboard settings with a new 'keyboardEnabled' key
- Add initDsgConfig and updateDXKeyboards methods to initialize the config manager and apply enable/disable operations to keyboard devices based on user settings
- Extend the device wrapper with a Keyboards type and getKeyboardInfos to discover and manage physical keyboards via dxinput

Enhancements:
- Trigger keyboard state updates on both device hotplug events and configuration value changes

Documentation:
- Add a JSON schema for input devices including the keyboardEnabled setting under misc/dsg-configs