### PR TITLE
fix: add nil checks for audio sink/source updates

### DIFF
--- a/audio1/audio.go
+++ b/audio1/audio.go
@@ -944,7 +944,7 @@ func (a *Audio) refreshDefaultSinkSource() {
 		}
 	}
 
-	if a.defaultSource != nil && a.defaultSource.Name != defaultSource {
+	if a.defaultSource == nil || a.defaultSource.Name != defaultSource {
 		logger.Debugf("update default source to %s", defaultSource)
 		a.updateDefaultSource(defaultSource)
 	} else {
@@ -1655,7 +1655,7 @@ func (a *Audio) refreshBluetoothOpts() {
 }
 
 func (a *Audio) updateDefaultSink(sinkName string) {
-	if a.defaultSink.Name == sinkName {
+	if a.defaultSink != nil && a.defaultSink.Name == sinkName {
 		logger.Warningf("defaultSink %s is the same as sinkName %s", a.defaultSink.Name, sinkName)
 		return
 	}
@@ -1759,7 +1759,7 @@ func (a *Audio) updateSinks(index uint32) (sink *Sink) {
 }
 
 func (a *Audio) updateDefaultSource(sourceName string) {
-	if a.defaultSource.Name == sourceName {
+	if a.defaultSource != nil && a.defaultSource.Name == sourceName {
 		logger.Warningf("defaultSource %s is the same as sourceName %s", a.defaultSource.Name, sourceName)
 		return
 	}


### PR DESCRIPTION
1. Added nil checks before accessing defaultSink and defaultSource properties
2. Prevents potential nil pointer dereference crashes when these properties are unset
3. Maintains existing warning log behavior but only when objects exist
4. Improves stability when audio devices are being initialized or changed

fix: 为音频接收器/源更新添加空值检查

1. 在访问 defaultSink 和 defaultSource 属性前添加了空值检查
2. 防止当这些属性未设置时可能出现的空指针解引用崩溃
3. 保持现有的警告日志行为，但仅在对象存在时触发
4. 提高音频设备初始化或更改时的稳定性

pms: BUG-325379

## Summary by Sourcery

Add nil checks to defaultSink and defaultSource updates to prevent crashes, maintain existing warnings conditionally, and enhance stability during audio device setup and changes

Bug Fixes:
- Add nil checks before accessing defaultSink and defaultSource to prevent nil pointer dereference crashes when these properties are unset

Enhancements:
- Retain warning logs only when the sink or source object exists
- Improve stability during audio device initialization and changes