### PR TITLE
fix: add security hardening flags and optimize build settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,8 +113,6 @@ BINARIES =  \
 
 LANGUAGES = $(basename $(notdir $(wildcard misc/po/*.po)))
 
-CFLAGS = -W -Wall -fPIC -fstack-protector-all -z relro -z noexecstack -z now -pie
-
 all: build
 
 prepare:

--- a/debian/rules
+++ b/debian/rules
@@ -5,6 +5,8 @@ include /usr/share/dpkg/architecture.mk
 export GOCACHE = /tmp/gocache
 export GOPATH = /usr/share/gocode
 export GO111MODULE=off
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+export CFLAGS = -W -Wall -fPIC -fstack-protector-all -z relro -z noexecstack -z now -pie
 
 SYSTYPE=Desktop
 SYSTYPE=$(shell cat /etc/deepin-version | grep Type= | awk -F'=' '{print $$2}')


### PR DESCRIPTION
add security hardening flags and optimize build settings

Log:
pms: BUG-321339

## Summary by Sourcery

Consolidate security hardening flags and streamline compiler settings by moving CFLAGS out of the Makefile into the Debian packaging script.

Enhancements:
- Remove hard-coded CFLAGS from the top-level Makefile
- Integrate security hardening flags into debian/rules
- Optimize build settings in the Debian packaging workflow

Build:
- Clean up Makefile by relocating build flags to packaging script