### PR TITLE
chore: prohibit the startup and auto start of some services

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -58,7 +58,14 @@ override_dh_auto_install:
 endif
 
 override_dh_installsystemd:
-	dh_installsystemd --no-start
+	# 需要开机自启动
+	dh_installsystemd --name=dde-system-daemon --no-start
+	# 不需要开机自启动
+	dh_installsystemd --name=dde-authority --no-enable --no-start
+	dh_installsystemd --name=dde-backlight-helper --no-enable --no-start
+	dh_installsystemd --name=dde-greeter-setter --no-enable --no-start
+	dh_installsystemd --name=dde-lock-service --no-enable --no-start
+	dh_installsystemd --name=deepin-grub2 --no-enable --no-start
 
 override_dh_auto_clean:
 	dh_auto_clean --


### PR DESCRIPTION
- The deepin-api-device, deepin-locale-helper, deepin-sound-theme-player can be started as needed.
- Not suitable for upgrading scenarios

Log: prohibit the startup and auto start of some services

## Summary by Sourcery

Prevent specified Deepin services from starting automatically or on installation

Chores:
- Block auto-start and immediate startup of deepin-api-device during package actions
- Block auto-start and immediate startup of deepin-locale-helper during package actions
- Block auto-start and immediate startup of deepin-sound-theme-player during package actions