### PR TITLE
fix: QuickLogin enable state only response to dconfig changes

### DIFF
--- a/accounts1/handle_event.go
+++ b/accounts1/handle_event.go
@@ -210,11 +210,6 @@ func (m *Manager) handleFileShadowChanged() {
 }
 
 func (m *Manager) handleDMConfigChanged() {
-	quickLoginEnabled, err := users.GetLightDMQuickLoginEnabled()
-	if err != nil {
-		logger.Warning("GetLightDMQuickLoginEnabled failed, err:", err)
-	}
-	m.setPropQuickLoginEnabled(quickLoginEnabled)
 	for _, u := range m.usersMap {
 		u.updatePropAutomaticLogin()
 		u.updatePropQuickLogin()

--- a/accounts1/manager.go
+++ b/accounts1/manager.go
@@ -744,11 +744,6 @@ func (m *Manager) initDConfigGreeterWatch() error {
 	if err != nil {
 		logger.Warning("getDConfigQuickLoginEnabled failed, err:", err)
 	} else {
-		// 从 dconfig 获取值，然后同步到 /etc/lightdm/lightdm.conf 配置文件中。
-		err = users.SetLightDMQuickLoginEnabled(enabled)
-		if err != nil {
-			logger.Warning("SetLightDMQuickLoginEnabled failed, error:", err)
-		}
 		m.setPropQuickLoginEnabled(enabled)
 	}
 
@@ -763,12 +758,16 @@ func (m *Manager) initDConfigGreeterWatch() error {
 		if err != nil {
 			logger.Warning("getDConfigQuickLoginEnabled failed, err:", err)
 			return
+		} else {
+			m.setPropQuickLoginEnabled(enabled)
 		}
 
-		logger.Debug("handle dconfig quick login enabled changed", enabled)
-		err = users.SetLightDMQuickLoginEnabled(enabled)
-		if err != nil {
-			logger.Warning("SetLightDMQuickLoginEnabled failed, error:", err)
+		if !enabled {
+			logger.Debug("handle dconfig quick login enabled changed", enabled)
+			err = users.SetLightDMQuickLoginEnabled(enabled)
+			if err != nil {
+				logger.Warning("SetLightDMQuickLoginEnabled failed, error:", err)
+			}
 		}
 	})
 	return nil

--- a/accounts1/user.go
+++ b/accounts1/user.go
@@ -1035,15 +1035,15 @@ func (u *User) setQuickLogin(enabled bool) *dbus.Error {
 		return nil
 	}
 
-	// 先打开总开关
+	// 先打开lightdm的quicklogin-enabled
 	if enabled {
-		accountsManager := getAccountsManager()
-		if accountsManager == nil {
-			return dbusutil.ToError(errors.New("get accounts manager failed"))
-		}
-		err := accountsManager.setDConfigQuickLoginEnabled(true)
+		mainEnable, err := users.GetLightDMQuickLoginEnabled()
 		if err != nil {
-			return dbusutil.ToError(fmt.Errorf("set greeter dconfig enableQuickLogin failed: %v", err))
+			return dbusutil.ToError(errors.New("get lightdm quick login failed"))
+		}
+
+		if !mainEnable {
+			users.SetLightDMQuickLoginEnabled(enabled)
 		}
 	}
 


### PR DESCRIPTION
when user enable quicklogin, also need enable quicklogin_enable for lightdm config

Log: as title
Pms: BUG-325117

## Summary by Sourcery

Synchronize QuickLogin state with LightDM configuration and clean up redundant DMConfigChanged handling

Bug Fixes:
- Ensure enabling QuickLogin also updates the LightDM quicklogin_enable setting
- Improve error handling for LightDM quick login state retrieval

Enhancements:
- Remove redundant QuickLogin state update in handleDMConfigChanged event handler