### PR TITLE
fix: 解决电源管理性能模式设置后实际不生效的问题

### DIFF
--- a/system/power1/manager_powersave.go
+++ b/system/power1/manager_powersave.go
@@ -5,7 +5,6 @@
 package power
 
 import (
-	"fmt"
 	"os/exec"
 )
 
@@ -45,11 +44,11 @@ var _powerConfigMap = map[string]*powerConfig{
 }
 
 func (m *Manager) setDSPCState(state DSPCMode) {
-	args := fmt.Sprintf("/usr/sbin/deepin-system-power-control set %v", state)
-	logger.Debug("set deepin tlp state cmd:", args)
-	err := exec.Command("/bin/sh", "-c", args).Run()
+	cmd := exec.Command("/usr/sbin/deepin-system-power-control", "set", string(state))
+	logger.Debug("Setting deepin tlp state with command:", cmd.String())
+	_, err := cmd.Output()
 	if err != nil {
-		logger.Warning("failed to set deepin tlp state ", err)
+		logger.Warning("Failed to set deepin tlp state:", err)
 	}
 }
 


### PR DESCRIPTION
使用exec.Command调用/bin/sh -c 执行tlp命令，提示参数错误

Log: 去掉/bin/sh -c执行
PMS: BUG-328373
Influence: 电源管理性能模式

## Summary by Sourcery

Fix the invocation of the deepin-system-power-control command by removing the shell wrapper and passing arguments directly

Bug Fixes:
- Remove "/bin/sh -c" wrapper and call exec.Command with argument list to correctly apply performance mode
- Capture and log command output properly and update debug/warning messages