### PR TITLE
fix: Fix incompatible function pointer types with g_timeout_add_full on GCC 15

### DIFF
--- a/system/gesture1/core.c
+++ b/system/gesture1/core.c
@@ -296,7 +296,7 @@ valid_long_press_touch(double x, double y)
 }
 
 static gboolean
- handle_tap()
+ handle_tap(gpointer data)
 {
     g_debug("[Tap] fingers: %d", raw->fingers);
     handleGestureEvent(GESTURE_TYPE_TAP, GESTURE_DIRECTION_NONE, raw->fingers);
@@ -304,7 +304,7 @@ static gboolean
 }
 
 static void
-handle_tap_destroy()
+handle_tap_destroy(gpointer data)
 {
     if (raw && raw->tap_id) {
         raw->tap_id = 0;


### PR DESCRIPTION
GCC 15 enforces stricter type checking for function pointers, which caused compilation errors when passing `handle_tap` and `handle_tap_destroy` to `g_timeout_add_full`. These functions were declared without parameters, but must match the expected signatures:

- GSourceFunc:      gboolean (*)(gpointer)
- GDestroyNotify:   void (*)(gpointer)

Log: This patch updates the function signatures to ensure compatibility without changing their runtime behavior, as the `gpointer` parameter is unused in both functions.

## Summary by Sourcery

Bug Fixes:
- Update handle_tap and handle_tap_destroy signatures to accept a gpointer parameter to match GSourceFunc and GDestroyNotify and comply with GCC 15’s stricter type checking.