### PR TITLE
fix:  设置输出端口的插拔管理默认开启

### DIFF
--- a/audio1/audio_events.go
+++ b/audio1/audio_events.go
@@ -317,8 +317,10 @@ func (a *Audio) autoSwitchPort() {
 func (a *Audio) handleCardEvent(eventType int, idx uint32) {
 	switch eventType {
 	case pulse.EventTypeNew: // 新增声卡
+		a.autoPause()
 		a.handleCardAdded(idx)
 	case pulse.EventTypeRemove: // 删除声卡
+		a.autoPause()
 		a.handleCardRemoved(idx)
 	case pulse.EventTypeChange: // 声卡属性变化,也可能是有线耳机插拔了端口
 		a.handleCardChanged(idx)

--- a/misc/dsg-configs/org.deepin.dde.daemon.audio.json
+++ b/misc/dsg-configs/org.deepin.dde.daemon.audio.json
@@ -3,7 +3,7 @@
   "version": "1.0",
   "contents": {
     "pausePlayer": {
-      "value": false,
+      "value": true,
       "serial":0,
       "flags" : [],
       "name": "PlayerPause",


### PR DESCRIPTION
1. 设置输出端口的插拔管理默认开启
2. 插拔管理开启时，关闭音乐

Log: 设置输出端口的插拔管理默认开启
PMS: BUG-314095
Influence:  声卡输入端口插拔管理

## Summary by Sourcery

Enable output port hotplug management by default and pause audio playback automatically on card plug/unplug events

Bug Fixes:
- Set output port hotplug management to enabled by default
- Automatically pause music when audio cards are added or removed during hotplug management