### PR TITLE
fix: correct flags format in system config

### DIFF
--- a/misc/dsg-configs/org.deepin.dde.daemon.system.json
+++ b/misc/dsg-configs/org.deepin.dde.daemon.system.json
@@ -5,7 +5,7 @@
     "customWallpaperMaximum": {
       "value": 20,
       "serial":0,
-      "flags" : [["global"]],
+      "flags" : ["global"],
       "name": "customWallpaperMaximum",
       "name[zh_CN]": "用户壁纸最大保存数量",
       "description": "Maximum Custom Wallpaper Limit",


### PR DESCRIPTION
The change fixes the format of the "flags" field in the system configuration JSON file. Previously it was incorrectly nested as a double array [["global"]], which has been simplified to a single array ["global"]. This aligns with the expected format for configuration flags and ensures proper parsing by the system configuration handler.

fix: 修正系统配置中 flags 的格式

该更改修复了系统配置 JSON 文件中 "flags" 字段的格式。之前错误地使用了双
重数组 [["global"]] 的嵌套格式，现已简化为单层数组 ["global"]。这符合配
置标志的预期格式，确保系统配置处理器能够正确解析。