### PR TITLE
fix: Double click setting does not take effect

### DIFF
--- a/inputdevices1/manager.go
+++ b/inputdevices1/manager.go
@@ -198,6 +198,13 @@ Shift_R,Down,Shift_R|Button5
 }
 
 func (m *Manager) init() {
+	// 初始化dconfig并同步配置
+	if err := initDConfig(); err == nil {
+		syncFromDConfig()
+	} else {
+		logger.Warning("dconfig init failed, using default settings")
+	}
+
 	m.kbd.init()
 	m.kbd.handleGSettings()
 
@@ -209,6 +216,10 @@ func (m *Manager) init() {
 		m.tpad.handleGSettings()
 		m.mouse.init()
 		m.mouse.handleGSettings()
+
+		// 设置全局mouse引用，用于属性同步
+		SetGlobalMouse(m.mouse)
+
 		m.trackPoint.init()
 		m.trackPoint.handleGSettings()
 	}

--- a/inputdevices1/utils.go
+++ b/inputdevices1/utils.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"sync"
 
+	"github.com/linuxdeepin/dde-daemon/common/dconfig"
 	"github.com/linuxdeepin/go-gir/gio-2.0"
 )
 
@@ -20,18 +21,130 @@ const (
 )
 
 var (
-	xsLocker  sync.Mutex
-	xsSetting = gio.NewSettings(xsettingsSchema)
+	xsLocker           sync.Mutex
+	xsSetting          = gio.NewSettings(xsettingsSchema)
+	dconf              *dconfig.DConfig
+	watcherInitialized bool   // 防止重复初始化监听器
+	globalMouse        *Mouse // 全局mouse引用，用于属性同步
 )
 
