### PR TITLE
fix: adjust gesture feature translations and reorder options

### DIFF
--- a/misc/dsg-configs/org.deepin.dde.daemon.gesture.json
+++ b/misc/dsg-configs/org.deepin.dde.daemon.gesture.json
@@ -77,7 +77,7 @@
           "visibility": "private"
       },
       "availableGesturesWithActionTap": {
-          "value": ["ToggleLaunchPad","ToggleClipboard","ToggleGrandSearch","ToggleNotifications", "Disable"],
+          "value": ["ToggleGrandSearch","ToggleLaunchPad","ToggleClipboard","ToggleNotifications", "Disable"],
           "serial": 0,
           "flags": [],
           "name": "availableGesturesWithActionTap",

--- a/misc/po/zh_CN.po
+++ b/misc/po/zh_CN.po
@@ -274,7 +274,7 @@ msgstr "隐藏桌面"
 
 #: ../../gesture1/gesture_action.go:48
 msgid "Show/hide launcher"
-msgstr "显示、隐藏启动器"
+msgstr "打开/关闭启动器"
 
 #: ../../gesture1/gesture_action.go:49
 msgid "Mouse right button pressed"
@@ -286,15 +286,15 @@ msgstr ""
 
 #: ../../gesture1/gesture_action.go:51
 msgid "Show/hide clipboard"
-msgstr "打开/隐藏剪切板"
+msgstr "打开/关闭剪贴板"
 
 #: ../../gesture1/gesture_action.go:52
 msgid "Show/hide grand search"
-msgstr "打开/隐藏全局搜索"
+msgstr "打开/关闭全局搜索"
 
 #: ../../gesture1/gesture_action.go:53
 msgid "Show/hide notification center"
-msgstr "打开/隐藏消息中心"
+msgstr "打开/关闭通知中心"
 
 #: ../../gesture1/gesture_action.go:54
 msgid "Disable"


### PR DESCRIPTION
- Updated Chinese translations for gesture features to use consistent "open/close" terminology
- Reordered gesture tap actions to prioritize Grand Search

Log: adjust gesture feature translations and reorder options
pms: BUG-312079
pms: BUG-312077

## Summary by Sourcery

Fix inconsistent Chinese translations for gesture open/close features and reorder tap actions to prioritize Grand Search.

Bug Fixes:
- Use consistent “open/close” terminology in Chinese translations for gesture features
- Reorder gesture tap actions to prioritize Grand Search first