### PR TITLE
fix: remove redundant kernel version check in plymouth theme setup

### DIFF
--- a/bin/dde-system-daemon/plymouth.go
+++ b/bin/dde-system-daemon/plymouth.go
@@ -167,10 +167,6 @@ func (d *Daemon) setPlymouthTheme(themeName string) error {
 		return fmt.Errorf("failed to set plymouth theme: %s, err: %v", string(out), err)
 	}
 
-	kernel, err := exec.Command("uname", "-r").CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to get kernel, err: %v", err)
-	}
 	out, err = exec.Command("update-initramfs", "-u", "-k", "all").CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to update initramfs: %s, err: %v", string(out), err)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-daemon (6.1.47) unstable; urgency=medium
+
+  * fix: remove redundant kernel version check in plymouth theme setup
+
+  -- lvpeilong <lvpeilong@uniontech.com>  Fri, 01 Aug 2025 10:00:00 +0800
+
 dde-daemon (6.1.46) unstable; urgency=medium
 
   * fix: update initramfs for all kernels instead of current


### PR DESCRIPTION
The change removes an unnecessary kernel version check when setting the Plymouth theme. The check was redundant because the subsequent update- initramfs command already handles all kernel versions with the "-k all" parameter. This simplifies the code and removes an unnecessary system call.

Influence:
1. Verify Plymouth theme changes still work correctly
2. Check that initramfs updates properly for all kernel versions
3. Test system boot process with different themes

fix: 移除Plymouth主题设置中多余的内核版本检查

该变更移除了设置Plymouth主题时不必要的内核版本检查。由于后续的update-
initramfs命令已经通过"-k all"参数处理所有内核版本，这个检查是多余的。这
简化了代码并移除了不必要的系统调用。

Influence:
1. 验证Plymouth主题更改仍能正常工作
2. 检查initramfs是否能为所有内核版本正确更新
3. 使用不同主题测试系统启动过程

## Summary by Sourcery

Enhancements:
- Remove exec.Command("uname", "-r") call from setPlymouthTheme to eliminate an unnecessary system call and redundant version check