### PR TITLE
fix: Add interface to obtain all keyboard layouts

### DIFF
--- a/inputdevices1/exported_methods_auto.go
+++ b/inputdevices1/exported_methods_auto.go
@@ -44,6 +44,11 @@ func (v *Keyboard) GetExportedMethods() dbusutil.ExportedMethods {
 			OutArgs: []string{"outArg0"},
 		},
 		{
+			Name:    "AllLayoutList",
+			Fn:      v.AllLayoutList,
+			OutArgs: []string{"outArg0"},
+		},
+		{
 			Name: "Reset",
 			Fn:   v.Reset,
 		},

--- a/inputdevices1/ifc.go
+++ b/inputdevices1/ifc.go
@@ -78,6 +78,18 @@ func (kbd *Keyboard) LayoutList() (map[string]string, *dbus.Error) {
 	return result, nil
 }
 
+func (kbd *Keyboard) AllLayoutList() (map[string]string, *dbus.Error) {
+	result := kbd.layoutMap.getAll()
+	kbd.PropsMu.RLock()
+	for _, layout := range kbd.UserLayoutList {
+		layoutDetail := kbd.layoutMap[layout]
+		result[layout] = layoutDetail.Description
+	}
+	kbd.PropsMu.RUnlock()
+
+	return result, nil
+}
+
 func (kbd *Keyboard) GetLayoutDesc(layout string) (string, *dbus.Error) {
 	if len(layout) == 0 {
 		return "", nil

--- a/inputdevices1/layout_list.go
+++ b/inputdevices1/layout_list.go
@@ -114,6 +114,14 @@ func (layoutMap layoutMap) filterByLocales(locales []string) map[string]string {
 	return result
 }
 
+func (layoutMap layoutMap) getAll() map[string]string {
+	result := make(map[string]string)
+	for layout, layoutDetail := range layoutMap {
+		result[layout] = layoutDetail.Description
+	}
+	return result
+}
+
 func (v *layoutDetail) matchAnyLang(languages []string) bool {
 	for _, l := range languages {
 		for _, ll := range v.Languages {


### PR DESCRIPTION
Add interface to obtain all keyboard layouts

pms: BUG-320219

## Summary by Sourcery

Add the AllLayoutList D-Bus interface on Keyboard to fetch every available and user-added layout by introducing a layoutMap.getAll helper and registering the new method in the exported methods list

New Features:
- Introduce Keyboard.AllLayoutList D-Bus method to return the complete set of keyboard layouts, including user-specific ones

Enhancements:
- Add layoutMap.getAll helper to assemble layout descriptions
- Expose AllLayoutList in the exported D-Bus methods configuration