### PR TITLE
fix: remove manual mode check and adjust auto mode logic

### DIFF
--- a/display1/color_temp.go
+++ b/display1/color_temp.go
@@ -338,9 +338,6 @@ func getTemperatureWithLine(line []byte) (int, bool) {
 
 // dbus 上导出的方法
 func (m *Manager) setColorTempValue(value int32) error {
-	if m.ColorTemperatureMode != ColorTemperatureModeManual {
-		return errors.New("current not manual mode, can not adjust color temperature by manual")
-	}
 	if !isValidColorTempValue(value) {
 		return errors.New("value out of range")
 	}
@@ -393,7 +390,12 @@ func (m *Manager) getColorTemperatureValue() int {
 	case ColorTemperatureModeManual:
 		return int(manual)
 	case ColorTemperatureModeAuto:
-		return m.redshiftRunner.getValue()
+		value := m.redshiftRunner.getValue()
+		// 日落时，返回手动设置的色温(from v20)
+		if value != defaultTemperature {
+			value = int(manual)
+		}
+		return value
 	case ColorTemperatureModeCustom:
 		value := defaultTemperature
 		if m.customColorTempFlag {


### PR DESCRIPTION
1. Removed manual mode check in setColorTempValue to allow temperature adjustment regardless of mode
2. Modified auto mode behavior in getColorTemperatureValue to use manual value when not default
3. This change provides more flexible temperature control and better handles edge cases in auto mode

fix: 移除手动模式检查并调整自动模式逻辑

1. 移除setColorTempValue中的手动模式检查，允许在任何模式下调整色温
2. 修改getColorTemperatureValue中的自动模式行为，在非默认值时使用手动值
3. 此变更提供了更灵活的色温控制，并更好地处理自动模式下的边缘情况

pms: BUG-308201
pms: BUG-308209

## Summary by Sourcery

Allow adjusting color temperature regardless of mode and refine auto mode to respect manual values when the redshift value diverges from the default

Bug Fixes:
- Remove manual mode restriction in setColorTempValue to permit temperature adjustments in any mode
- Update auto mode in getColorTemperatureValue to return the manual temperature when the redshift value isn’t the default