### PR TITLE
fix: remove redundant own policy in Accounts1 config

### DIFF
--- a/misc/conf/org.deepin.dde.Accounts1.conf
+++ b/misc/conf/org.deepin.dde.Accounts1.conf
@@ -12,7 +12,6 @@
 
   <!-- Allow anyone to invoke methods on the interfaces -->
   <policy context="default">
-    <allow own="org.deepin.dde.Accounts1"/>
     <allow send_destination="org.deepin.dde.Accounts1"/>
 
     <allow send_destination="org.deepin.dde.Accounts1"


### PR DESCRIPTION
Removed the redundant 'allow own' policy for org.deepin.dde.Accounts1
in the D-Bus configuration file. This policy was unnecessary since
the service ownership is already managed by systemd or other service
management tools. The change simplifies the configuration while
maintaining the same security and access control levels, as the
'send_destination' policy remains intact to allow method invocations.

fix: 移除 Accounts1 配置中冗余的 own 策略

从 D-Bus 配置文件中移除了 org.deepin.dde.Accounts1 冗余的 'allow own' 策
略。该策略是多余的，因为服务所有权已由 systemd 或其他服务管理工具处理。
此更改简化了配置，同时保持了相同的安全和访问控制级别，因为允许方法调用的
'send_destination' 策略仍然保留。

## Summary by Sourcery

Enhancements:
- Remove redundant 'allow own' policy from org.deepin.dde.Accounts1 configuration to streamline access control.