### PR TITLE
fix: replace TrustedExe with Exe due to systemd namespace changes

### DIFF
--- a/accounts1/user.go
+++ b/accounts1/user.go
@@ -283,7 +283,7 @@ func (u *User) getSenderDBus(sender dbus.Sender) string {
 		return ""
 	}
 	proc := procfs.Process(pid)
-	exe, err := proc.TrustedExe()
+	exe, err := proc.Exe()
 	if err != nil {
 		logger.Warning(err)
 		return ""
@@ -530,7 +530,7 @@ func (u *User) checkIsControlCenter(sender dbus.Sender) bool {
 	}
 
 	p := procfs.Process(pid)
-	exe, err := p.TrustedExe()
+	exe, err := p.Exe()
 	if err != nil {
 		logger.Warning(err)
 		return false
@@ -551,7 +551,7 @@ func (u *User) checkIsDeepinDaemon(sender dbus.Sender) bool {
 	}
 
 	p := procfs.Process(pid)
-	exe, err := p.TrustedExe()
+	exe, err := p.Exe()
 	if err != nil {
 		logger.Warning(err)
 		return false

--- a/accounts1/user_chpwd_union_id.go
+++ b/accounts1/user_chpwd_union_id.go
@@ -116,7 +116,7 @@ func newCaller(service *dbusutil.Service, sender dbus.Sender) (ret *caller, err 
 		return
 	}
 
-	exe, err := proc.TrustedExe()
+	exe, err := proc.Exe()
 	if err != nil {
 		err = fmt.Errorf("get sender exe error: %v", err)
 		return

--- a/bin/dde-system-daemon/tty.go
+++ b/bin/dde-system-daemon/tty.go
@@ -111,7 +111,7 @@ func (d *Daemon) SetLogindTTY(sender dbus.Sender, NAutoVTs int, resetCustom bool
 			return dbusutil.ToError(err)
 		}
 		p := procfs.Process(pid)
-		cmd, err = p.TrustedExe()
+		cmd, err = p.Exe()
 		if err != nil {
 			// 当调用者在使用过程中发生了更新,则在获取该进程的exe时,会出现lstat xxx (deleted)此类的error,如果发生的是覆盖,则该路径依旧存在,因此增加以下判断
 			pErr, ok := err.(*os.PathError)

--- a/bin/dde-system-daemon/virtual.go
+++ b/bin/dde-system-daemon/virtual.go
@@ -82,7 +82,7 @@ func getValidSupData(supApps []string) []string {
 // 获取App二进制名称，将exe和cmdline拼接成一个string
 func getActivePidInfo(pid uint32) (execPath string, err error) {
 	value := procfs.Process(pid)
-	execPath, err = value.TrustedExe()
+	execPath, err = value.Exe()
 	if err != nil {
 		logger.Warning(err)
 		return "", err

--- a/grub2/grub2.go
+++ b/grub2/grub2.go
@@ -623,7 +623,7 @@ func checkInvokePermission(service *dbusutil.Service, sender dbus.Sender) error 
 			return err
 		}
 		p := procfs.Process(pid)
-		cmd, err := p.TrustedExe()
+		cmd, err := p.Exe()
 		if err != nil {
 			// 当调用者在使用过程中发生了更新,则在获取该进程的exe时,会出现lstat xxx (deleted)此类的error,如果发生的是覆盖,则该路径依旧存在,因此增加以下判断
 			pErr, ok := err.(*os.PathError)

--- a/system/display1/displaycfg.go
+++ b/system/display1/displaycfg.go
@@ -276,7 +276,7 @@ func (d *Display) doDetectSupportWayland(sender dbus.Sender) (bool, error) {
 			logger.Warning(err)
 			return false, err
 		}
-		execPath, err := p.TrustedExe()
+		execPath, err := p.Exe()
 		if err != nil {
 			logger.Warning(err)
 			return false, err

--- a/system/scheduler/scheduler.go
+++ b/system/scheduler/scheduler.go
@@ -54,7 +54,7 @@ func setProcessPriority(cfg *config, pid int) {
 
 // 获取进程可执行文件路径
 func getProcessExe(pid int) (string, error) {
-	exe, err := procfs.Process(pid).TrustedExe()
+	exe, err := procfs.Process(pid).Exe()
 	return exe, err
 }
 

--- a/system/uadp1/manager.go
+++ b/system/uadp1/manager.go
@@ -162,7 +162,7 @@ func (m *Manager) getExecPath(sender dbus.Sender) (string, error) {
 		return "", err
 	}
 
-	execPath, err := procfs.Process(pid).TrustedExe()
+	execPath, err := procfs.Process(pid).Exe()
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
The change replaces all instances of TrustedExe with Exe in process path resolution. This is necessary because after implementing systemd security control, systemd creates a new namespace that differs from the init process (PID 1) namespace. TrustedExe relies on the init process namespace and thus becomes unreliable in this context. The Exe interface provides a more direct and reliable way to get the executable path regardless of namespace changes.

Technical details:
1. Affects multiple components including user management, display configuration, and system services
2. Changes are consistent across all affected files
3. Maintains same error handling patterns
4. Preserves existing functionality while fixing the namespace issue

fix: 由于systemd命名空间变化将TrustedExe替换为Exe

将所有进程路径解析中的TrustedExe替换为Exe。这是必要的，因为在实现
systemd安全管控后，systemd会创建一个与init进程(PID 1)不同的新命名空间。
TrustedExe依赖于init进程命名空间，因此在此上下文中变得不可靠。Exe接口提
供了一种更直接可靠的方式来获取可执行路径，不受命名空间变化的影响。

技术细节：
1. 影响多个组件包括用户管理、显示配置和系统服务
2. 所有受影响文件的修改保持一致
3. 保持相同的错误处理模式
4. 在修复命名空间问题的同时保留现有功能

PMS: BUG-327465 BUG-327463

## Summary by Sourcery

Replace all usage of procfs.Process.TrustedExe with procfs.Process.Exe to address process path resolution issues caused by systemd namespace changes.

Bug Fixes:
- Use Exe instead of TrustedExe for retrieving process executable paths to ensure reliability in new systemd namespaces

Enhancements:
- Maintain existing error handling and functionality while migrating to the Exe interface across user management, system daemon, display configuration, scheduler, and other components