### PR TITLE
chore: remove ipwatchd dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -77,7 +77,6 @@ Depends:
  libglib2.0-bin,
  hwinfo,
  imwheel,
- ipwatchd,
  iso-codes,
  lastore-daemon,
  libfprint0 | libfprint | libfprint-2-2,


### PR DESCRIPTION
as title

Log: as title
Pms: TASK-380689

## Summary by Sourcery

Build:
- Remove ipwatchd from the Debian control file dependencies