### PR TITLE
chore: bump version to 6.1.39

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-daemon (6.1.39) unstable; urgency=medium
+
+  * fix: reorder module dependencies in session daemon and update
+    imports
+
+ -- fuleyi <fuleyi@uniontech.com>  Sat, 21 Jun 2025 15:35:24 +0800
+
 dde-daemon (6.1.38) unstable; urgency=medium
 
   * fix: update text scale factor in XSettings configuration


### PR DESCRIPTION
update changelog to 6.1.39

## Summary by Sourcery

Chores:
- Bump Debian package version to 6.1.39 in changelog