### PR TITLE
fix: Fix the initial value of Bluetooth status

### DIFF
--- a/bluetooth1/bluetooth.go
+++ b/bluetooth1/bluetooth.go
@@ -447,6 +447,7 @@ func (b *Bluetooth) init() {
 	}
 	b.settings = gio.NewSettings(bluetoothSchema)
 	b.DisplaySwitch.Bind(b.settings, displaySwitch)
+	b.DisplaySwitch.Set(false)
 
 	b.agent.init()
 	b.obexAgent.init()


### PR DESCRIPTION
Fix the initial value of Bluetooth status

Log: Fix the initial value of Bluetooth status
pms: BUG-283349

## Summary by Sourcery

Bug Fixes:
- Set DisplaySwitch to false on initialization to fix incorrect initial Bluetooth status