### PR TITLE
fix: reorder module dependencies in session daemon and update imports

### DIFF
--- a/bin/dde-session-daemon/daemon.go
+++ b/bin/dde-session-daemon/daemon.go
@@ -177,8 +177,8 @@ func (s *SessionDaemon) register(service *dbusutil.Service) error {
 
 func (s *SessionDaemon) initModules() {
 	part1ModuleNames := []string{
-		"display",
 		"xsettings",
+		"display",
 		"trayicon",
 		"x-event-monitor",
 	}

--- a/display1/main.go
+++ b/display1/main.go
@@ -5,15 +5,16 @@
 package display1
 
 import (
+	"os"
+	"os/exec"
+	"time"
+
 	"github.com/godbus/dbus/v5"
 	"github.com/linuxdeepin/dde-daemon/loader"
 	"github.com/linuxdeepin/go-lib/dbusutil"
 	"github.com/linuxdeepin/go-lib/gsettings"
 	"github.com/linuxdeepin/go-lib/log"
 	x "github.com/linuxdeepin/go-x11-client"
-	"os"
-	"os/exec"
-	"time"
 )
 
 var logger = log.NewLogger("daemon/display")
@@ -34,7 +35,7 @@ func NewModule(logger *log.Logger) *daemon {
 }
 
 func (*daemon) GetDependencies() []string {
-	return []string{}
+	return []string{"xsettings"}
 }
 
 var _mainBeginTime time.Time

--- a/misc/dsg-configs/org.deepin.XSettings.json
+++ b/misc/dsg-configs/org.deepin.XSettings.json
@@ -228,7 +228,7 @@
       "visibility": "private"
     },
     "scale-factor": {
-      "value": 1,
+      "value": 0,
       "serial": 0,
       "flags": [],
       "name": "Text Scale Factor",

--- a/xsettings1/daemon.go
+++ b/xsettings1/daemon.go
@@ -5,11 +5,12 @@
 package xsettings
 
 import (
+	"os"
+
 	"github.com/linuxdeepin/dde-daemon/common/scale"
 	"github.com/linuxdeepin/dde-daemon/loader"
 	"github.com/linuxdeepin/go-lib/log"
 	x "github.com/linuxdeepin/go-x11-client"
-	"os"
 )
 
 var logger = log.NewLogger("xsettings")
@@ -29,7 +30,7 @@ func NewModule(logger *log.Logger) *daemon {
 }
 
 func (*daemon) GetDependencies() []string {
-	return []string{"display"}
+	return []string{}
 }
 
 func (d *daemon) Start() error {

--- a/xsettings1/scale.go
+++ b/xsettings1/scale.go
@@ -20,8 +20,6 @@ import (
 	gio "github.com/linuxdeepin/go-gir/gio-2.0"
 	"github.com/linuxdeepin/go-lib/keyfile"
 	"github.com/linuxdeepin/go-lib/xdg/basedir"
-	x "github.com/linuxdeepin/go-x11-client"
-	"github.com/linuxdeepin/go-x11-client/ext/randr"
 )
 
 const (
@@ -181,47 +179,9 @@ func getMapFirstValueSF(m map[string]float64) float64 {
 	return 0
 }
 
-func getPrimaryScreenName(xConn *x.Conn) (string, error) {
-	rootWin := xConn.GetDefaultScreen().Root
-	getPrimaryReply, err := randr.GetOutputPrimary(xConn, rootWin).Reply(xConn)
-	if err != nil {
-		logger.Debug("Failed to get output primary:", err)
-		return getPrimaryScreenFromBus()
-	}
-	outputInfo, err := randr.GetOutputInfo(xConn, getPrimaryReply.Output,
-		x.CurrentTime).Reply(xConn)
-	if err != nil {
-		logger.Debug("Failed to get output info:", err)
-		return getPrimaryScreenFromBus()
-	}
-	return outputInfo.Name, nil
-}
-
 var (
 	_sessionConn *dbus.Conn
 )
-
-func getPrimaryScreenFromBus() (string, error) {
-	if _sessionConn == nil {
-		conn, err := dbus.SessionBus()
-		if err != nil {
-			return "", err
-		}
-		_sessionConn = conn
-	}
-
-	variant, err := _sessionConn.Object("org.deepin.dde.Display1",
-		"/org/deepin/dde/Display1").GetProperty("org.deepin.dde.Display1.Primary")
-	if err != nil {
-		return "", err
-	}
-
-	primary, ok := (variant.Value()).(string)
-	if !ok {
-		return "", fmt.Errorf("invalid primary signature: %s", variant.String())
-	}
-	return primary, nil
-}
 
 // 不发送通知版本, 设置流程会转到 setScreenScaleFactors
 func (m *XSManager) setScaleFactorWithoutNotify(scale float64) error {

--- a/xsettings1/xsettings.go
+++ b/xsettings1/xsettings.go
@@ -137,8 +137,7 @@ func (m *XSManager) getScaleFactor() float64 {
 func (m *XSManager) adjustScaleFactor(recommendedScaleFactor float64) {
 	logger.Debug("recommended scale factor:", recommendedScaleFactor)
 	var err error
-	if m.cfgHelper.GetDouble(gsKeyScaleFactor) <= 0 &&
-		recommendedScaleFactor != defaultScaleFactor {
+	if m.cfgHelper.GetDouble(gsKeyScaleFactor) <= 0 {
 		err = m.setScaleFactorWithoutNotify(recommendedScaleFactor)
 		if err != nil {
 			logger.Warning("failed to set scale factor:", err)
@@ -149,9 +148,11 @@ func (m *XSManager) adjustScaleFactor(recommendedScaleFactor float64) {
 	// migrate old configuration
 	if os.Getenv("STARTDDE_MIGRATE_SCALE_FACTOR") != "" {
 		scaleFactor := m.getScaleFactor()
-		err = m.setScreenScaleFactorsForQt(map[string]float64{"": scaleFactor})
-		if err != nil {
-			logger.Warning("failed to set scale factor for qt:", err)
+		if scaleFactor > 0 {
+			err = m.setScreenScaleFactorsForQt(map[string]float64{"": scaleFactor})
+			if err != nil {
+				logger.Warning("failed to set scale factor for qt:", err)
+			}
 		}
 
 		err = cleanUpDdeEnv()
@@ -166,7 +167,7 @@ func (m *XSManager) adjustScaleFactor(recommendedScaleFactor float64) {
 		if os.IsNotExist(err) {
 			// lightdm-deepin-greeter does not have the qt-theme.ini file yet.
 			scaleFactor := m.getScaleFactor()
-			if scaleFactor != defaultScaleFactor {
+			if scaleFactor > 0 {
 				err = m.setScreenScaleFactorsForQt(map[string]float64{"": scaleFactor})
 				if err != nil {
 					logger.Warning("failed to set scale factor for qt:", err)


### PR DESCRIPTION
- Added "display" module back to the session daemon's initialization.
- Updated dependencies for the display and xsettings modules to reflect changes in their interdependencies.
- Cleaned up unused imports in the xsettings scale file.

Log: This ensures proper module loading and resolves potential dependency issues.
pms: BUG-321001

## Summary by Sourcery

Reorder and update module dependencies between display and xsettings in the session daemon; remove obsolete imports and primary-screen helpers; refine scale-factor logic to only apply positive values.

Bug Fixes:
- Add display module back to session daemon initialization and adjust dependencies between display and xsettings to resolve load-order issues.

Enhancements:
- Remove unused X11 client imports and obsolete primary-screen retrieval functions from xsettings.
- Simplify scale-factor migration and setting logic to only apply when the value is positive.