### PR TITLE
chore: bump version to 6.1.45

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-daemon (6.1.45) unstable; urgency=medium
+
+  * fix: add nil checks for audio sink/source updates
+  * fix: The scheduled shutdown during holidays takes effect
+
+ -- zhangkun <zhangkun2@uniontech.com>  Tue, 22 Jul 2025 11:26:59 +0800
+
 dde-daemon (6.1.44) unstable; urgency=medium
 
   * fix: fix some modules loaded failed


### PR DESCRIPTION
update changelog to 6.1.45

## Summary by Sourcery

Build:
- Update Debian changelog to bump version to 6.1.45