-func xsSetInt32(prop string, value int32) {
-	xsLocker.Lock()
-	if value == xsSetting.GetInt(prop) {
-		xsLocker.Unlock()
+// 初始化dconfig
+func initDConfig() error {
+	var err error
+	dconf, err = dconfig.NewDConfig("org.deepin.dde.daemon", "org.deepin.XSettings", "")
+	if err != nil {
+		logger.Warning("init dconfig failed:", err)
+		return err
+	}
+
+	if !watcherInitialized {
+		watchDConfigChanges()
+		watcherInitialized = true
+		logger.Debug("dconfig watcher initialized")
+	}
+
+	return nil
+}
+
+// 监听dconfig变化
+func watchDConfigChanges() {
+	if dconf == nil {
 		return
 	}
+
+	keys := []string{xsPropBlinkTimeut, xsPropDoubleClick, xsPropDragThres}
+	for _, key := range keys {
+		currentKey := key
+		dconf.ConnectConfigChanged(currentKey, func(value interface{}) {
+			var intValue int32
+			switch v := value.(type) {
+			case int:
+				intValue = int32(v)
+			case int32:
+				intValue = v
+			case int64:
+				intValue = int32(v)
+			default:
+				logger.Warning("unexpected dconfig value type:", currentKey, value)
+				return
+			}
+
+			logger.Debugf("dconfig changed: %s = %d", currentKey, intValue)
+
+			xsLocker.Lock()
+			xsSetting.SetInt(currentKey, intValue)
+			xsLocker.Unlock()
+
+			notifyMouseModuleUpdate(currentKey, intValue)
+		})
+	}
+}
+
+// 设置全局mouse引用
+func SetGlobalMouse(mouse *Mouse) {
+	globalMouse = mouse
+}
+
+// dconfig变化时通知mouse模块更新dbus属性
+func notifyMouseModuleUpdate(key string, value int32) {
+	if globalMouse == nil {
+		return
+	}
+
+	switch key {
+	case xsPropDoubleClick:
+		globalMouse.setting.SetInt("double-click", value)
+	case xsPropDragThres:
+		globalMouse.setting.SetInt("drag-threshold", value)
+	}
+}
+
+// 启动时从dconfig同步到xsettings
+func syncFromDConfig() {
+	if dconf == nil {
+		return
+	}
+
+	logger.Debug("syncing from dconfig to xsettings")
+	keys := []string{xsPropBlinkTimeut, xsPropDoubleClick, xsPropDragThres}
+	for _, key := range keys {
+		if value, err := dconf.GetValueInt(key); err == nil && value > 0 {
+			logger.Debugf("sync %s from dconfig: %d", key, value)
+			xsLocker.Lock()
+			xsSetting.SetInt(key, int32(value))
+			xsLocker.Unlock()
+		}
+	}
+}
+
+// 统一的xsettings设置函数（以dconfig为准，并同步回dconfig）
+func xsSetInt32(prop string, value int32) {
+	xsLocker.Lock()
+	defer xsLocker.Unlock()
+
+	// 以dconfig为准：先检查dconfig的值
+	if dconf != nil {
+		if dconfigValue, err := dconf.GetValueInt(prop); err == nil && dconfigValue > 0 {
+			if value != int32(dconfigValue) {
+				logger.Debugf("using dconfig value for %s: %d (requested: %d)", prop, dconfigValue, value)
+			}
+			value = int32(dconfigValue)
+		}
+	}
+
+	if value == xsSetting.GetInt(prop) {
+		return
+	}
+
+	logger.Debugf("set xsettings %s to %d", prop, value)
 	xsSetting.SetInt(prop, value)
-	xsLocker.Unlock()
+
+	// 同步到dconfig
+	if dconf != nil {
+		if err := dconf.SetValue(prop, int(value)); err != nil {
+			logger.Warning("sync to dconfig failed:", err)
+		}
+	}
 }
 
 func addItemToList(item string, list []string) ([]string, bool) {


### PR DESCRIPTION
integrate dconfig for xsettings management

1. Added dconfig initialization and synchronization in Manager init
2. Implemented dconfig watcher for xsettings properties (blink-timeout, double-click, drag-threshold)
3. Added global mouse reference for property synchronization
4. Modified xsSetInt32 to use dconfig as source of truth
5. Added bidirectional sync between dconfig and xsettings
6. Added proper error handling and logging throughout

Log: Added dconfig support for xsettings management with mouse property synchronization

Influence:
1. Test xsettings changes through both dconfig and direct API calls
2. Verify property synchronization between dconfig and xsettings
3. Check mouse properties update when dconfig changes
4. Test with missing/invalid dconfig values
5. Verify proper logging of configuration changes
6. Test concurrent access to xsettings properties

feat: 为xsettings管理集成dconfig支持

1. 在Manager初始化中添加dconfig初始化和同步
2. 实现xsettings属性(dconfig监听器(闪烁超时、双击、拖动阈值)
3. 添加全局鼠标引用用于属性同步
4. 修改xsSetInt32以dconfig为权威数据源
5. 添加dconfig与xsettings之间的双向同步
6. 在整个过程中添加适当的错误处理和日志记录

Log: 新增xsettings管理的dconfig支持及鼠标属性同步功能

Influence:
1. 测试通过dconfig和直接API调用修改xsettings
2. 验证dconfig与xsettings之间的属性同步
3. 检查dconfig变更时鼠标属性是否更新
4. 测试缺失/无效dconfig值的情况
5. 验证配置变更的正确日志记录
6. 测试对xsettings属性的并发访问

PMS: BUG-313331

## Summary by Sourcery

Integrate dconfig support for xsettings management with bidirectional synchronization and propagate mouse-related setting changes

New Features:
- Initialize and synchronize dconfig in Manager init for blink-timeout, double-click, and drag-threshold
- Add a watcher to propagate dconfig changes to xsettings and notify the mouse module
- Perform initial sync from dconfig to xsettings on startup
- Introduce SetGlobalMouse and notifyMouseModuleUpdate for mouse property updates

Bug Fixes:
- Ensure double-click and drag-threshold settings take effect consistently through dconfig synchronization

Enhancements:
- Modify xsSetInt32 to use dconfig as the source of truth and sync changes back to dconfig
- Improve error handling and logging for all dconfig operations