### PR TITLE
refactor: remove ai-assistant shortcuts and related actions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/godbus/dbus/v5 v5.1.0
 	github.com/gosexy/gettext v0.0.0-20160830220431-74466a0a0c4a
 	github.com/jouyouyun/hardware v0.1.8
-	github.com/linuxdeepin/dde-api v0.0.0-20250515055156-b3908acc7af1
+	github.com/linuxdeepin/dde-api v0.0.0-20250603084823-9f6196d55806
 	github.com/linuxdeepin/go-dbus-factory v0.0.0-20250513130423-081e4e5aca69
 	github.com/linuxdeepin/go-gir v0.0.0-20230710064042-bd15f0549c87
 	github.com/linuxdeepin/go-lib v0.0.0-20250514064815-de7ec8f89a8a

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,8 @@ github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/linuxdeepin/dde-api v0.0.0-20250515055156-b3908acc7af1 h1:DJKDkej1SKeVmHUTRW6P/YYUjUWmD8BVee0PDhBvlqo=
-github.com/linuxdeepin/dde-api v0.0.0-20250515055156-b3908acc7af1/go.mod h1:Ms92CRDOjzkDmX1x0x6+b0vQSYHJ7Ab9jQMY2JYWiio=
+github.com/linuxdeepin/dde-api v0.0.0-20250603084823-9f6196d55806 h1:MB+P88Freh09A1wKmrDbR2ZryElMxX1I7fz6E/f1Ono=
+github.com/linuxdeepin/dde-api v0.0.0-20250603084823-9f6196d55806/go.mod h1:Ms92CRDOjzkDmX1x0x6+b0vQSYHJ7Ab9jQMY2JYWiio=
 github.com/linuxdeepin/go-dbus-factory v0.0.0-20250513130423-081e4e5aca69 h1:fkdKGNucj9zg7P+C2OGYi/jDDReH9l8Pry0XKUi+YfM=
 github.com/linuxdeepin/go-dbus-factory v0.0.0-20250513130423-081e4e5aca69/go.mod h1:iIlTR50SA8MJ9ORPyMOpKWMF4g+AUorbER5AX0RD9Jk=
 github.com/linuxdeepin/go-gir v0.0.0-20230331033513-a8d7a9e89f9b/go.mod h1:a0tox5vepTQu5iO6rdKc4diGT+fkyXZlRROM8ULEvaI=

--- a/keybinding1/manager.go
+++ b/keybinding1/manager.go
@@ -8,6 +8,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+
 	"github.com/linuxdeepin/go-lib/appinfo/desktopappinfo"
 	"github.com/linuxdeepin/go-lib/strv"
 
@@ -486,7 +487,6 @@ var kwinSysActionCmdMap = map[string]string{
 	"Deepin Picker":         "color-picker",           // ctrl+alt+v
 	"System Monitor":        "system-monitor",         // ctrl+alt+escape
 	"Screen Recorder":       "deepin-screen-recorder", // deepin-screen-recorder ctrl+alt+r
-	"Desktop AI Assistant":  "ai-assistant",           // ai-assistant [<Super>Q]q
 	"Text to Speech":        "text-to-speech",
 	"Speech to Text":        "speech-to-text",
 	"Clipboard":             "clipboard",

--- a/keybinding1/shortcuts/id_name_map.go
+++ b/keybinding1/shortcuts/id_name_map.go
@@ -29,7 +29,6 @@ func getSystemIdNameMap() map[string]string {
 		"turn-off-screen":        gettext.Tr("Fast Screen Off"),
 		"system-monitor":         gettext.Tr("System Monitor"),
 		"color-picker":           gettext.Tr("Deepin Picker"),
-		"ai-assistant":           gettext.Tr("Desktop AI Assistant"),
 		"text-to-speech":         gettext.Tr("Text to Speech"),
 		"speech-to-text":         gettext.Tr("Speech to Text"),
 		"clipboard":              gettext.Tr("Clipboard"),

--- a/keybinding1/shortcuts/shortcut_manager.go
+++ b/keybinding1/shortcuts/shortcut_manager.go
@@ -21,7 +21,6 @@ import (
 	"github.com/linuxdeepin/go-lib/gettext"
 	"github.com/linuxdeepin/go-lib/keyfile"
 	"github.com/linuxdeepin/go-lib/log"
-	"github.com/linuxdeepin/go-lib/strv"
 	dutils "github.com/linuxdeepin/go-lib/utils"
 	x "github.com/linuxdeepin/go-x11-client"
 	"github.com/linuxdeepin/go-x11-client/ext/record"
@@ -958,12 +957,7 @@ func (sm *ShortcutManager) CheckSystem(gsPlatform, gsEnable *gio.Settings, id st
 	platformSet := arr2set(gsPlatform.ListKeys())
 	enableSet := arr2set(gsEnable.ListKeys())
 	sysType := strings.ToLower(systemType())
-	assistiveToolsShortcut := []string{
-		"ai-assistant",
-		"speech-to-text",
-		"text-to-speech",
-		"translation",
-	}
+
 	// 判断是否是支持的平台
 	if platformSet[id] {
 		plats := gsPlatform.GetStrv(id)
@@ -972,9 +966,6 @@ func (sm *ShortcutManager) CheckSystem(gsPlatform, gsEnable *gio.Settings, id st
 		if !platSet["all"] && !platSet[sysType] {
 			return false
 		}
-	}
-	if sysType == "community" && strv.Strv(assistiveToolsShortcut).Contains(id) {
-		return false
 	}
 
 	// 判断是否配置开启

--- a/misc/dde-daemon/keybinding/system_actions.json
+++ b/misc/dde-daemon/keybinding/system_actions.json
@@ -65,10 +65,6 @@
             "Key": "turn-off-screen"
         },
         {
-            "Key": "ai-assistant",
-            "Action": "dbus-send  --print-reply --dest=com.iflytek.aiassistant /aiassistant/deepinmain com.iflytek.aiassistant.mainWindow.changeui"
-        },
-        {
             "Key": "text-to-speech",
             "Action": "/usr/share/uos-ai-assistant/shell/tts.sh"
         },
@@ -82,7 +78,7 @@
         },
         {
             "Key": "translation",
-            "Action": "dbus-send  --print-reply --dest=com.iflytek.aiassistant /aiassistant/deepinmain com.iflytek.aiassistant.mainWindow.TextToTranslate"
+            "Action": "/usr/share/uos-ai-assistant/shell/translation.sh"
         },
 		{
             "key":"notification-center",


### PR DESCRIPTION
Removed references to the "ai-assistant" from keybinding configurations and system actions. This includes updates to the keybinding manager, id-name mapping, and system actions JSON file to streamline the keyboard shortcuts and improve overall clarity.

Log: remove ai-assistant shortcuts and related actions
pms: TASK-369021

## Summary by Sourcery

Remove all ai-assistant related shortcuts and actions from keybinding configurations and update the dde-api dependency.

Enhancements:
- Update linuxdeepin/dde-api dependency version.

Chores:
- Remove ai-assistant entries from ShortcutManager logic.
- Remove ai-assistant mappings from kwinSysActionCmdMap and id-name map.
- Eliminate unused import of strv in shortcut_manager.go.