### PR TITLE
fix: 解决内置声卡被禁用端口插拔时没有通知的问题

### DIFF
--- a/audio1/audio_events.go
+++ b/audio1/audio_events.go
@@ -427,6 +427,7 @@ func (a *Audio) handleCardChanged(idx uint32) {
 	} else if !isBluezAudio(ac.Name) {
 		// 蓝牙声卡不检查状态
 		// 因为蓝牙声卡会处理a2dp模式，会导致端口状态对不上
+		shouldAutoSwitch := false
 		for _, port := range oldPorts {
 			p, err := ac.Ports.Get(port.Name, port.Direction)
 			if err != nil {
@@ -442,9 +443,11 @@ func (a *Audio) handleCardChanged(idx uint32) {
 					logger.Debugf("port<%s,%s> notify", ac.Name, port.Name)
 					a.notifyPortDisabled(ac.Id, port)
 				}
-				a.autoSwitchPort()
-				break
+				shouldAutoSwitch = true
 			}
+		}
+		if shouldAutoSwitch {
+			a.autoSwitchPort()
 		}
 	}
 }


### PR DESCRIPTION
一次插拔事件，可能有多个端口发生变化，需要遍历完整的端口，查询状态发出通知

Log: 处理端口状态更新，发送通知
PMS: BUG-329381
Influence: 声卡端口

## Summary by Sourcery

Ensure full traversal of audio card ports to issue notifications for each disabled port and defer auto-switching until all ports are processed

Bug Fixes:
- Notify on all built-in audio card port enable/disable events instead of missing some events

Enhancements:
- Accumulate port state changes then invoke autoSwitchPort once after iterating all ports