### PR TITLE
fix: 修复换不同显示器后系统缩放未改变的问题。

### DIFF
--- a/display1/handle_event.go
+++ b/display1/handle_event.go
@@ -15,6 +15,9 @@ import (
 // 在 wayland 下，仅显示器属性改变。
 func (m *Manager) handleMonitorChanged(monitorInfo *MonitorInfo) {
 	m.updateMonitor(monitorInfo)
+	if monitorInfo.Enabled {
+		m.tryToChangeScaleFactor(monitorInfo.Width, monitorInfo.Height)
+	}
 	if _useWayland {
 		return
 	}
@@ -54,6 +57,7 @@ func (m *Manager) handleMonitorAdded(monitorInfo *MonitorInfo) {
 	}
 	m.updatePropMonitors()
 	m.updateMonitorsId(nil)
+	m.tryToChangeScaleFactor(monitorInfo.Width, monitorInfo.Height)
 }
 
 // wayland 下断开显示器


### PR DESCRIPTION
接4k缩放到2.75倍后，拔掉再接1080p显示器，此时系统仍然为2.75倍缩放。切换显示器后，通过计算当前显示器最大缩放倍数a和当前系统缩放倍数b对比，a小于b则设置为当前显示器推荐的缩放值。 接多块不同显示器（最大缩放率不同），逻辑如上。

Log: 修复换不同显示器后系统缩放未改变的问题。
pms: BUG-306327

## Summary by Sourcery

Adjust system display scaling on monitor switch to ensure scale factor does not exceed the new display’s maximum recommended value by computing a resolution-based limit and applying it via the XSettings API.

Bug Fixes:
- Reset system scale to the recommended value when connecting a monitor whose maximum scale is lower than the current one

Enhancements:
- Add calcMaxScaleFactor to compute a display’s maximum allowable scale based on its resolution
- Introduce tryToChangeScaleFactor and invoke it during monitor addition and change to perform scale adjustments
- Initialize and utilize the XSettings manager for programmatic scale factor updates