### PR TITLE
fix: 解决连接蓝牙耳机时模式跟配置不匹配的问题

### DIFF
--- a/audio1/audio.go
+++ b/audio1/audio.go
@@ -1095,7 +1095,7 @@ func (a *Audio) init() error {
 	a.moveSinkInputsToDefaultSink()
 
 	// 蓝牙支持的模式
-	a.setPropBluetoothAudioModeOpts([]string{"a2dp", "headset", "handsfree"})
+	a.refreshBluetoothOpts()
 
 	return nil
 }
@@ -1369,7 +1369,7 @@ func (a *Audio) setPortWithProfileSwitch(card *pulse.Card, portName string, dire
 
 	// 切换配置文件
 	logger.Debugf("set profile: %s %s %s", card.Name, portName, firstProfile)
-	GetConfigKeeper().SetProfile(card.Name, portName, firstProfile)
+	GetConfigKeeper().SetProfile(card.Name, firstProfile)
 	card.SetProfile(firstProfile)
 
 	return nil
@@ -2016,7 +2016,7 @@ func (a *Audio) SetBluetoothAudioMode(mode string) *dbus.Error {
 			// 设置回调函数，当对应的sink/source创建完成后，设置默认sink/source
 			a.setupPortCallback(card.Id, a.defaultSink.ActivePort.Name, pulse.DirectionSink)
 			// 切换配置文件
-			GetConfigKeeper().SetProfile(card.Name, a.defaultSink.ActivePort.Name, profile.Name)
+			GetConfigKeeper().SetProfile(card.Name, profile.Name)
 			card.core.SetProfile(profile.Name)
 
 			// 手动切换蓝牙模式为headset，Profiles是排序之后的，按照优先级先后来设置

--- a/audio1/audio_events.go
+++ b/audio1/audio_events.go
@@ -131,12 +131,6 @@ func (a *Audio) needAutoSwitchInputPort() bool {
 		return false
 	}
 
-	// 当前端口为空
-	if a.defaultSource == nil {
-		logger.Debug("current source is nil")
-		return true
-	}
-
 	// 设置端口时，不触发自动切换
 	a.callbackLocker.Lock()
 	if a.defaultSourceCallback != nil {
@@ -156,6 +150,21 @@ func (a *Audio) needAutoSwitchInputPort() bool {
 	// 如果配置是空，则可能是第一次新增，应该进行自动切换
 	if profile != "" && cp.Name != profile {
 		logger.Warningf("output profile not match, current: %s, prefer: %s", cp.Name, profile)
+		return false
+	}
+	// 如果port的配置文件和profile也不能自动切换
+	found := false
+	port, err := card.Ports.Get(firstPort.PortName, pulse.DirectionSource)
+	if err != nil {
+		logger.Warning(err)
+		return false
+	}
+	for _, pp := range port.Profiles {
+		if pp.Available != 0 && pp.Name == profile {
+			found = true
+		}
+	}
+	if !found {
 		return false
 	}
 
@@ -194,12 +203,6 @@ func (a *Audio) needAutoSwitchOutputPort() bool {
 		return false
 	}
 
-	// 当前端口为空
-	if a.defaultSink == nil {
-		logger.Debug("default sink is nil")
-		return true
-	}
-
 	// 设置端口时，不触发自动切换
 	a.callbackLocker.Lock()
 	if a.defaultSinkCallback != nil {
@@ -218,6 +221,21 @@ func (a *Audio) needAutoSwitchOutputPort() bool {
 	profile := GetConfigKeeper().GetCardPreferProfile(card.core.Name)
 	if profile != "" && cp.Name != profile {
 		logger.Warningf("output profile not match, current: %s, prefer: %s", cp.Name, profile)
+		return false
+	}
+	// 如果port的配置文件和profile不匹配也不能自动切换
+	found := false
+	port, err := card.Ports.Get(firstPort.PortName, pulse.DirectionSink)
+	if err != nil {
+		logger.Warning(err)
+		return false
+	}
+	for _, pp := range port.Profiles {
+		if pp.Available != 0 && pp.Name == profile {
+			found = true
+		}
+	}
+	if !found {
 		return false
 	}
 
@@ -245,14 +263,15 @@ func (a *Audio) needAutoSwitchOutputPort() bool {
 func (a *Audio) autoSwitchProfile(card *Card) {
 	profile := GetConfigKeeper().GetCardPreferProfile(card.core.Name)
 	if profile == "" {
-		return
+		profile = card.core.Profiles.SelectProfile()
 	}
 
 	cp := card.core.ActiveProfile
-	if cp.Name == profile {
+	if profile == "" || cp.Name == profile {
 		return
 	}
 	logger.Debugf("auto switch profile %s to %s", cp.Name, profile)
+	GetConfigKeeper().SetProfile(card.core.Name, profile)
 	card.core.SetProfile(profile)
 }
 

--- a/audio1/config_keeper.go
+++ b/audio1/config_keeper.go
@@ -209,13 +209,14 @@ func (ck *ConfigKeeper) SetEnabled(cardName string, portName string, enabled boo
 	ck.Save()
 }
 
-func (ck *ConfigKeeper) SetProfile(cardName string, portName string, profile string) {
+func (ck *ConfigKeeper) SetProfile(cardName string, profile string) {
 	ck.mu.Lock()
 	defer ck.mu.Unlock()
 
-	card, port := ck.GetCardAndPortConfig(cardName, portName)
-	port.PreferProfile = profile
-	card.PreferPort = portName
+	card, ok := ck.Cards[cardName]
+	if !ok {
+		return
+	}
 	card.PreferProfile = profile
 	ck.Save()
 }


### PR DESCRIPTION
连接蓝牙耳机时，首选的输入输出端口的配置文件可能不一样，导致自动切换输入时，修改了声卡的配置文件，导致蓝牙耳机的模式发生了变化。

Log: 解决连接蓝牙耳机时模式跟配置不匹配的问题
PMS: TASK-369021