### PR TITLE
feat: root进程需要判断调用者时，使用TrustedExe替换Exe

### DIFF
--- a/accounts1/user.go
+++ b/accounts1/user.go
@@ -283,7 +283,7 @@ func (u *User) getSenderDBus(sender dbus.Sender) string {
 		return ""
 	}
 	proc := procfs.Process(pid)
-	exe, err := proc.Exe()
+	exe, err := proc.TrustedExe()
 	if err != nil {
 		logger.Warning(err)
 		return ""
@@ -530,7 +530,7 @@ func (u *User) checkIsControlCenter(sender dbus.Sender) bool {
 	}
 
 	p := procfs.Process(pid)
-	exe, err := p.Exe()
+	exe, err := p.TrustedExe()
 	if err != nil {
 		logger.Warning(err)
 		return false
@@ -551,7 +551,7 @@ func (u *User) checkIsDeepinDaemon(sender dbus.Sender) bool {
 	}
 
 	p := procfs.Process(pid)
-	exe, err := p.Exe()
+	exe, err := p.TrustedExe()
 	if err != nil {
 		logger.Warning(err)
 		return false

--- a/accounts1/user_chpwd_union_id.go
+++ b/accounts1/user_chpwd_union_id.go
@@ -116,7 +116,7 @@ func newCaller(service *dbusutil.Service, sender dbus.Sender) (ret *caller, err 
 		return
 	}
 
-	exe, err := proc.Exe()
+	exe, err := proc.TrustedExe()
 	if err != nil {
 		err = fmt.Errorf("get sender exe error: %v", err)
 		return

--- a/bin/dde-system-daemon/tty.go
+++ b/bin/dde-system-daemon/tty.go
@@ -111,7 +111,7 @@ func (d *Daemon) SetLogindTTY(sender dbus.Sender, NAutoVTs int, resetCustom bool
 			return dbusutil.ToError(err)
 		}
 		p := procfs.Process(pid)
-		cmd, err = p.Exe()
+		cmd, err = p.TrustedExe()
 		if err != nil {
 			// 当调用者在使用过程中发生了更新,则在获取该进程的exe时,会出现lstat xxx (deleted)此类的error,如果发生的是覆盖,则该路径依旧存在,因此增加以下判断
 			pErr, ok := err.(*os.PathError)

--- a/bin/dde-system-daemon/virtual.go
+++ b/bin/dde-system-daemon/virtual.go
@@ -82,7 +82,7 @@ func getValidSupData(supApps []string) []string {
 // 获取App二进制名称，将exe和cmdline拼接成一个string
 func getActivePidInfo(pid uint32) (execPath string, err error) {
 	value := procfs.Process(pid)
-	execPath, err = value.Exe()
+	execPath, err = value.TrustedExe()
 	if err != nil {
 		logger.Warning(err)
 		return "", err

--- a/grub2/grub2.go
+++ b/grub2/grub2.go
@@ -623,7 +623,7 @@ func checkInvokePermission(service *dbusutil.Service, sender dbus.Sender) error 
 			return err
 		}
 		p := procfs.Process(pid)
-		cmd, err := p.Exe()
+		cmd, err := p.TrustedExe()
 		if err != nil {
 			// 当调用者在使用过程中发生了更新,则在获取该进程的exe时,会出现lstat xxx (deleted)此类的error,如果发生的是覆盖,则该路径依旧存在,因此增加以下判断
 			pErr, ok := err.(*os.PathError)

--- a/system/display1/displaycfg.go
+++ b/system/display1/displaycfg.go
@@ -276,7 +276,7 @@ func (d *Display) doDetectSupportWayland(sender dbus.Sender) (bool, error) {
 			logger.Warning(err)
 			return false, err
 		}
-		execPath, err := p.Exe()
+		execPath, err := p.TrustedExe()
 		if err != nil {
 			logger.Warning(err)
 			return false, err

--- a/system/scheduler/scheduler.go
+++ b/system/scheduler/scheduler.go
@@ -54,7 +54,7 @@ func setProcessPriority(cfg *config, pid int) {
 
 // 获取进程可执行文件路径
 func getProcessExe(pid int) (string, error) {
-	exe, err := procfs.Process(pid).Exe()
+	exe, err := procfs.Process(pid).TrustedExe()
 	return exe, err
 }
 

--- a/system/uadp1/manager.go
+++ b/system/uadp1/manager.go
@@ -162,7 +162,7 @@ func (m *Manager) getExecPath(sender dbus.Sender) (string, error) {
 		return "", err
 	}
 
-	execPath, err := procfs.Process(pid).Exe()
+	execPath, err := procfs.Process(pid).TrustedExe()
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
root进程需要判断调用者时，使用TrustedExe替换Exe

Log: root进程需要判断调用者时，使用TrustedExe替换Exe
pms: TASK-369021

## Summary by Sourcery

Enhancements:
- Replace procfs.Process.Exe() calls with TrustedExe() in user, daemon, grub2, displaycfg, scheduler, and uadp1 modules to improve caller verification.