### PR TITLE
chore: update go.mod and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ themes/themes
 network1/network
 accounts1/accounts
 audio1/audio
+audio1/testdata/
 datetime/datetime
 deepin-daemon/deepin-daemon
 desktop-toggle/desktop-toggle
@@ -38,6 +39,7 @@ bin/dde-system-daemon/dde-system-daemon
 bin/dde-dock-daemon/dde-dock-daemon
 bin/dde-session-initializer/dde-session-initializer
 !launcher/testdata/.config/launcher/*
+system/uadp1/testdata/
 
 out/
 gopath/

--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/godbus/dbus/v5 v5.1.0
 	github.com/gosexy/gettext v0.0.0-20160830220431-74466a0a0c4a
 	github.com/jouyouyun/hardware v0.1.8
-	github.com/linuxdeepin/dde-api v0.0.0-20250722064252-56fe3754c77d
-	github.com/linuxdeepin/go-dbus-factory v0.0.0-20250619030320-fc75fd4537a8
+	github.com/linuxdeepin/dde-api v0.0.0-20250731115329-a7fbf5c1b7e1
+	github.com/linuxdeepin/go-dbus-factory v0.0.0-20250731053001-954f97feae8c
 	github.com/linuxdeepin/go-gir v0.0.0-20230710064042-bd15f0549c87
 	github.com/linuxdeepin/go-lib v0.0.0-20250715130109-a4b5968b93a3
 	github.com/linuxdeepin/go-x11-client v0.0.0-20240415051504-c8e43d028ff9

--- a/go.sum
+++ b/go.sum
@@ -32,10 +32,10 @@ github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/linuxdeepin/dde-api v0.0.0-20250722064252-56fe3754c77d h1:THsjivv6EZ/NmlN+jlsjlzNZQ0kj12A9lV3lc03Yqdg=
-github.com/linuxdeepin/dde-api v0.0.0-20250722064252-56fe3754c77d/go.mod h1:Ms92CRDOjzkDmX1x0x6+b0vQSYHJ7Ab9jQMY2JYWiio=
-github.com/linuxdeepin/go-dbus-factory v0.0.0-20250619030320-fc75fd4537a8 h1:3PxyFrMZwlS3DJ9jSNheexu1QgsuOOgF9knJ1B++t3E=
-github.com/linuxdeepin/go-dbus-factory v0.0.0-20250619030320-fc75fd4537a8/go.mod h1:iIlTR50SA8MJ9ORPyMOpKWMF4g+AUorbER5AX0RD9Jk=
+github.com/linuxdeepin/dde-api v0.0.0-20250731115329-a7fbf5c1b7e1 h1:PenyzCfepHVWU3XsHhquGxiTNhAnLFz4+iFR6da2jRI=
+github.com/linuxdeepin/dde-api v0.0.0-20250731115329-a7fbf5c1b7e1/go.mod h1:Ms92CRDOjzkDmX1x0x6+b0vQSYHJ7Ab9jQMY2JYWiio=
+github.com/linuxdeepin/go-dbus-factory v0.0.0-20250731053001-954f97feae8c h1:NBC8KtCXoxs8DNHhEpUz1RlqA9mOn9yXTe5HbVPZ8TI=
+github.com/linuxdeepin/go-dbus-factory v0.0.0-20250731053001-954f97feae8c/go.mod h1:iIlTR50SA8MJ9ORPyMOpKWMF4g+AUorbER5AX0RD9Jk=
 github.com/linuxdeepin/go-gir v0.0.0-20230331033513-a8d7a9e89f9b/go.mod h1:a0tox5vepTQu5iO6rdKc4diGT+fkyXZlRROM8ULEvaI=
 github.com/linuxdeepin/go-gir v0.0.0-20230710064042-bd15f0549c87 h1:ga3ioifiDJJDfWv0ZJPX8e//fQNIzINXxJb4BMQofOo=
 github.com/linuxdeepin/go-gir v0.0.0-20230710064042-bd15f0549c87/go.mod h1:a0tox5vepTQu5iO6rdKc4diGT+fkyXZlRROM8ULEvaI=


### PR DESCRIPTION
update go.mod and gitignore

## Summary by Sourcery

Bump key LinuxDeepin dependencies and refresh project metadata

Enhancements:
- Update github.com/linuxdeepin/dde-api to v0.0.0-20250731115329-a7fbf5c1b7e1 and github.com/linuxdeepin/go-dbus-factory to v0.0.0-20250731053001-954f97feae8c in go.mod

Chores:
- Regenerate go.sum after dependency updates
- Refresh .gitignore file