### PR TITLE
fix: update initramfs for all kernels instead of current

### DIFF
--- a/bin/dde-system-daemon/plymouth.go
+++ b/bin/dde-system-daemon/plymouth.go
@@ -171,8 +171,7 @@ func (d *Daemon) setPlymouthTheme(themeName string) error {
 	if err != nil {
 		return fmt.Errorf("failed to get kernel, err: %v", err)
 	}
-	out, err = exec.Command("update-initramfs",
-		"-u", "-k", string(bytes.TrimSpace(kernel))).CombinedOutput()
+	out, err = exec.Command("update-initramfs", "-u", "-k", "all").CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to update initramfs: %s, err: %v", string(out), err)
 	}


### PR DESCRIPTION
Changed the plymouth theme update command to apply to all kernels (-k all) rather than just the currently running kernel. This ensures theme changes are properly applied across all installed kernels, preventing potential inconsistencies when booting with different kernel versions.

The previous implementation used the currently running kernel version which could miss updates for other installed kernels. This change makes the theme update more comprehensive and reliable.

Influence:
1. Test plymouth theme changes with multiple kernel versions installed
2. Verify theme consistency after updates across different kernels
3. Check system boot process with different kernel versions

fix: 更新所有内核的initramfs而非仅当前内核

将plymouth主题更新命令修改为应用于所有内核(-k all)，而不仅仅是当前运行的
内核。这确保主题更改能正确应用于所有已安装的内核，防止在使用不同内核版本
启动时出现不一致的情况。

之前的实现仅使用当前运行的内核版本，可能会错过其他已安装内核的更新。此更
改使主题更新更加全面可靠。

Influence:
1. 测试在安装多个内核版本时的plymouth主题更改
2. 验证不同内核版本更新后的主题一致性
3. 检查使用不同内核版本的系统启动过程

PMS: BUG-325645

## Summary by Sourcery

Bug Fixes:
- Update-initramfs command now applies to all installed kernels instead of only the current one