### PR TITLE
fix: 解决配置声音输入设备优先级，没有生效

### DIFF
--- a/audio1/audio.go
+++ b/audio1/audio.go
@@ -2094,8 +2094,10 @@ func (a *Audio) initDsgProp() error {
 		logger.Warning(err)
 	} else {
 		for i := range ret {
-			if v, ok := ret[i].Value().(float64); ok {
+			if v, ok := ret[i].Value().(int64); ok {
 				inputDefaultPriorities = append(inputDefaultPriorities, int(v))
+			} else {
+				logger.Warningf("Input default priority list type is not int64, real is:%T", ret[i].Value())
 			}
 		}
 		logger.Info("input default priority list", inputDefaultPriorities)
@@ -2107,8 +2109,10 @@ func (a *Audio) initDsgProp() error {
 		logger.Warning(err)
 	} else {
 		for i := range ret {
-			if v, ok := ret[i].Value().(float64); ok {
+			if v, ok := ret[i].Value().(int64); ok {
 				outputDefaultPriorities = append(outputDefaultPriorities, int(v))
+			} else {
+				logger.Warningf("output default priority list type is not int64, real is:%T", ret[i].Value())
 			}
 		}
 		logger.Info("output default priority list", outputDefaultPriorities)


### PR DESCRIPTION
获取dconfig配置的时候，优先级配置的数据类型识别不正确，导致获取为空

Log: 更正配置类型
PMS: BUG-312335
Influence: 优先级配置

## Summary by Sourcery

Bug Fixes:
- Use int64 rather than float64 when asserting default priority values for audio inputs and outputs to fix empty configuration issue.