### PR TITLE
fix: 解决控制中心时区列表格式不统一的问题

### DIFF
--- a/timedate1/zoneinfo/wrapper.go
+++ b/timedate1/zoneinfo/wrapper.go
@@ -69,12 +69,10 @@ func newZoneInfo(zone string) *ZoneInfo {
 
 	info.Name = zone
 	info.Desc = DGettext("deepin-installer-timezones", zone)
-
 	tokens := strings.Split(info.Desc, "/")
-	if len(tokens) == 2 {
-		info.Desc = tokens[1]
+	if len(tokens) > 0 {
+		info.Desc = tokens[len(tokens)-1]
 	}
-
 	dst := newDSTInfo(zone)
 	if dst == nil {
 		info.Offset = getOffsetByUSec(zone, 0)


### PR DESCRIPTION
时区列表解析的时格式有洲/国、洲/国/城市，当前只处理了洲/国的情况。应该只显示最后一个地名即可

Log: 解析时区列表，显示描述的最后一个地名
PMS: BUG-313957
Influence: 时区显示

## Summary by Sourcery

Bug Fixes:
- Handle timezone descriptions with more than two segments by always using the final token for display