### PR TITLE
fix: Modify the refresh rate accuracy to 0.01

### DIFF
--- a/display1/mode.go
+++ b/display1/mode.go
@@ -253,9 +253,10 @@ func getFirstModeBySize(modes []ModeInfo, width, height uint16) ModeInfo {
 }
 
 func getFirstModeBySizeRate(modes []ModeInfo, width, height uint16, rate float64) ModeInfo {
+	roundedRate := math.Round(rate * 100)
 	for _, modeInfo := range modes {
 		if modeInfo.Width == width && modeInfo.Height == height &&
-			math.Abs(modeInfo.Rate-rate) <= 0.01 {
+			math.Round(modeInfo.Rate * 100) == roundedRate {
 			return modeInfo
 		}
 	}

--- a/display1/monitor_test.go
+++ b/display1/monitor_test.go
@@ -22,8 +22,8 @@ func Test_getFirstModeBySize(t *testing.T) {
 func Test_getFirstModeBySizeRate(t *testing.T) {
 	modes := []ModeInfo{{84, "", 1920, 1080, 60.0}, {85, "", 1920, 1080, 50.0},
 		{95, "", 1600, 1200, 60.0}}
-	assert.Equal(t, getFirstModeBySizeRate(modes, 1920, 1080, 59.99), ModeInfo{84, "", 1920, 1080, 60.0})
-	assert.Equal(t, getFirstModeBySizeRate(modes, 1920, 1080, 49.99), ModeInfo{85, "", 1920, 1080, 50.0})
+	assert.Equal(t, getFirstModeBySizeRate(modes, 1920, 1080, 59.999), ModeInfo{84, "", 1920, 1080, 60.0})
+	assert.Equal(t, getFirstModeBySizeRate(modes, 1920, 1080, 49.999), ModeInfo{85, "", 1920, 1080, 50.0})
 	assert.Equal(t, getFirstModeBySizeRate(modes, 1600, 1200, 59), ModeInfo{})
 	assert.Equal(t, getFirstModeBySizeRate(modes, 1280, 740, 60), ModeInfo{})
 


### PR DESCRIPTION
Modify the refresh rate accuracy to 0.01

pms: BUG-318627

## Summary by Sourcery

Refine mode refresh rate matching to round input rates to two decimal places and narrow the tolerance window for more accurate mode selection.

Enhancements:
- Round the provided refresh rate to two decimal places before comparison
- Adjust the absolute difference tolerance to 0.005 to achieve 0.01 rate accuracy

Tests:
- Update unit tests to use 59.999 and 49.999 input rates reflecting the new precision threshold