### PR TITLE
feat: add GenLocale method and improve locale state handling

### DIFF
--- a/langselector1/exported_methods_auto.go
+++ b/langselector1/exported_methods_auto.go
@@ -19,6 +19,11 @@ func (v *LangSelector) GetExportedMethods() dbusutil.ExportedMethods {
 			InArgs: []string{"locale"},
 		},
 		{
+			Name:   "GenLocale",
+			Fn:     v.GenLocale,
+			InArgs: []string{"locale"},
+		},
+		{
 			Name:    "GetLanguageSupportPackages",
 			Fn:      v.GetLanguageSupportPackages,
 			InArgs:  []string{"locale"},

--- a/langselector1/locale_ifc.go
+++ b/langselector1/locale_ifc.go
@@ -40,7 +40,7 @@ func (lang *LangSelector) SetLocale(locale string) *dbus.Error {
 
 	lang.PropsMu.Lock()
 	defer lang.PropsMu.Unlock()
-	if lang.LocaleState == LocaleStateChanging || lang.CurrentLocale == locale {
+	if (lang.LocaleState&LocaleStateChanging != 0) || lang.CurrentLocale == locale {
 		return nil
 	}
 	_ = lang.addLocale(locale)
@@ -113,4 +113,17 @@ func (lang *LangSelector) DeleteLocale(locale string) *dbus.Error {
 
 	err := lang.deleteLocale(locale)
 	return dbusutil.ToError(err)
+}
+
+func (lang *LangSelector) GenLocale(locale string) *dbus.Error {
+	lang.service.DelayAutoQuit()
+
+	lang.PropsMu.Lock()
+	defer lang.PropsMu.Unlock()
+	if lang.LocaleState&LocaleStateChanging != 0 {
+		return nil
+	}
+	logger.Debugf("genLocale %q", locale)
+	go lang.genLocale(locale)
+	return nil
 }


### PR DESCRIPTION
1. Added new GenLocale method to allow generating locale without changing system language
2. Improved locale state tracking with new flags LocaleStateSetLang and LocaleStateGenLocale
3. Refactored generateLocale to doGenerateLocale for better code reuse
4. Enhanced state checking logic in SetLocale to use bitwise operations
5. Added proper state management during locale generation operations

The changes allow more granular control over locale operations and better state tracking when performing different types of locale changes. The new GenLocale method provides a way to generate locale files without changing the system language, which can be useful for system maintenance or preparation.

feat: 添加 GenLocale 方法并改进区域设置状态处理

1. 新增 GenLocale 方法允许在不更改系统语言的情况下生成区域设置
2. 使用 LocaleStateSetLang 和 LocaleStateGenLocale 标志改进区域设置状态 跟踪
3. 重构 generateLocale 为 doGenerateLocale 以提高代码复用性
4. 在 SetLocale 中增强状态检查逻辑以使用位运算
5. 添加在区域设置生成操作期间的正确状态管理

这些变更允许对区域设置操作进行更精细的控制，并在执行不同类型的区域设置更
改时提供更好的状态跟踪。新的 GenLocale 方法提供了一种在不更改系统语言的
情况下生成区域设置文件的方式，这对于系统维护或准备工作非常有用。

pms: TASK-378739

## Summary by Sourcery

Add a GenLocale API for standalone locale generation and enhance locale state handling with bitwise flags, shared logic refactoring, and robust locking.

New Features:
- Introduce GenLocale method to generate locale files without altering system language

Enhancements:
- Add LocaleStateSetLang and LocaleStateGenLocale flags for finer-grained locale operation tracking
- Rename generateLocale to doGenerateLocale and reuse it in both SetLocale and GenLocale
- Use bitwise checks on LocaleState in SetLocale to determine ongoing operations
- Improve state transitions and locking in setLocale and genLocale to ensure accurate state updates
- Register the new GenLocale method in the DBus exported methods list