### PR TITLE
fix: 解决端口禁用没有切换的问题

### DIFF
--- a/audio1/card.go
+++ b/audio1/card.go
@@ -95,6 +95,7 @@ func (c *Card) update(card *pulse.Card) {
 	c.Name = getCardName(card)
 	c.ActiveProfile = newProfile(card.ActiveProfile)
 	sort.Sort(card.Profiles)
+	// profile是排序过的
 	c.Profiles = newProfileList(card.Profiles)
 	c.filterProfile(card)
 	filterList := strv.Strv(portFilterList)


### PR DESCRIPTION
1. 解决禁用端口后, 没有自动切换到可用端口
2. 解决端口可用后, 没有恢复到之前选中的端口
3. 优化端口的自动切换逻辑, 减少无意义的切换

Log: 声卡自动切换优化
PMS: BUG-298243
Influence: 声卡模块端口禁用/自动切换

## Summary by Sourcery

Rewrite and optimize audio port auto-switching logic to ensure disabled ports trigger a switch to available ports, re-enabled ports restore previous selections, and unnecessary switches are reduced by honoring port/profile preferences configuration and improving event handling.

Bug Fixes:
- Trigger automatic switch when a port is disabled so audio always moves to an available port
- Restore the previously selected port when a re-enabled port becomes available

Enhancements:
- Refactor auto-switch into separate output and input methods and unify them under autoSwitchPort
- Remove callback-based port switching and introduce explicit auto/manual flags in setPort
- Extend ConfigKeeper with SetPortProfile and SetCardPreferPort to track preferred ports and profiles
- Enhance event handlers to properly reassign defaults on sink/source removal and move sink inputs to the default sink
- Simplify tryGetPreferOutPut logic to skip disabled ports and reduce redundant switches based on configuration
- Improve logging around card profile changes, port availability updates, and switch decisions