### PR TITLE
Revert "chore: prohibit the startup and auto start of some services"

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -60,14 +60,7 @@ override_dh_auto_install:
 endif
 
 override_dh_installsystemd:
-	# 需要开机自启动
-	dh_installsystemd --name=dde-system-daemon --no-start
-	# 不需要开机自启动
-	dh_installsystemd --name=dde-authority --no-enable --no-start
-	dh_installsystemd --name=dde-backlight-helper --no-enable --no-start
-	dh_installsystemd --name=dde-greeter-setter --no-enable --no-start
-	dh_installsystemd --name=dde-lock-service --no-enable --no-start
-	dh_installsystemd --name=deepin-grub2 --no-enable --no-start
+	dh_installsystemd --no-start
 
 override_dh_auto_clean:
 	dh_auto_clean --


### PR DESCRIPTION
This reverts commit d6a1b20cb82a94d2df1a04e37a8a34e1bcd5dd89. This commit will cause the dbus service to fail to start

## Summary by Sourcery

Bug Fixes:
- Fix dbus service startup by restoring original service auto-start behavior