### PR TITLE
feat(power&keybinding): Change backend configuration to dconfig

### DIFF
--- a/keybinding1/constants/dsettings.go
+++ b/keybinding1/constants/dsettings.go
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2018 - 2022 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package constants provides shared constants for the keybinding daemon
+package constants
+
+// DSettings related constants
+const (
+	DSettingsAppID = "org.deepin.dde.daemon"
+
+	DSettingsKeyBindingName                = "org.deepin.dde.daemon.keybinding"
+	DSettingsKeyWirelessControlEnable      = "wirelessControlEnable"
+	DSettingsKeyNeedXrandrQDevices         = "needXrandrQDevices"
+	DSettingsKeyDeviceManagerControlEnable = "deviceManagerControlEnable"
+
+	DSettingsKeybindingPlatformId    = "org.deepin.dde.daemon.keybinding.platform"
+	DSettingsKeybindingMediaKeyId    = "org.deepin.dde.daemon.keybinding.mediakey"
+	DSettingsKeybindingSystemKeysId  = "org.deepin.dde.daemon.keybinding.system"
+	DSettingsKeybindingWrapGnomeWmId = "org.deepin.dde.daemon.keybinding.wrap.gnome.wm"
+	DSettingsKeybindingEnableId      = "org.deepin.dde.daemon.keybinding.enable"
+	DSettingsKeyboardId              = "org.deepin.dde.daemon.keyboard"
+
+	DSettingsKeyUpperLayerWLAN               = "upperLayerWlan"
+	DSettingsPowerId                         = "org.deepin.dde.daemon.power"
+	DSettingsKeyBatteryPressPowerBtnAction   = "batteryPressPowerButton"
+	DSettingsKeyLinePowerPressPowerBtnAction = "linePowerPressPowerButton"
+	DSettingsKeyScreenBlackLock              = "screenBlackLock"
+	DSettingsKeyHighPerformanceEnabled       = "highPerformanceEnabled"
+	DSettingsKeySleepLock                    = "sleepLock"
+
+	DSettingsKeyNumLockState             = "numlockState"
+	DSettingsKeySaveNumLockState         = "saveNumlockState"
+	DSettingsKeyShortcutSwitchLayout     = "shortcutSwitchLayout"
+	DSettingsKeyShowCapsLockOSD          = "capslockToggle"
+	DSettingsKeyOsdAdjustBrightnessState = "osdAdjustBrightnessEnabled"
+	DSettingsKeyOsdAdjustVolumeState     = "osdAdjustVolumeEnabled"
+
+	DSettingsKeyAmbientLightAdjustBrightness = "ambientLightAdjustBrightness"
+)

--- a/keybinding1/daemon.go
+++ b/keybinding1/daemon.go
@@ -67,10 +67,9 @@ func (d *Daemon) Start() error {
 		m := d.manager
 		m.initHandlers()
 
-		// listen gsettings changed event
-		m.listenGSettingsChanged(gsSchemaSystem, d.manager.gsSystem, shortcuts.ShortcutTypeSystem)
-		m.listenGSettingsChanged(gsSchemaMediaKey, d.manager.gsMediaKey, shortcuts.ShortcutTypeMedia)
-		m.listenGSettingsChanged(gsSchemaGnomeWM, d.manager.gsGnomeWM, shortcuts.ShortcutTypeWM)
+		m.listenDConfigChanged(d.manager.shortcutSystemConfigMgr, shortcuts.ShortcutTypeSystem)
+		m.listenDConfigChanged(d.manager.shortcutMediaConfigMgr, shortcuts.ShortcutTypeMedia)
+		m.listenDConfigChanged(d.manager.shortcutWrapGnomeWmConfigMgr, shortcuts.ShortcutTypeWM)
 
 		m.listenSystemEnableChanged()
 		m.listenSystemPlatformChanged()

--- a/keybinding1/shortcuts/gsettings_shortcut.go
+++ b/keybinding1/shortcuts/gsettings_shortcut.go
@@ -6,32 +6,35 @@ package shortcuts
 
 import (
 	wm "github.com/linuxdeepin/go-dbus-factory/session/com.deepin.wm"
-	"github.com/linuxdeepin/go-gir/gio-2.0"
 )
 
-type GSettingsShortcut struct {
+type ShortcutObject struct {
 	BaseShortcut
-	gsettings *gio.Settings
-	wm        wm.Wm
+	wm                 wm.Wm
+	configSaveCallback func(id string, keystrokes []string) error
+	configLoadCallback func(id string) ([]string, error)
 }
 
-func NewGSettingsShortcut(gsettings *gio.Settings, wm wm.Wm, id string, type0 int32,
-	keystrokes []string, name string) *GSettingsShortcut {
-	gs := &GSettingsShortcut{
+func NewShortcut(wm wm.Wm, id string, type0 int32,
+	keystrokes []string, name string,
+	configSaveCallback func(id string, keystrokes []string) error,
+	configLoadCallback func(id string) ([]string, error)) *ShortcutObject {
+	gs := &ShortcutObject{
 		BaseShortcut: BaseShortcut{
 			Id:         id,
 			Type:       type0,
 			Keystrokes: ParseKeystrokes(keystrokes),
 			Name:       name,
 		},
-		gsettings: gsettings,
-		wm:        wm,
+		wm:                 wm,
+		configSaveCallback: configSaveCallback,
+		configLoadCallback: configLoadCallback,
 	}
 
 	return gs
 }
 
-func (gs *GSettingsShortcut) SaveKeystrokes() error {
+func (gs *ShortcutObject) SaveKeystrokes() error {
 	keystrokesStrv := make([]string, 0, len(gs.Keystrokes))
 	for _, ks := range gs.Keystrokes {
 		keystrokesStrv = append(keystrokesStrv, ks.String())
@@ -42,9 +45,17 @@ func (gs *GSettingsShortcut) SaveKeystrokes() error {
 			return err
 		}
 	}
-	gs.gsettings.SetStrv(gs.Id, keystrokesStrv)
-	gio.SettingsSync()
-	logger.Debugf("GSettingsShortcut.SaveKeystrokes id: %v, keystrokes: %v", gs.Id, keystrokesStrv)
+
+	// 使用配置管理器回调保存配置
+	if gs.configSaveCallback != nil {
+		err := gs.configSaveCallback(gs.Id, keystrokesStrv)
+		if err != nil {
+			logger.Warning("Failed to save keystrokes via callback:", err)
+			return err
+		}
+	}
+
+	logger.Debugf("ShortcutObject.SaveKeystrokes id: %v, keystrokes: %v", gs.Id, keystrokesStrv)
 	return nil
 }
 
@@ -67,10 +78,25 @@ func keystrokesEqual(s1 []*Keystroke, s2 []*Keystroke) bool {
 	return true
 }
 
-func (gs *GSettingsShortcut) ReloadKeystrokes() bool {
+func (gs *ShortcutObject) ReloadKeystrokes() bool {
 	oldVal := gs.GetKeystrokes()
 	id := gs.GetId()
-	newVal := ParseKeystrokes(gs.gsettings.GetStrv(id))
+
+	// 使用配置管理器回调加载配置
+	var keystrokesStrv []string
+	if gs.configLoadCallback != nil {
+		var err error
+		keystrokesStrv, err = gs.configLoadCallback(id)
+		if err != nil {
+			logger.Warning("Failed to reload keystrokes via callback:", err)
+			return false
+		}
+	} else {
+		logger.Warning("No config load callback available for shortcut:", id)
+		return false
+	}
+
+	newVal := ParseKeystrokes(keystrokesStrv)
 	gs.setKeystrokes(newVal)
 	return !keystrokesEqual(oldVal, newVal)
 }

--- a/keybinding1/shortcuts/id_name_map.go
+++ b/keybinding1/shortcuts/id_name_map.go
@@ -12,31 +12,31 @@ func getSystemIdNameMap() map[string]string {
 	var idNameMap = map[string]string{
 		"launcher":               gettext.Tr("Launcher"),
 		"terminal":               gettext.Tr("Terminal"),
-		"deepin-screen-recorder": gettext.Tr("Screen Recorder"),
-		"lock-screen":            gettext.Tr("Lock screen"),
-		"show-dock":              gettext.Tr("Show/Hide the dock"),
+		"deepinScreenRecorder":   gettext.Tr("Screen Recorder"),
+		"lockScreen":             gettext.Tr("Lock screen"),
+		"showDock":               gettext.Tr("Show/Hide the dock"),
 		"logout":                 gettext.Tr("Shutdown interface"),
-		"terminal-quake":         gettext.Tr("Terminal Quake Window"),
+		"terminalQuake":          gettext.Tr("Terminal Quake Window"),
 		"screenshot":             gettext.Tr("Screenshot"),
-		"screenshot-fullscreen":  gettext.Tr("Full screenshot"),
-		"screenshot-window":      gettext.Tr("Window screenshot"),
-		"screenshot-delayed":     gettext.Tr("Delay screenshot"),
-		"screenshot-ocr":         gettext.Tr("OCR (Image to Text)"),
-		"screenshot-scroll":      gettext.Tr("Scrollshot"),
-		"file-manager":           gettext.Tr("File manager"),
-		"disable-touchpad":       gettext.Tr("Disable Touchpad"),
-		"wm-switcher":            gettext.Tr("Switch window effects"),
-		"turn-off-screen":        gettext.Tr("Fast Screen Off"),
-		"system-monitor":         gettext.Tr("System Monitor"),
-		"color-picker":           gettext.Tr("Deepin Picker"),
-		"text-to-speech":         gettext.Tr("Text to Speech"),
-		"speech-to-text":         gettext.Tr("Speech to Text"),
+		"screenshotFullscreen":   gettext.Tr("Full screenshot"),
+		"screenshotWindow":       gettext.Tr("Window screenshot"),
+		"screenshotDelayed":      gettext.Tr("Delay screenshot"),
+		"screenshotOcr":          gettext.Tr("OCR (Image to Text)"),
+		"screenshotScroll":       gettext.Tr("Scrollshot"),
+		"fileManager":            gettext.Tr("File manager"),
+		"disableTouchpad":        gettext.Tr("Disable Touchpad"),
+		"wmSwitcher":             gettext.Tr("Switch window effects"),
+		"turnOffScreen":          gettext.Tr("Fast Screen Off"),
+		"systemMonitor":          gettext.Tr("System Monitor"),
+		"colorPicker":            gettext.Tr("Deepin Picker"),
+		"textToSpeech":           gettext.Tr("Text to Speech"),
+		"speechToText":           gettext.Tr("Speech to Text"),
 		"clipboard":              gettext.Tr("Clipboard"),
 		"translation":            gettext.Tr("Translation"),
-		"global-search":          gettext.Tr("Grand Search"),
-		"notification-center":    gettext.Tr("Notification Center"),
+		"globalSearch":           gettext.Tr("Grand Search"),
+		"notificationCenter":     gettext.Tr("Notification Center"),
 		"switch-next-kbd-layout": gettext.Tr("Switch Layout"),
-		"switch-monitors":        gettext.Tr("Toggle multiple displays"),
+		"switchMonitors":         gettext.Tr("Toggle multiple displays"),
 	}
 	return idNameMap
 }
@@ -50,160 +50,160 @@ func getSpecialIdNameMap() map[string]string {
 
 func getWMIdNameMap() map[string]string {
 	var idNameMap = map[string]string{
-		"switch-to-workspace-1":        "Switch to workspace 1",
-		"switch-to-workspace-2":        "Switch to workspace 2",
-		"switch-to-workspace-3":        "Switch to workspace 3",
-		"switch-to-workspace-4":        "Switch to workspace 4",
-		"switch-to-workspace-5":        "Switch to workspace 5",
-		"switch-to-workspace-6":        "Switch to workspace 6",
-		"switch-to-workspace-7":        "Switch to workspace 7",
-		"switch-to-workspace-8":        "Switch to workspace 8",
-		"switch-to-workspace-9":        "Switch to workspace 9",
-		"switch-to-workspace-10":       "Switch to workspace 10",
-		"switch-to-workspace-11":       "Switch to workspace 11",
-		"switch-to-workspace-12":       "Switch to workspace 12",
-		"switch-to-workspace-left":     gettext.Tr("Switch to left workspace"),
-		"switch-to-workspace-right":    gettext.Tr("Switch to right workspace"),
-		"switch-to-workspace-up":       gettext.Tr("Switch to upper workspace"),
-		"switch-to-workspace-down":     gettext.Tr("Switch to lower workspace"),
-		"switch-to-workspace-last":     "Switch to last workspace",
-		"switch-group":                 gettext.Tr("Switch similar windows"),
-		"switch-group-backward":        gettext.Tr("Switch similar windows in reverse"),
-		"switch-applications":          gettext.Tr("Switch windows"),
-		"switch-applications-backward": gettext.Tr("Switch windows in reverse"),
-		"switch-windows":               "Switch windows",
-		"switch-windows-backward":      "Reverse switch windows",
-		"switch-panels":                "Switch system controls",
-		"switch-panels-backward":       "Reverse switch system controls",
-		"cycle-group":                  "Switch windows of an app directly",
-		"cycle-group-backward":         "Reverse switch windows of an app directly",
-		"cycle-windows":                "Switch windows directly",
-		"cycle-windows-backward":       "Reverse switch windows directly",
-		"cycle-panels":                 "Switch system controls directly",
-		"cycle-panels-backward":        "Reverse switch system controls directly",
-		"show-desktop":                 gettext.Tr("Show desktop"),
-		"panel-main-menu":              "Show the activities overview",
-		"panel-run-dialog":             "Show the run command prompt",
+		"switchToWorkspace1":         "Switch to workspace 1",
+		"switchToWorkspace2":         "Switch to workspace 2",
+		"switchToWorkspace3":         "Switch to workspace 3",
+		"switchToWorkspace4":         "Switch to workspace 4",
+		"switchToWorkspace5":         "Switch to workspace 5",
+		"switchToWorkspace6":         "Switch to workspace 6",
+		"switchToWorkspace7":         "Switch to workspace 7",
+		"switchToWorkspace8":         "Switch to workspace 8",
+		"switchToWorkspace9":         "Switch to workspace 9",
+		"switchToWorkspace10":        "Switch to workspace 10",
+		"switchToWorkspace11":        "Switch to workspace 11",
+		"switchToWorkspace12":        "Switch to workspace 12",
+		"switchToWorkspaceLeft":      gettext.Tr("Switch to left workspace"),
+		"switchToWorkspaceRight":     gettext.Tr("Switch to right workspace"),
+		"switchToWorkspaceUp":        gettext.Tr("Switch to upper workspace"),
+		"switchToWorkspaceDown":      gettext.Tr("Switch to lower workspace"),
+		"switchToWorkspaceLast":      "Switch to last workspace",
+		"switchGroup":                gettext.Tr("Switch similar windows"),
+		"switchGroupBackward":        gettext.Tr("Switch similar windows in reverse"),
+		"switchApplications":         gettext.Tr("Switch windows"),
+		"switchApplicationsBackward": gettext.Tr("Switch windows in reverse"),
+		"switchWindows":              "Switch windows",
+		"switchWindowsBackward":      "Reverse switch windows",
+		"switchPanels":               "Switch system controls",
+		"switchPanelsBackward":       "Reverse switch system controls",
+		"cycleGroup":                 "Switch windows of an app directly",
+		"cycleGroupBackward":         "Reverse switch windows of an app directly",
+		"cycleWindows":               "Switch windows directly",
+		"cycleWindowsBackward":       "Reverse switch windows directly",
+		"cyclePanels":                "Switch system controls directly",
+		"cyclePanelsBackward":        "Reverse switch system controls directly",
+		"showDesktop":                gettext.Tr("Show desktop"),
+		"panelMainMenu":              "Show the activities overview",
+		"panelRunDialog":             "Show the run command prompt",
 		// Don't use
 		// "set-spew-mark":                gettext.Tr(""),
-		"activate-window-menu":         "Activate window menu",
-		"toggle-fullscreen":            "toggle-fullscreen",
-		"toggle-maximized":             "Toggle maximization state",
-		"toggle-above":                 "Toggle window always appearing on top",
-		"maximize":                     gettext.Tr("Maximize window"),
-		"unmaximize":                   gettext.Tr("Restore window"),
-		"toggle-shaded":                "Switch furl state",
-		"minimize":                     gettext.Tr("Minimize window"),
-		"close":                        gettext.Tr("Close window"),
-		"begin-move":                   gettext.Tr("Move window"),
-		"begin-resize":                 gettext.Tr("Resize window"),
-		"toggle-on-all-workspaces":     "Toggle window on all workspaces or one",
-		"move-to-workspace-1":          "Move to workspace 1",
-		"move-to-workspace-2":          "Move to workspace 2",
-		"move-to-workspace-3":          "Move to workspace 3",
-		"move-to-workspace-4":          "Move to workspace 4",
-		"move-to-workspace-5":          "Move to workspace 5",
-		"move-to-workspace-6":          "Move to workspace 6",
-		"move-to-workspace-7":          "Move to workspace 7",
-		"move-to-workspace-8":          "Move to workspace 8",
-		"move-to-workspace-9":          "Move to workspace 9",
-		"move-to-workspace-10":         "Move to workspace 10",
-		"move-to-workspace-11":         "Move to workspace 11",
-		"move-to-workspace-12":         "Move to workspace 12",
-		"move-to-workspace-last":       "Move to last workspace",
-		"move-to-workspace-left":       gettext.Tr("Move to left workspace"),
-		"move-to-workspace-right":      gettext.Tr("Move to right workspace"),
-		"move-to-workspace-up":         gettext.Tr("Move to upper workspace"),
-		"move-to-workspace-down":       gettext.Tr("Move to lower workspace"),
-		"move-to-monitor-left":         "Move to left monitor",
-		"move-to-monitor-right":        "Move to right monitor",
-		"move-to-monitor-up":           "Move to up monitor",
-		"move-to-monitor-down":         "Move to down monitor",
-		"raise-or-lower":               "Raise window if covered, otherwise lower it",
-		"raise":                        "Raise window above other windows",
-		"lower":                        "Lower window below other windows",
-		"maximize-vertically":          "Maximize window vertically",
-		"maximize-horizontally":        "Maximize window horizontally",
-		"move-to-corner-nw":            "Move window to top left corner",
-		"move-to-corner-ne":            "Move window to top right corner",
-		"move-to-corner-sw":            "Move window to bottom left corner",
-		"move-to-corner-se":            "Move window to bottom right corner",
-		"move-to-side-n":               "Move window to top edge of screen",
-		"move-to-side-s":               "Move window to bottom edge of screen",
-		"move-to-side-e":               "Move window to right side of screen",
-		"move-to-side-w":               "Move window to left side of screen",
-		"move-to-center":               "Move window to center of screen",
-		"switch-input-source":          "Binding to select the next input source",
-		"switch-input-source-backward": "Binding to select the previous input source",
-		"always-on-top":                "Set or unset window to appear always on top",
-		"expose-all-windows":           gettext.Tr("Display windows of all workspaces"),
-		"expose-windows":               gettext.Tr("Display windows of current workspace"),
-		"preview-workspace":            gettext.Tr("Display workspace"),
-		"view-zoom-in":                 gettext.Tr("Zoom In"),
-		"view-zoom-out":                gettext.Tr("Zoom Out"),
-		"view-actual-size":             gettext.Tr("Zoom to Actual Size"),
-		"toggle-to-left":               gettext.Tr("Window Quick Tile Left"),
-		"toggle-to-right":              gettext.Tr("Window Quick Tile Right"),
+		"activateWindowMenu":        "Activate window menu",
+		"toggleFullscreen":          "toggle-fullscreen",
+		"toggleMaximized":           "Toggle maximization state",
+		"toggleAbove":               "Toggle window always appearing on top",
+		"maximize":                  gettext.Tr("Maximize window"),
+		"unmaximize":                gettext.Tr("Restore window"),
+		"toggleShaded":              "Switch furl state",
+		"minimize":                  gettext.Tr("Minimize window"),
+		"close":                     gettext.Tr("Close window"),
+		"beginMove":                 gettext.Tr("Move window"),
+		"beginResize":               gettext.Tr("Resize window"),
+		"toggle-on-all-workspaces":  "Toggle window on all workspaces or one",
+		"moveToWorkspace1":          "Move to workspace 1",
+		"moveToWorkspace2":          "Move to workspace 2",
+		"moveToWorkspace3":          "Move to workspace 3",
+		"moveToWorkspace4":          "Move to workspace 4",
+		"moveToWorkspace5":          "Move to workspace 5",
+		"moveToWorkspace6":          "Move to workspace 6",
+		"moveToWorkspace7":          "Move to workspace 7",
+		"moveToWorkspace8":          "Move to workspace 8",
+		"moveToWorkspace9":          "Move to workspace 9",
+		"moveToWorkspace10":         "Move to workspace 10",
+		"moveToWorkspace11":         "Move to workspace 11",
+		"moveToWorkspace12":         "Move to workspace 12",
+		"moveToWorkspaceLast":       "Move to last workspace",
+		"moveToWorkspaceLeft":       gettext.Tr("Move to left workspace"),
+		"moveToWorkspaceRight":      gettext.Tr("Move to right workspace"),
+		"moveToWorkspaceUp":         gettext.Tr("Move to upper workspace"),
+		"moveToWorkspaceDown":       gettext.Tr("Move to lower workspace"),
+		"moveToMonitorLeft":         "Move to left monitor",
+		"moveToMonitorRight":        "Move to right monitor",
+		"moveToMonitorUp":           "Move to up monitor",
+		"moveToMonitorDown":         "Move to down monitor",
+		"raise-or-lower":            "Raise window if covered, otherwise lower it",
+		"raise":                     "Raise window above other windows",
+		"lower":                     "Lower window below other windows",
+		"maximizeVertically":        "Maximize window vertically",
+		"maximizeHorizontally":      "Maximize window horizontally",
+		"move-to-corner-nw":         "Move window to top left corner",
+		"move-to-corner-ne":         "Move window to top right corner",
+		"move-to-corner-sw":         "Move window to bottom left corner",
+		"move-to-corner-se":         "Move window to bottom right corner",
+		"move-to-side-n":            "Move window to top edge of screen",
+		"move-to-side-s":            "Move window to bottom edge of screen",
+		"move-to-side-e":            "Move window to right side of screen",
+		"move-to-side-w":            "Move window to left side of screen",
+		"move-to-center":            "Move window to center of screen",
+		"switchInputSource":         "Binding to select the next input source",
+		"switchInputSourceBackward": "Binding to select the previous input source",
+		"always-on-top":             "Set or unset window to appear always on top",
+		"exposeAllWindows":          gettext.Tr("Display windows of all workspaces"),
+		"exposeWindows":             gettext.Tr("Display windows of current workspace"),
+		"previewWorkspace":          gettext.Tr("Display workspace"),
+		"viewZoomIn":                gettext.Tr("Zoom In"),
+		"viewZoomOut":               gettext.Tr("Zoom Out"),
+		"viewActualSize":            gettext.Tr("Zoom to Actual Size"),
+		"toggleToLeft":              gettext.Tr("Window Quick Tile Left"),
+		"toggleToRight":             gettext.Tr("Window Quick Tile Right"),
 	}
 	return idNameMap
 }
 
 func getMediaIdNameMap() map[string]string {
 	var idNameMap = map[string]string{
-		"messenger":           "Messenger",         // XF86Messenger
-		"save":                "Save",              // XF86Save
-		"new":                 "New",               // XF86New
-		"wake-up":             "WakeUp",            // XF86WakeUp
-		"audio-rewind":        "AudioRewind",       // XF86AudioRewind
-		"audio-mute":          "AudioMute",         // XF86AudioMute
-		"mon-brightness-up":   "MonBrightnessUp",   // XF86MonBrightnessUp
-		"wlan":                "WLAN",              // XF86WLAN
-		"audio-media":         "AudioMedia",        // XF86AudioMedia
-		"reply":               "Reply",             // XF86Reply
-		"favorites":           "Favorites",         // XF86Favorites
-		"audio-play":          "AudioPlay",         // XF86AudioPlay
-		"audio-mic-mute":      "AudioMicMute",      // XF86AudioMicMute
-		"audio-pause":         "AudioPause",        // XF86AudioPause
-		"audio-stop":          "AudioStop",         // XF86AudioStop
-		"documents":           "Documents",         // XF86Documents
-		"game":                "Game",              // XF86Game
-		"search":              "Search",            // XF86Search
-		"audio-record":        "AudioRecord",       // XF86AudioRecord
-		"display":             "Display",           // XF86Display
-		"reload":              "Reload",            // XF86Reload
-		"explorer":            "Explorer",          // XF86Explorer
-		"calculator":          "Calculator",        // XF86Calculator
-		"calendar":            "Calendar",          // XF86Calendar
-		"forward":             "Forward",           // XF86Forward
-		"cut":                 "Cut",               // XF86Cut
-		"mon-brightness-down": "MonBrightnessDown", // XF86MonBrightnessDown
-		"copy":                "Copy",              // XF86Copy
-		"tools":               "Tools",             // XF86Tools
-		"audio-raise-volume":  "AudioRaiseVolume",  // XF86AudioRaiseVolume
-		"media-close":         "media-Close",       // XF86Close
-		"www":                 "WWW",               // XF86WWW
-		"home-page":           "HomePage",          // XF86HomePage
-		"sleep":               "Sleep",             // XF86Sleep
-		"audio-lower-volume":  "AudioLowerVolume",  // XF86AudioLowerVolume
-		"audio-prev":          "AudioPrev",         // XF86AudioPrev
-		"audio-next":          "AudioNext",         // XF86AudioNext
-		"paste":               "Paste",             // XF86Paste
-		"open":                "Open",              // XF86Open
-		"send":                "Send",              // XF86Send
-		"my-computer":         "MyComputer",        // XF86MyComputer
-		"mail":                "Mail",              // XF86Mail
-		"adjust-brightness":   "BrightnessAdjust",  // XF86BrightnessAdjust
-		"log-off":             "LogOff",            // XF86LogOff
-		"pictures":            "Pictures",          // XF86Pictures
-		"terminal":            "Terminal",          // XF86Terminal
-		"video":               "Video",             // XF86Video
-		"music":               "Music",             // XF86Music
-		"app-left":            "ApplicationLeft",   // XF86ApplicationLeft
-		"app-right":           "ApplicationRight",  // XF86ApplicationRight
-		"meeting":             "Meeting",           // XF86Meeting
-		"touchpad-toggle":     "ToggleTouchpad",    // XF86TouchpadToggle
-		"away":                "Away",              // XF86Away
-		"web-cam":             "Camera",            // XF86WebCam
+		"messenger":         "Messenger",         // XF86Messenger
+		"save":              "Save",              // XF86Save
+		"new":               "New",               // XF86New
+		"wakeUp":            "WakeUp",            // XF86WakeUp
+		"audioRewind":       "AudioRewind",       // XF86AudioRewind
+		"audioMute":         "AudioMute",         // XF86AudioMute
+		"monBrightnessUp":   "MonBrightnessUp",   // XF86MonBrightnessUp
+		"wlan":              "WLAN",              // XF86WLAN
+		"audioMedia":        "AudioMedia",        // XF86AudioMedia
+		"reply":             "Reply",             // XF86Reply
+		"favorites":         "Favorites",         // XF86Favorites
+		"audioPlay":         "AudioPlay",         // XF86AudioPlay
+		"audioMicMute":      "AudioMicMute",      // XF86AudioMicMute
+		"audioPause":        "AudioPause",        // XF86AudioPause
+		"audioStop":         "AudioStop",         // XF86AudioStop
+		"documents":         "Documents",         // XF86Documents
+		"game":              "Game",              // XF86Game
+		"search":            "Search",            // XF86Search
+		"audioRecord":       "AudioRecord",       // XF86AudioRecord
+		"display":           "Display",           // XF86Display
+		"reload":            "Reload",            // XF86Reload
+		"explorer":          "Explorer",          // XF86Explorer
+		"calculator":        "Calculator",        // XF86Calculator
+		"calendar":          "Calendar",          // XF86Calendar
+		"forward":           "Forward",           // XF86Forward
+		"cut":               "Cut",               // XF86Cut
+		"monBrightnessDown": "MonBrightnessDown", // XF86MonBrightnessDown
+		"copy":              "Copy",              // XF86Copy
+		"tools":             "Tools",             // XF86Tools
+		"audioRaiseVolume":  "AudioRaiseVolume",  // XF86AudioRaiseVolume
+		"mediaClose":        "media-Close",       // XF86Close
+		"www":               "WWW",               // XF86WWW
+		"homePage":          "HomePage",          // XF86HomePage
+		"sleep":             "Sleep",             // XF86Sleep
+		"audioLowerVolume":  "AudioLowerVolume",  // XF86AudioLowerVolume
+		"audioPrev":         "AudioPrev",         // XF86AudioPrev
+		"audioNext":         "AudioNext",         // XF86AudioNext
+		"paste":             "Paste",             // XF86Paste
+		"open":              "Open",              // XF86Open
+		"send":              "Send",              // XF86Send
+		"myComputer":        "MyComputer",        // XF86MyComputer
+		"mail":              "Mail",              // XF86Mail
+		"adjustBrightness":  "BrightnessAdjust",  // XF86BrightnessAdjust
+		"logOff":            "LogOff",            // XF86LogOff
+		"pictures":          "Pictures",          // XF86Pictures
+		"terminal":          "Terminal",          // XF86Terminal
+		"video":             "Video",             // XF86Video
+		"music":             "Music",             // XF86Music
+		"appLeft":           "ApplicationLeft",   // XF86ApplicationLeft
+		"appRight":          "ApplicationRight",  // XF86ApplicationRight
+		"meeting":           "Meeting",           // XF86Meeting
+		"touchpadToggle":    "ToggleTouchpad",    // XF86TouchpadToggle
+		"away":              "Away",              // XF86Away
+		"webCam":            "Camera",            // XF86WebCam
 	}
 	return idNameMap
 }

--- a/keybinding1/shortcuts/kwin_shortcut.go
+++ b/keybinding1/shortcuts/kwin_shortcut.go
@@ -46,8 +46,8 @@ func (ks *kWinShortcut) ReloadKeystrokes() bool {
 		if ks.Id == "launcher" {
 			keystrokes[0] = "<Super_L>"
 		}
-		//system-monitor
-		if ks.Id == "system-monitor" {
+		//systemMonitor
+		if ks.Id == "systemMonitor" {
 			for i := 0; i < len(keystrokes); i++ {
 				keystrokes[i] = strings.Replace(keystrokes[i], "Esc", "Escape", 1)
 			}

--- a/keybinding1/shortcuts/media_shortcut.go
+++ b/keybinding1/shortcuts/media_shortcut.go
@@ -9,7 +9,7 @@ import (
 )
 
 type MediaShortcut struct {
-	*GSettingsShortcut
+	*ShortcutObject
 }
 
 const (
@@ -38,67 +38,67 @@ var mediaIdActionMap = map[string]*Action{
 	"numlock":  &Action{Type: ActionTypeShowNumLockOSD},
 	"capslock": &Action{Type: ActionTypeShowCapsLockOSD},
 	// Open MimeType
-	"home-page":   NewOpenMimeTypeAction(mimeTypeBrowser),
-	"www":         NewOpenMimeTypeAction(mimeTypeBrowser),
-	"explorer":    NewOpenMimeTypeAction(mimeTypeDir),
-	"mail":        NewOpenMimeTypeAction(mimeTypeMail),
-	"audio-media": NewOpenMimeTypeAction(mimeTypeAudioMedia),
-	"music":       NewOpenMimeTypeAction(mimeTypeAudioMedia),
-	"pictures":    NewOpenMimeTypeAction(mimeTypeImagePng),
-	"video":       NewOpenMimeTypeAction(mimeTypeVideoMp4),
+	"homePage":   NewOpenMimeTypeAction(mimeTypeBrowser),
+	"www":        NewOpenMimeTypeAction(mimeTypeBrowser),
+	"explorer":   NewOpenMimeTypeAction(mimeTypeDir),
+	"mail":       NewOpenMimeTypeAction(mimeTypeMail),
+	"audioMedia": NewOpenMimeTypeAction(mimeTypeAudioMedia),
+	"music":      NewOpenMimeTypeAction(mimeTypeAudioMedia),
+	"pictures":   NewOpenMimeTypeAction(mimeTypeImagePng),
+	"video":      NewOpenMimeTypeAction(mimeTypeVideoMp4),
 
 	// command
-	"my-computer": NewExecCmdAction(cmdMyComputer, false),
-	"documents":   NewExecCmdAction(cmdDocuments, false),
-	"eject":       NewExecCmdAction(cmdEject, false),
-	"calculator":  NewExecCmdAction(cmdCalculator, false),
-	"calendar":    NewExecCmdAction(cmdCalendar, false),
-	"meeting":     NewExecCmdAction(cmdMeeting, false),
-	"terminal":    NewExecCmdAction(cmdTerminal, false),
-	"messenger":   NewExecCmdAction(cmdMessenger, false),
-	"app-left":    NewExecCmdAction(cmdLauncher, false),
-	"app-right":   NewExecCmdAction(cmdLauncher, false),
+	"myComputer": NewExecCmdAction(cmdMyComputer, false),
+	"documents":  NewExecCmdAction(cmdDocuments, false),
+	"eject":      NewExecCmdAction(cmdEject, false),
+	"calculator": NewExecCmdAction(cmdCalculator, false),
+	"calendar":   NewExecCmdAction(cmdCalendar, false),
+	"meeting":    NewExecCmdAction(cmdMeeting, false),
+	"terminal":   NewExecCmdAction(cmdTerminal, false),
+	"messenger":  NewExecCmdAction(cmdMessenger, false),
+	"appLeft":    NewExecCmdAction(cmdLauncher, false),
+	"appRight":   NewExecCmdAction(cmdLauncher, false),
 
 	// audio control
-	"audio-mute":         NewAudioCtrlAction(AudioSinkMuteToggle),
-	"audio-raise-volume": NewAudioCtrlAction(AudioSinkVolumeUp),
-	"audio-lower-volume": NewAudioCtrlAction(AudioSinkVolumeDown),
-	"audio-mic-mute":     NewAudioCtrlAction(AudioSourceMuteToggle),
+	"audioMute":        NewAudioCtrlAction(AudioSinkMuteToggle),
+	"audioRaiseVolume": NewAudioCtrlAction(AudioSinkVolumeUp),
+	"audioLowerVolume": NewAudioCtrlAction(AudioSinkVolumeDown),
+	"audioMicMute":     NewAudioCtrlAction(AudioSourceMuteToggle),
 
 	// media player control
-	"audio-play":    NewMediaPlayerCtrlAction(MediaPlayerPlay),
-	"audio-pause":   NewMediaPlayerCtrlAction(MediaPlayerPause),
-	"audio-stop":    NewMediaPlayerCtrlAction(MediaPlayerStop),
-	"audio-forward": NewMediaPlayerCtrlAction(MediaPlayerForword),
-	"audio-rewind":  NewMediaPlayerCtrlAction(MediaPlayerRewind),
-	"audio-prev":    NewMediaPlayerCtrlAction(MediaPlayerPrevious),
-	"audio-next":    NewMediaPlayerCtrlAction(MediaPlayerNext),
-	"audio-repeat":  NewMediaPlayerCtrlAction(MediaPlayerRepeat),
+	"audioPlay":    NewMediaPlayerCtrlAction(MediaPlayerPlay),
+	"audioPause":   NewMediaPlayerCtrlAction(MediaPlayerPause),
+	"audioStop":    NewMediaPlayerCtrlAction(MediaPlayerStop),
+	"audioForward": NewMediaPlayerCtrlAction(MediaPlayerForword),
+	"audioRewind":  NewMediaPlayerCtrlAction(MediaPlayerRewind),
+	"audioPrev":    NewMediaPlayerCtrlAction(MediaPlayerPrevious),
+	"audioNext":    NewMediaPlayerCtrlAction(MediaPlayerNext),
+	"audioRepeat":  NewMediaPlayerCtrlAction(MediaPlayerRepeat),
 	// TODO audio-random-play audio-cycle-track
 
 	// display control
-	"mon-brightness-up":   NewDisplayCtrlAction(MonitorBrightnessUp),
-	"mon-brightness-down": NewDisplayCtrlAction(MonitorBrightnessDown),
-	"display":             NewDisplayCtrlAction(DisplayModeSwitch),
-	"adjust-brightness":   NewDisplayCtrlAction(AdjustBrightnessSwitch),
+	"monBrightnessUp":   NewDisplayCtrlAction(MonitorBrightnessUp),
+	"monBrightnessDown": NewDisplayCtrlAction(MonitorBrightnessDown),
+	"display":           NewDisplayCtrlAction(DisplayModeSwitch),
+	"adjustBrightness":  NewDisplayCtrlAction(AdjustBrightnessSwitch),
 
 	// kbd light control
-	"kbd-light-on-off":    NewKbdBrightnessCtrlAction(KbdLightToggle),
-	"kbd-brightness-up":   NewKbdBrightnessCtrlAction(KbdLightBrightnessUp),
-	"kbd-brightness-down": NewKbdBrightnessCtrlAction(KbdLightBrightnessDown),
+	"kbdLightOnOff":     NewKbdBrightnessCtrlAction(KbdLightToggle),
+	"kbdBrightnessUp":   NewKbdBrightnessCtrlAction(KbdLightBrightnessUp),
+	"kbdBrightnessDown": NewKbdBrightnessCtrlAction(KbdLightBrightnessDown),
 
 	// touchpad
-	"touchpad-toggle": NewTouchpadCtrlAction(TouchpadToggle),
-	"touchpad-on":     NewTouchpadCtrlAction(TouchpadOn),
-	"touchpad-off":    NewTouchpadCtrlAction(TouchpadOff),
+	"touchpadToggle": NewTouchpadCtrlAction(TouchpadToggle),
+	"touchpadOn":     NewTouchpadCtrlAction(TouchpadOn),
+	"touchpadOff":    NewTouchpadCtrlAction(TouchpadOff),
 
 	// power
 	"suspend": &Action{Type: ActionTypeSystemSuspend},
 	"sleep":   &Action{Type: ActionTypeSystemSuspend},
-	"log-off": &Action{Type: ActionTypeSystemLogOff},
+	"logOff":  &Action{Type: ActionTypeSystemLogOff},
 	"away":    &Action{Type: ActionTypeSystemAway},
 
-	"web-cam": NewExecCmdAction(cmdCamera, false),
+	"webCam": NewExecCmdAction(cmdCamera, false),
 
 	// We do not need to deal with XF86Wlan key default,
 	// but can be specially by 'EnableNetworkController'

--- a/keybinding1/shortcuts/system_shortcut.go
+++ b/keybinding1/shortcuts/system_shortcut.go
@@ -21,7 +21,7 @@ const (
 )
 
 type SystemShortcut struct {
-	*GSettingsShortcut
+	*ShortcutObject
 	arg *ActionExecCmdArg
 }
 
@@ -75,40 +75,40 @@ func getSystemActionCmd(id string) string {
 			return cmd
 		}
 	}
-	if id == "lock-screen" && _useWayland {
-		id = "lock-screen-wayland"
+	if id == "lockScreen" && _useWayland {
+		id = "lockScreen-wayland"
 	}
 	return defaultSysActionCmdMap[id]
 }
 
 // key is id, value is commandline.
 var defaultSysActionCmdMap = map[string]string{
-	"launcher":       "dbus-send --print-reply --dest=org.deepin.dde.Launcher1 /org/deepin/dde/Launcher1 org.deepin.dde.Launcher1.Toggle",
-	"terminal":       "/usr/lib/deepin-daemon/default-terminal",
-	"terminal-quake": "dde-am deepin-terminal quake-mode",
-	"lock-screen":    "originmap=$(setxkbmap -query | grep option | awk -F ' ' '{print $2}');/usr/bin/setxkbmap -option grab:break_actions&&/usr/bin/xdotool key XF86Ungrab&&dbus-send --print-reply --dest=org.deepin.dde.LockFront1 /org/deepin/dde/LockFront1 org.deepin.dde.LockFront1.Show&&/usr/bin/setxkbmap -option $originmap",
+	"launcher":      "dbus-send --print-reply --dest=org.deepin.dde.Launcher1 /org/deepin/dde/Launcher1 org.deepin.dde.Launcher1.Toggle",
+	"terminal":      "/usr/lib/deepin-daemon/default-terminal",
+	"terminalQuake": "dde-am deepin-terminal quake-mode",
+	"lockScreen":    "originmap=$(setxkbmap -query | grep option | awk -F ' ' '{print $2}');/usr/bin/setxkbmap -option grab:break_actions&&/usr/bin/xdotool key XF86Ungrab&&dbus-send --print-reply --dest=org.deepin.dde.LockFront1 /org/deepin/dde/LockFront1 org.deepin.dde.LockFront1.Show&&/usr/bin/setxkbmap -option $originmap",
 	//wayland不能设置XF86Ungrab，否则会导致Bug-224309
-	"lock-screen-wayland":    "originmap=$(setxkbmap -query | grep option | awk -F ' ' '{print $2}');/usr/bin/setxkbmap -option grab:break_actions&&dbus-send --print-reply --dest=org.deepin.dde.LockFront1 /org/deepin/dde/LockFront1 org.deepin.dde.LockFront1.Show&&/usr/bin/setxkbmap -option $originmap",
-	"logout":                 "dbus-send --print-reply --dest=org.deepin.dde.ShutdownFront1 /org/deepin/dde/ShutdownFront1 org.deepin.dde.ShutdownFront1.Show",
-	"deepin-screen-recorder": "dbus-send --print-reply --dest=com.deepin.ScreenRecorder /com/deepin/ScreenRecorder com.deepin.ScreenRecorder.stopRecord",
-	"system-monitor":         "/usr/bin/deepin-system-monitor",
-	"color-picker":           "dbus-send --print-reply --dest=com.deepin.Picker /com/deepin/Picker com.deepin.Picker.Show",
+	"lockScreen-wayland":   "originmap=$(setxkbmap -query | grep option | awk -F ' ' '{print $2}');/usr/bin/setxkbmap -option grab:break_actions&&dbus-send --print-reply --dest=org.deepin.dde.LockFront1 /org/deepin/dde/LockFront1 org.deepin.dde.LockFront1.Show&&/usr/bin/setxkbmap -option $originmap",
+	"logout":               "dbus-send --print-reply --dest=org.deepin.dde.ShutdownFront1 /org/deepin/dde/ShutdownFront1 org.deepin.dde.ShutdownFront1.Show",
+	"deepinScreenRecorder": "dbus-send --print-reply --dest=com.deepin.ScreenRecorder /com/deepin/ScreenRecorder com.deepin.ScreenRecorder.stopRecord",
+	"systemMonitor":        "/usr/bin/deepin-system-monitor",
+	"colorPicker":          "dbus-send --print-reply --dest=com.deepin.Picker /com/deepin/Picker com.deepin.Picker.Show",
 	// screenshot actions:
 	"screenshot":             screenshotCmdPrefix + "StartScreenshot",
-	"screenshot-fullscreen":  screenshotCmdPrefix + "FullscreenScreenshot",
-	"screenshot-window":      screenshotCmdPrefix + "TopWindowScreenshot",
-	"screenshot-delayed":     screenshotCmdPrefix + "DelayScreenshot int64:5",
-	"screenshot-ocr":         screenshotCmdPrefix + "OcrScreenshot",
-	"screenshot-scroll":      screenshotCmdPrefix + "ScrollScreenshot",
-	"file-manager":           "/usr/lib/deepin-daemon/default-file-manager",
-	"disable-touchpad":       "gsettings set com.deepin.dde.touchpad touchpad-enabled false",
-	"wm-switcher":            "dbus-send --type=method_call --dest=org.deepin.dde.WMSwitcher1 /org/deepin/dde/WMSwitcher1 org.deepin.dde.WMSwitcher1.RequestSwitchWM",
-	"turn-off-screen":        "sleep 0.5; xset dpms force off",
-	"notification-center":    "dbus-send --print-reply --dest=org.deepin.dde.Osd1 /org/deepin/dde/shell/notification/center org.deepin.dde.shell.notification.center.Toggle",
+	"screenshotFullscreen":   screenshotCmdPrefix + "FullscreenScreenshot",
+	"screenshotWindow":       screenshotCmdPrefix + "TopWindowScreenshot",
+	"screenshotDelayed":      screenshotCmdPrefix + "DelayScreenshot int64:5",
+	"screenshotOcr":          screenshotCmdPrefix + "OcrScreenshot",
+	"screenshotScroll":       screenshotCmdPrefix + "ScrollScreenshot",
+	"fileManager":            "/usr/lib/deepin-daemon/default-file-manager",
+	"disableTouchpad":        "gsettings set com.deepin.dde.touchpad touchpad-enabled false",
+	"wmSwitcher":             "dbus-send --type=method_call --dest=org.deepin.dde.WMSwitcher1 /org/deepin/dde/WMSwitcher1 org.deepin.dde.WMSwitcher1.RequestSwitchWM",
+	"turnOffScreen":          "sleep 0.5; xset dpms force off",
+	"notificationCenter":     "dbus-send --print-reply --dest=org.deepin.dde.Osd1 /org/deepin/dde/shell/notification/center org.deepin.dde.shell.notification.center.Toggle",
 	"clipboard":              "dbus-send --print-reply --dest=org.deepin.dde.Clipboard1 /org/deepin/dde/Clipboard1 org.deepin.dde.Clipboard1.Toggle; dbus-send --print-reply --dest=org.deepin.dde.Launcher1 /org/deepin/dde/Launcher1 org.deepin.dde.Launcher1.Hide",
-	"global-search":          "/usr/libexec/dde-daemon/keybinding/shortcut-dde-grand-search.sh",
+	"globalSearch":           "/usr/libexec/dde-daemon/keybinding/shortcut-dde-grand-search.sh",
 	"switch-next-kbd-layout": "dbus-send --print-reply --dest=org.deepin.dde.Keybinding1 /org/deepin/dde/InputDevice1/Keyboard org.deepin.dde.InputDevice1.Keyboard.ToggleNextLayout",
-	"switch-monitors":        "/usr/libexec/dde-daemon/keybinding/shortcut-dde-switch-monitors.sh",
+	"switchMonitors":         "/usr/libexec/dde-daemon/keybinding/shortcut-dde-switch-monitors.sh",
 	// cmd
 	"calculator": "/usr/bin/deepin-calculator",
 	"search":     "/usr/libexec/dde-daemon/keybinding/shortcut-dde-grand-search.sh",

--- a/keybinding1/special_keycode.go
+++ b/keybinding1/special_keycode.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/godbus/dbus/v5"
+	"github.com/linuxdeepin/dde-daemon/keybinding1/constants"
 	power "github.com/linuxdeepin/go-dbus-factory/system/org.deepin.dde.power1"
 )
 
@@ -262,7 +263,11 @@ func (m *Manager) handleSwitchPowerMode() {
 		return
 	}
 
-	bHighPerformanceEnabled := m.gsPower.GetBoolean("high-performance-enabled")
+	bHighPerformanceEnabledValue, err := m.powerConfigMgr.Value(0, constants.DSettingsKeyHighPerformanceEnabled)
+	if err != nil {
+		logger.Warning(err)
+	}
+	bHighPerformanceEnabled := bHighPerformanceEnabledValue.Value().(bool)
 	logger.Info(" handleSwitchPowerMode, isHighPerformanceSupported : ", isHighPerformanceSupported)
 
 	targetMode := ""
@@ -340,12 +345,24 @@ func (m *Manager) handlePower() {
 		logger.Warning(err)
 	}
 
-	screenBlackLock := m.gsPower.GetBoolean("screen-black-lock")
+	screenBlackLockValue, err := m.powerConfigMgr.Value(0, constants.DSettingsKeyScreenBlackLock)
+	if err != nil {
+		logger.Warning(err)
+	}
 
+	screenBlackLock := screenBlackLockValue.Value().(bool)
 	if onBattery {
-		powerPressAction = m.gsPower.GetEnum("battery-press-power-button")
+		powerPressActionValue, err := m.powerConfigMgr.Value(0, constants.DSettingsKeyBatteryPressPowerBtnAction)
+		if err != nil {
+			logger.Warning(err)
+		}
+		powerPressAction = int32(powerPressActionValue.Value().(int64))
 	} else {
-		powerPressAction = m.gsPower.GetEnum("line-power-press-power-button")
+		powerPressActionValue, err := m.powerConfigMgr.Value(0, constants.DSettingsKeyLinePowerPressPowerBtnAction)
+		if err != nil {
+			logger.Warning(err)
+		}
+		powerPressAction = int32(powerPressActionValue.Value().(int64))
 	}
 	switch powerPressAction {
 	case powerActionShutdown:

--- a/misc/dde-daemon/keybinding/system_actions.json
+++ b/misc/dde-daemon/keybinding/system_actions.json
@@ -9,11 +9,11 @@
             "Key": "terminal"
         },
         {
-            "Key": "deepin-screen-recorder",
+            "Key": "deepinScreenRecorder",
             "Action": "dbus-send --print-reply --dest=com.deepin.ScreenRecorder /com/deepin/ScreenRecorder com.deepin.ScreenRecorder.stopRecord"
         },
         {
-            "Key": "system-monitor",
+            "Key": "systemMonitor",
             "Action": "dde-am deepin-system-monitor"
         },
         {
@@ -22,7 +22,7 @@
         },
         {
             "Action": "/usr/lib/deepin-daemon/dde-lock.sh",
-            "Key": "lock-screen"
+            "Key": "lockScreen"
         },
         {
             "Action": "dbus-send --print-reply --dest=org.deepin.dde.ShutdownFront1 /org/deepin/dde/ShutdownFront1 org.deepin.dde.ShutdownFront1.Show",
@@ -30,7 +30,7 @@
         },
         {
             "Action": "deepin-terminal --quake-mode",
-            "Key": "terminal-quake"
+            "Key": "terminalQuake"
         },
         {
             "Action": "dbus-send --print-reply --dest=com.deepin.Screenshot /com/deepin/Screenshot com.deepin.Screenshot.StartScreenshot",
@@ -38,38 +38,38 @@
         },
         {
             "Action": "dbus-send --print-reply --dest=com.deepin.Screenshot /com/deepin/Screenshot com.deepin.Screenshot.FullscreenScreenshot",
-            "Key": "screenshot-fullscreen"
+            "Key": "screenshotFullscreen"
         },
         {
             "Action": "dbus-send --print-reply --dest=com.deepin.Screenshot /com/deepin/Screenshot com.deepin.Screenshot.TopWindowScreenshot",
-            "Key": "screenshot-window"
+            "Key": "screenshotWindow"
         },
         {
             "Action": "dbus-send --print-reply --dest=com.deepin.Screenshot /com/deepin/Screenshot com.deepin.Screenshot.DelayScreenshot int64:5",
-            "Key": "screenshot-delayed"
+            "Key": "screenshotDelayed"
         },
         {
             "Action": "/usr/lib/deepin-daemon/default-file-manager",
-            "Key": "file-manager"
+            "Key": "fileManager"
         },
         {
             "Action": "gsettings set com.deepin.dde.touchpad touchpad-enabled false",
-            "Key": "disable-touchpad"
+            "Key": "disableTouchpad"
         },
         {
             "Action": "dbus-send --type=method_call --dest=org.deepin.dde.WMSwitcher1 /org/deepin/dde/WMSwitcher1 org.deepin.dde.WMSwitcher1.RequestSwitchWM",
-            "Key": "wm-switcher"
+            "Key": "wmSwitcher"
         },
         {
             "Action": "sleep 0.5; xset dpms force off",
-            "Key": "turn-off-screen"
+            "Key": "turnOffScreen"
         },
         {
-            "Key": "text-to-speech",
+            "Key": "textToSpeech",
             "Action": "/usr/share/uos-ai-assistant/shell/tts.sh"
         },
         {
-            "Key": "speech-to-text",
+            "Key": "speechToText",
             "Action": "dbus-send  --print-reply --dest=com.iflytek.aiassistant /aiassistant/deepinmain com.iflytek.aiassistant.mainWindow.SpeechToText"
         },
         {
@@ -81,15 +81,15 @@
             "Action": "/usr/share/uos-ai-assistant/shell/translation.sh"
         },
 		{
-            "key":"notification-center",
+            "key":"notificationCenter",
             "Action":"dbus-send --print-reply --dest=org.deepin.dde.Widgets1 /org/deepin/dde/Widgets1 org.deepin.dde.Widgets1.Toggle"
         },
         {
-            "Key": "screenshot-ocr",
+            "Key": "screenshotOcr",
             "Action": "dbus-send --print-reply --dest=com.deepin.Screenshot /com/deepin/Screenshot com.deepin.Screenshot.OcrScreenshot"
         },
 		{
-            "key":"screenshot-scroll",
+            "key":"screenshotScroll",
             "Action": "dbus-send --print-reply --dest=com.deepin.Screenshot /com/deepin/Screenshot com.deepin.Screenshot.ScrollScreenshot"
         }
 

--- a/misc/dsg-configs/org.deepin.dde.daemon.keybinding.enable.json
+++ b/misc/dsg-configs/org.deepin.dde.daemon.keybinding.enable.json
@@ -1,0 +1,226 @@
+{
+    "magic": "dsg.config.meta",
+    "version": "1.0",
+    "contents": {
+        "launcher": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "launcher",
+            "name[zh_CN]": "启用/禁用启动器",
+            "description": "enabled/disable launcher",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "screenshotDelayed": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "screenshotDelayed",
+            "name[zh_CN]": "启用/禁用延时截图",
+            "description": "enabled/disable screenshotDelayed",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "screenshotFullscreen": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "screenshotFullscreen",
+            "name[zh_CN]": "启用/禁用全屏截图",
+            "description": "enabled/disable screenshotFullscreen",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "deepinScreenRecorder": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "deepinScreenRecorder",
+            "name[zh_CN]": "启用/禁用屏幕录制",
+            "description": "enabled/disable deepinScreenRecorder",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "translation": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "translation",
+            "name[zh_CN]": "启用/禁用翻译",
+            "description": "enabled/disable translation",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "screenshot": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "screenshot",
+            "name[zh_CN]": "启用/禁用截图",
+            "description": "enabled/disable screenshot",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "logout": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "logout",
+            "name[zh_CN]": "启用/禁用注销",
+            "description": "enabled/disable logout",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "lockScreen": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "lockScreen",
+            "name[zh_CN]": "启用/禁用锁定屏幕",
+            "description": "enabled/disable lockScreen",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "clipboard": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "clipboard",
+            "name[zh_CN]": "启用/禁用剪贴板",
+            "description": "enabled/disable clipboard",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "notificationCenter": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "notificationCenter",
+            "name[zh_CN]": "启用/禁用通知中心",
+            "description": "enabled/disable notificationCenter",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "disableTouchpad": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "disableTouchpad",
+            "name[zh_CN]": "启用/禁用触摸板禁用功能",
+            "description": "enabled/disable disableTouchpad",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "screenshotWindow": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "screenshotWindow",
+            "name[zh_CN]": "启用/禁用窗口截图",
+            "description": "enabled/disable screenshotWindow",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "turnOffScreen": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "turnOffScreen",
+            "name[zh_CN]": "启用/禁用关闭屏幕",
+            "description": "enabled/disable turnOffScreen",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "terminal": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "terminal",
+            "name[zh_CN]": "启用/禁用终端",
+            "description": "enabled/disable terminal",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "fileManager": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "fileManager",
+            "name[zh_CN]": "启用/禁用文件管理器",
+            "description": "enabled/disable fileManager",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "systemMonitor": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "systemMonitor",
+            "name[zh_CN]": "启用/禁用系统监视器",
+            "description": "enabled/disable systemMonitor",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "globalSearch": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "globalSearch",
+            "name[zh_CN]": "启用/禁用全局搜索",
+            "description": "enabled/disable globalSearch",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "textToSpeech": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "textToSpeech",
+            "name[zh_CN]": "启用/禁用语音朗读",
+            "description": "enabled/disable textToSpeech",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "speechToText": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "speechToText",
+            "name[zh_CN]": "启用/禁用语音转文字",
+            "description": "enabled/disable speechToText",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "terminalQuake": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "terminalQuake",
+            "name[zh_CN]": "启用/禁用雷神终端",
+            "description": "enabled/disable terminalQuake",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "wmSwitcher": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "wmSwitcher",
+            "name[zh_CN]": "启用/禁用窗口特效切换",
+            "description": "enabled/disable wmSwitcher",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "upperLayerWlan": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "upperLayerWlan",
+            "name[zh_CN]": "启用/禁用上层无线网络",
+            "description": "enable or disable the wireless network in upper layer",
+            "permissions": "readwrite",
+            "visibility": "private"
+        }
+    }
+}

--- a/misc/dsg-configs/org.deepin.dde.daemon.keybinding.json
+++ b/misc/dsg-configs/org.deepin.dde.daemon.keybinding.json
@@ -12,7 +12,7 @@
       "permissions": "readwrite",
       "visibility": "private"
     },
-    "need-xrandr-q-devices": {
+    "needXrandrQDevices": {
       "value": [
         ""
       ],

--- a/misc/dsg-configs/org.deepin.dde.daemon.keybinding.mediakey.json
+++ b/misc/dsg-configs/org.deepin.dde.daemon.keybinding.mediakey.json
@@ -1,0 +1,726 @@
+{
+    "magic": "dsg.config.meta",
+    "version": "1.0",
+    "contents": {
+        "monBrightnessUp": {
+            "value": ["XF86MonBrightnessUp"],
+            "serial": 0,
+            "flags": [],
+            "name": "monBrightnessUp",
+            "name[zh_CN]": "显示器亮度增加",
+            "description": "Monitor/panel brightness",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "monBrightnessDown": {
+            "value": ["XF86MonBrightnessDown"],
+            "serial": 0,
+            "flags": [],
+            "name": "monBrightnessDown",
+            "name[zh_CN]": "显示器亮度减少",
+            "description": "Monitor/panel brightness",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "kbdLightOnOff": {
+            "value": ["XF86KbdLightOnOff"],
+            "serial": 0,
+            "flags": [],
+            "name": "kbdLightOnOff",
+            "name[zh_CN]": "键盘背光开关",
+            "description": "Keyboards may be lit",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "kbdBrightnessUp": {
+            "value": ["XF86KbdBrightnessUp"],
+            "serial": 0,
+            "flags": [],
+            "name": "kbdBrightnessUp",
+            "name[zh_CN]": "键盘背光增加",
+            "description": "Keyboards may be lit",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "kbdBrightnessDown": {
+            "value": ["XF86KbdBrightnessDown"],
+            "serial": 0,
+            "flags": [],
+            "name": "kbdBrightnessDown",
+            "name[zh_CN]": "键盘背光减少",
+            "description": "Keyboards may be lit",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "audioLowerVolume": {
+            "value": ["XF86AudioLowerVolume"],
+            "serial": 0,
+            "flags": [],
+            "name": "audioLowerVolume",
+            "name[zh_CN]": "音量减少",
+            "description": "Volume control down",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "audioMute": {
+            "value": ["XF86AudioMute"],
+            "serial": 0,
+            "flags": [],
+            "name": "audioMute",
+            "name[zh_CN]": "静音",
+            "description": "Mute sound from the system",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "audioRaiseVolume": {
+            "value": ["XF86AudioRaiseVolume"],
+            "serial": 0,
+            "flags": [],
+            "name": "audioRaiseVolume",
+            "name[zh_CN]": "音量增加",
+            "description": "Volume control up",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "audioPlay": {
+            "value": ["XF86AudioPlay"],
+            "serial": 0,
+            "flags": [],
+            "name": "audioPlay",
+            "name[zh_CN]": "播放",
+            "description": "Start playing of audio >",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "audioStop": {
+            "value": ["XF86AudioStop"],
+            "serial": 0,
+            "flags": [],
+            "name": "audioStop",
+            "name[zh_CN]": "停止",
+            "description": "Stop playing audio",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "audioPrev": {
+            "value": ["XF86AudioPrev"],
+            "serial": 0,
+            "flags": [],
+            "name": "audioPrev",
+            "name[zh_CN]": "上一曲",
+            "description": "Previous track",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "audioNext": {
+            "value": ["XF86AudioNext"],
+            "serial": 0,
+            "flags": [],
+            "name": "audioNext",
+            "name[zh_CN]": "下一曲",
+            "description": "Next track",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "homePage": {
+            "value": ["XF86HomePage"],
+            "serial": 0,
+            "flags": [],
+            "name": "homePage",
+            "name[zh_CN]": "主页",
+            "description": "Display user's home page",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "mail": {
+            "value": ["XF86Mail"],
+            "serial": 0,
+            "flags": [],
+            "name": "mail",
+            "name[zh_CN]": "邮件",
+            "description": "Invoke user's mail program",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "search": {
+            "value": ["XF86Search"],
+            "serial": 0,
+            "flags": [],
+            "name": "search",
+            "name[zh_CN]": "搜索",
+            "description": "Search",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "audioRecord": {
+            "value": ["XF86AudioRecord"],
+            "serial": 0,
+            "flags": [],
+            "name": "audioRecord",
+            "name[zh_CN]": "录音",
+            "description": "Record audio application",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "calculator": {
+            "value": ["XF86Calculator"],
+            "serial": 0,
+            "flags": [],
+            "name": "calculator",
+            "name[zh_CN]": "计算器",
+            "description": "Invoke calculator program",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "back": {
+            "value": ["XF86Back"],
+            "serial": 0,
+            "flags": [],
+            "name": "back",
+            "name[zh_CN]": "后退",
+            "description": "Like back on a browser",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "forward": {
+            "value": ["XF86Forward"],
+            "serial": 0,
+            "flags": [],
+            "name": "forward",
+            "name[zh_CN]": "前进",
+            "description": "Like forward on a browser",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "powerOff": {
+            "value": ["XF86PowerOff"],
+            "serial": 0,
+            "flags": [],
+            "name": "powerOff",
+            "name[zh_CN]": "关机",
+            "description": "Power off system entirely",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "wakeUp": {
+            "value": ["XF86WakeUp"],
+            "serial": 0,
+            "flags": [],
+            "name": "wakeUp",
+            "name[zh_CN]": "唤醒",
+            "description": "Wake up system from sleep",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "eject": {
+            "value": ["XF86Eject"],
+            "serial": 0,
+            "flags": [],
+            "name": "eject",
+            "name[zh_CN]": "弹出",
+            "description": "Eject device (e.g. DVD)",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "screenSaver": {
+            "value": ["XF86ScreenSaver"],
+            "serial": 0,
+            "flags": [],
+            "name": "screenSaver",
+            "name[zh_CN]": "屏幕保护",
+            "description": "Invoke screensaver",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "www": {
+            "value": ["XF86WWW"],
+            "serial": 0,
+            "flags": [],
+            "name": "www",
+            "name[zh_CN]": "网页浏览器",
+            "description": "Invoke web browser",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "sleep": {
+            "value": ["XF86Sleep"],
+            "serial": 0,
+            "flags": [],
+            "name": "sleep",
+            "name[zh_CN]": "睡眠",
+            "description": "Put system to sleep",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "favorites": {
+            "value": ["XF86Favorites"],
+            "serial": 0,
+            "flags": [],
+            "name": "favorites",
+            "name[zh_CN]": "收藏夹",
+            "description": "Show favorite locations",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "audioPause": {
+            "value": ["XF86AudioPause"],
+            "serial": 0,
+            "flags": [],
+            "name": "audioPause",
+            "name[zh_CN]": "暂停",
+            "description": "Pause audio playing",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "audioMedia": {
+            "value": ["XF86AudioMedia"],
+            "serial": 0,
+            "flags": [],
+            "name": "audioMedia",
+            "name[zh_CN]": "媒体",
+            "description": "Launch media collection app",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "myComputer": {
+            "value": ["XF86MyComputer"],
+            "serial": 0,
+            "flags": [],
+            "name": "myComputer",
+            "name[zh_CN]": "我的电脑",
+            "description": "Display \"My Computer\" window",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "shop": {
+            "value": ["XF86Shop"],
+            "serial": 0,
+            "flags": [],
+            "name": "shop",
+            "name[zh_CN]": "购物",
+            "description": "Display shopping web site",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "finance": {
+            "value": ["XF86Finance"],
+            "serial": 0,
+            "flags": [],
+            "name": "finance",
+            "name[zh_CN]": "财务",
+            "description": "Display financial site",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "audioRewind": {
+            "value": ["XF86AudioRewind"],
+            "serial": 0,
+            "flags": [],
+            "name": "audioRewind",
+            "name[zh_CN]": "倒带",
+            "description": "\"rewind\" audio track",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "close": {
+            "value": ["XF86Close"],
+            "serial": 0,
+            "flags": [],
+            "name": "close",
+            "name[zh_CN]": "关闭",
+            "description": "Close window",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "mediaClose": {
+            "value": ["XF86Close"],
+            "serial": 0,
+            "flags": [],
+            "name": "mediaClose",
+            "name[zh_CN]": "媒体关闭",
+            "description": "Close window",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "copy": {
+            "value": ["XF86Copy"],
+            "serial": 0,
+            "flags": [],
+            "name": "copy",
+            "name[zh_CN]": "复制",
+            "description": "Copy selection",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "cut": {
+            "value": ["XF86Cut"],
+            "serial": 0,
+            "flags": [],
+            "name": "cut",
+            "name[zh_CN]": "剪切",
+            "description": "Cut selection",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "display": {
+            "value": ["XF86Display"],
+            "serial": 0,
+            "flags": [],
+            "name": "display",
+            "name[zh_CN]": "显示器切换",
+            "description": "Output switch key",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "dos": {
+            "value": ["XF86DOS"],
+            "serial": 0,
+            "flags": [],
+            "name": "dos",
+            "name[zh_CN]": "DOS",
+            "description": "Launch DOS (emulation)",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "documents": {
+            "value": ["XF86Documents"],
+            "serial": 0,
+            "flags": [],
+            "name": "documents",
+            "name[zh_CN]": "文档",
+            "description": "Open documents window",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "explorer": {
+            "value": ["XF86Explorer"],
+            "serial": 0,
+            "flags": [],
+            "name": "explorer",
+            "name[zh_CN]": "文件浏览器",
+            "description": "Launch file explorer",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "game": {
+            "value": ["XF86Game"],
+            "serial": 0,
+            "flags": [],
+            "name": "game",
+            "name[zh_CN]": "游戏",
+            "description": "Launch game",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "go": {
+            "value": ["XF86Go"],
+            "serial": 0,
+            "flags": [],
+            "name": "go",
+            "name[zh_CN]": "跳转",
+            "description": "Go to URL",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "menuKb": {
+            "value": ["XF86MenuKB"],
+            "serial": 0,
+            "flags": [],
+            "name": "menuKb",
+            "name[zh_CN]": "菜单键盘",
+            "description": "distingush keyboard from PB",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "new": {
+            "value": ["XF86New"],
+            "serial": 0,
+            "flags": [],
+            "name": "new",
+            "name[zh_CN]": "新建",
+            "description": "New (folder, document...",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "open": {
+            "value": ["XF86Open"],
+            "serial": 0,
+            "flags": [],
+            "name": "open",
+            "name[zh_CN]": "打开",
+            "description": "Open",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "paste": {
+            "value": ["XF86Paste"],
+            "serial": 0,
+            "flags": [],
+            "name": "paste",
+            "name[zh_CN]": "粘贴",
+            "description": "Paste",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "phone": {
+            "value": ["XF86Phone"],
+            "serial": 0,
+            "flags": [],
+            "name": "phone",
+            "name[zh_CN]": "电话",
+            "description": "Launch phone; dial number",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "reply": {
+            "value": ["XF86Reply"],
+            "serial": 0,
+            "flags": [],
+            "name": "reply",
+            "name[zh_CN]": "回复",
+            "description": "Reply e.g., mail",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "reload": {
+            "value": ["XF86Reload"],
+            "serial": 0,
+            "flags": [],
+            "name": "reload",
+            "name[zh_CN]": "重新加载",
+            "description": "Reload web page, file, etc.",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "rotateWindows": {
+            "value": ["XF86RotateWindows"],
+            "serial": 0,
+            "flags": [],
+            "name": "rotateWindows",
+            "name[zh_CN]": "旋转窗口",
+            "description": "Rotate windows e.g. xrandr",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "save": {
+            "value": ["XF86Save"],
+            "serial": 0,
+            "flags": [],
+            "name": "save",
+            "name[zh_CN]": "保存",
+            "description": "Save (file, document, state",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "scrollUp": {
+            "value": ["XF86ScrollUp"],
+            "serial": 0,
+            "flags": [],
+            "name": "scrollUp",
+            "name[zh_CN]": "向上滚动",
+            "description": "Scroll window/contents up",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "scrollDown": {
+            "value": ["XF86ScrollDown"],
+            "serial": 0,
+            "flags": [],
+            "name": "scrollDown",
+            "name[zh_CN]": "向下滚动",
+            "description": "Scrool window/contentd down",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "send": {
+            "value": ["XF86Send"],
+            "serial": 0,
+            "flags": [],
+            "name": "send",
+            "name[zh_CN]": "发送",
+            "description": "Send mail, file, object",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "taskPane": {
+            "value": ["XF86TaskPane"],
+            "serial": 0,
+            "flags": [],
+            "name": "taskPane",
+            "name[zh_CN]": "任务面板",
+            "description": "Show tasks",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "tools": {
+            "value": ["XF86Tools"],
+            "serial": 0,
+            "flags": [],
+            "name": "tools",
+            "name[zh_CN]": "工具",
+            "description": "toolbox of desktop/app.",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "xfer": {
+            "value": ["XF86Xfer"],
+            "serial": 0,
+            "flags": [],
+            "name": "xfer",
+            "name[zh_CN]": "传输",
+            "description": "",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "away": {
+            "value": ["XF86Away"],
+            "serial": 0,
+            "flags": [],
+            "name": "away",
+            "name[zh_CN]": "离开",
+            "description": "Lock user",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "messenger": {
+            "value": ["XF86Messenger"],
+            "serial": 0,
+            "flags": [],
+            "name": "messenger",
+            "name[zh_CN]": "即时消息",
+            "description": "as in instant messaging",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "webCam": {
+            "value": ["XF86WebCam"],
+            "serial": 0,
+            "flags": [],
+            "name": "webCam",
+            "name[zh_CN]": "网络摄像头",
+            "description": "Launch web camera app.",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "mailForward": {
+            "value": ["XF86MailForward"],
+            "serial": 0,
+            "flags": [],
+            "name": "mailForward",
+            "name[zh_CN]": "邮件转发",
+            "description": "Forward in mail",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "battery": {
+            "value": ["XF86Battery"],
+            "serial": 0,
+            "flags": [],
+            "name": "battery",
+            "name[zh_CN]": "电池",
+            "description": "Display battery information",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "wlan": {
+            "value": ["XF86WLAN"],
+            "serial": 0,
+            "flags": [],
+            "name": "wlan",
+            "name[zh_CN]": "无线网络",
+            "description": "Enable/disable WLAN",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "audioForward": {
+            "value": ["XF86AudioForward"],
+            "serial": 0,
+            "flags": [],
+            "name": "audioForward",
+            "name[zh_CN]": "快进",
+            "description": "fast-forward audio track",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "suspend": {
+            "value": ["XF86Suspend"],
+            "serial": 0,
+            "flags": [],
+            "name": "suspend",
+            "name[zh_CN]": "挂起",
+            "description": "Sleep to RAM",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "touchpadToggle": {
+            "value": ["XF86TouchpadToggle"],
+            "serial": 0,
+            "flags": [],
+            "name": "touchpadToggle",
+            "name[zh_CN]": "触摸板切换",
+            "description": "Toggle between touchpad/trackstick",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "touchpadOn": {
+            "value": ["XF86TouchpadOn"],
+            "serial": 0,
+            "flags": [],
+            "name": "touchpadOn",
+            "name[zh_CN]": "触摸板开启",
+            "description": "The touchpad got switched on",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "touchpadOff": {
+            "value": ["XF86TouchpadOff"],
+            "serial": 0,
+            "flags": [],
+            "name": "touchpadOff",
+            "name[zh_CN]": "触摸板关闭",
+            "description": "The touchpad got switched off",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "audioMicMute": {
+            "value": ["XF86AudioMicMute"],
+            "serial": 0,
+            "flags": [],
+            "name": "audioMicMute",
+            "name[zh_CN]": "麦克风静音",
+            "description": "Mute the Mic from the system",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "airplaneModeToggle": {
+            "value": ["XF86RFKill"],
+            "serial": 0,
+            "flags": [],
+            "name": "airplaneModeToggle",
+            "name[zh_CN]": "飞行模式切换",
+            "description": "",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "capslock": {
+            "value": ["Caps_Lock"],
+            "serial": 0,
+            "flags": [],
+            "name": "capslock",
+            "name[zh_CN]": "大写锁定",
+            "description": "",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "numlock": {
+            "value": ["Num_Lock"],
+            "serial": 0,
+            "flags": [],
+            "name": "numlock",
+            "name[zh_CN]": "数字锁定",
+            "description": "",
+            "permissions": "readwrite",
+            "visibility": "private"
+        }
+    }
+}

--- a/misc/dsg-configs/org.deepin.dde.daemon.keybinding.platform.json
+++ b/misc/dsg-configs/org.deepin.dde.daemon.keybinding.platform.json
@@ -1,0 +1,15 @@
+{
+    "magic": "dsg.config.meta",
+    "version": "1.0",
+    "contents": {
+        "globalSearch": {
+            "value": ["All"],
+            "serial": 0,
+            "flags": [],
+            "name": "globalSearch",
+            "description": "filemanager global search",
+            "permissions": "readwrite",
+            "visibility": "private"
+        }
+    }
+}

--- a/misc/dsg-configs/org.deepin.dde.daemon.keybinding.system.json
+++ b/misc/dsg-configs/org.deepin.dde.daemon.keybinding.system.json
@@ -1,0 +1,246 @@
+{
+    "magic": "dsg.config.meta",
+    "version": "1.0",
+    "contents": {
+        "launcher": {
+            "value": ["Super_L","Super_R"],
+            "serial": 0,
+            "flags": [],
+            "name": "launcher",
+            "name[zh_CN]": "显示隐藏启动器",
+            "description": "Show or hide dde-launcher",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "switchMonitors": {
+            "value": ["<Super>P"],
+            "serial": 0,
+            "flags": [],
+            "name": "switchMonitors",
+            "name[zh_CN]": "切换显示器",
+            "description": "allow switch monitors display mode",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "terminal": {
+            "value": ["<Control><Alt>T"],
+            "serial": 0,
+            "flags": [],
+            "name": "terminal",
+            "name[zh_CN]": "启动终端",
+            "description": "Launch default terminal emulator",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "deepinScreenRecorder": {
+            "value": ["<Control><Alt>R"],
+            "serial": 0,
+            "flags": [],
+            "name": "deepinScreenRecorder",
+            "name[zh_CN]": "启动屏幕录制",
+            "description": "Launch screen recorder",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "systemMonitor": {
+            "value": ["<Control><Alt>Escape"],
+            "serial": 0,
+            "flags": [],
+            "name": "systemMonitor",
+            "name[zh_CN]": "启动系统监视器",
+            "description": "Launch system monitor",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "lockScreen": {
+            "value": ["<Super>L"],
+            "serial": 0,
+            "flags": [],
+            "name": "lockScreen",
+            "name[zh_CN]": "锁定屏幕",
+            "description": "Lock screen",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "logout": {
+            "value": ["<Control><Alt>Delete","<Control><Alt>KP_Delete","<Control><Alt>."],
+            "serial": 0,
+            "flags": [],
+            "name": "logout",
+            "name[zh_CN]": "显示关机界面",
+            "description": "Show shutdown interface",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "terminalQuake": {
+            "value": ["<Alt>F2"],
+            "serial": 0,
+            "flags": [],
+            "name": "terminalQuake",
+            "name[zh_CN]": "雷神终端",
+            "description": "Show or hide quake mode deepin terminal",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "screenshot": {
+            "value": ["<Control><Alt>A"],
+            "serial": 0,
+            "flags": [],
+            "name": "screenshot",
+            "name[zh_CN]": "截图",
+            "description": "Take a screenshot",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "screenshotFullscreen": {
+            "value": ["Print"],
+            "serial": 0,
+            "flags": [],
+            "name": "screenshotFullscreen",
+            "name[zh_CN]": "全屏截图",
+            "description": "Take a screenshot the whole screen",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "screenshotWindow": {
+            "value": ["<Alt>Print"],
+            "serial": 0,
+            "flags": [],
+            "name": "screenshotWindow",
+            "name[zh_CN]": "窗口截图",
+            "description": "Take a screenshot of the most top window",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "screenshotDelayed": {
+            "value": ["<Control>Print"],
+            "serial": 0,
+            "flags": [],
+            "name": "screenshotDelayed",
+            "name[zh_CN]": "延时截图",
+            "description": "Take a screenshot after a few seconds",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "fileManager": {
+            "value": ["<Super>E"],
+            "serial": 0,
+            "flags": [],
+            "name": "fileManager",
+            "name[zh_CN]": "启动文件管理器",
+            "description": "Launch default file manager",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "disableTouchpad": {
+            "value": [""],
+            "serial": 0,
+            "flags": [],
+            "name": "disableTouchpad",
+            "name[zh_CN]": "禁用触摸板",
+            "description": "Disable touchpad",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "wmSwitcher": {
+            "value": ["<Shift><Super>Tab"],
+            "serial": 0,
+            "flags": [],
+            "name": "wmSwitcher",
+            "name[zh_CN]": "切换窗口特效",
+            "description": "Switch window effects",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "turnOffScreen": {
+            "value": ["<Shift><Super>L"],
+            "serial": 0,
+            "flags": [],
+            "name": "turnOffScreen",
+            "name[zh_CN]": "关闭屏幕",
+            "description": "Turn off the screen",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "textToSpeech": {
+            "value": ["<Control><Alt>P"],
+            "serial": 0,
+            "flags": [],
+            "name": "textToSpeech",
+            "name[zh_CN]": "语音朗读",
+            "description": "Text to speech",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "speechToText": {
+            "value": ["<Control><Alt>D"],
+            "serial": 0,
+            "flags": [],
+            "name": "speechToText",
+            "name[zh_CN]": "语音转文字",
+            "description": "Speech to text",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "clipboard": {
+            "value": ["<Super>V","<Meta>V"],
+            "serial": 0,
+            "flags": [],
+            "name": "clipboard",
+            "name[zh_CN]": "显示剪贴板",
+            "description": "Show clipboard",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "translation": {
+            "value": ["<Control><Alt>U"],
+            "serial": 0,
+            "flags": [],
+            "name": "translation",
+            "name[zh_CN]": "翻译",
+            "description": "Translation",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "notificationCenter": {
+            "value": ["<Super>M","<Meta>M"],
+            "serial": 0,
+            "flags": [],
+            "name": "notificationCenter",
+            "name[zh_CN]": "打开通知中心",
+            "description": "open notification center",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "screenshotOcr": {
+            "value": ["<Control><Alt>C"],
+            "serial": 0,
+            "flags": [],
+            "name": "screenshotOcr",
+            "name[zh_CN]": "OCR截图",
+            "description": "Take a screenshot for ocr",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "screenshotScroll": {
+            "value": ["<Control><Alt>I"],
+            "serial": 0,
+            "flags": [],
+            "name": "screenshotScroll",
+            "name[zh_CN]": "滚动截图",
+            "description": "Take a screenshot the scroll screen",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "globalSearch": {
+            "value": ["<Shift>space"],
+            "serial": 0,
+            "flags": [],
+            "name": "globalSearch",
+            "name[zh_CN]": "全局搜索",
+            "description": "filemanager global search",
+            "permissions": "readwrite",
+            "visibility": "private"
+        }
+    }
+}

--- a/misc/dsg-configs/org.deepin.dde.daemon.keybinding.wrap.gnome.wm.json
+++ b/misc/dsg-configs/org.deepin.dde.daemon.keybinding.wrap.gnome.wm.json
@@ -1,0 +1,456 @@
+{
+    "magic": "dsg.config.meta",
+    "version": "1.0",
+    "contents": {
+        "switchToWorkspaceLeft": {
+            "value": ["<Control><Alt>Left"],
+            "serial": 0,
+            "flags": [],
+            "name": "switchToWorkspaceLeft",
+            "name[zh_CN]": "切换到左侧工作区",
+            "description": "Switch to workspace left",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "switchToWorkspaceRight": {
+            "value": ["<Control><Alt>Right"],
+            "serial": 0,
+            "flags": [],
+            "name": "switchToWorkspaceRight",
+            "name[zh_CN]": "切换到右侧工作区",
+            "description": "Switch to workspace right",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "switchToWorkspaceUp": {
+            "value": ["<Super>Page_Up","<Control><Alt>Up"],
+            "serial": 0,
+            "flags": [],
+            "name": "switchToWorkspaceUp",
+            "name[zh_CN]": "切换到上方工作区",
+            "description": "Switch to workspace above",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "switchToWorkspaceDown": {
+            "value": ["<Super>Page_Down","<Control><Alt>Down"],
+            "serial": 0,
+            "flags": [],
+            "name": "switchToWorkspaceDown",
+            "name[zh_CN]": "切换到下方工作区",
+            "description": "Switch to workspace below",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "switchToWorkspaceFirst": {
+            "value": ["<Super>Home"],
+            "serial": 0,
+            "flags": [],
+            "name": "switchToWorkspaceFirst",
+            "name[zh_CN]": "切换到第一个工作区",
+            "description": "Switch to workspace 1",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "switchToWorkspaceLast": {
+            "value": ["<Super>End"],
+            "serial": 0,
+            "flags": [],
+            "name": "switchToWorkspaceLast",
+            "name[zh_CN]": "切换到最后一个工作区",
+            "description": "Switch to last workspace",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "switchGroup": {
+            "value": ["<Super>Above_Tab","<Alt>Above_Tab"],
+            "serial": 0,
+            "flags": [],
+            "name": "switchGroup",
+            "name[zh_CN]": "切换应用程序窗口",
+            "description": "Switch windows of an application",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "switchGroupBackward": {
+            "value": ["<Shift><Super>Above_Tab","<Shift><Alt>Above_Tab"],
+            "serial": 0,
+            "flags": [],
+            "name": "switchGroupBackward",
+            "name[zh_CN]": "反向切换应用程序窗口",
+            "description": "Reverse switch windows of an application",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "switchApplications": {
+            "value": ["<Super>Tab","<Alt>Tab"],
+            "serial": 0,
+            "flags": [],
+            "name": "switchApplications",
+            "name[zh_CN]": "切换应用程序",
+            "description": "Switch applications",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "switchApplicationsBackward": {
+            "value": ["<Shift><Super>Tab","<Shift><Alt>Tab"],
+            "serial": 0,
+            "flags": [],
+            "name": "switchApplicationsBackward",
+            "name[zh_CN]": "反向切换应用程序",
+            "description": "Reverse switch applications",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "switchPanels": {
+            "value": ["<Control><Alt>Tab"],
+            "serial": 0,
+            "flags": [],
+            "name": "switchPanels",
+            "name[zh_CN]": "切换系统控件",
+            "description": "Switch system controls",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "switchPanelsBackward": {
+            "value": ["<Shift><Control><Alt>Tab"],
+            "serial": 0,
+            "flags": [],
+            "name": "switchPanelsBackward",
+            "name[zh_CN]": "反向切换系统控件",
+            "description": "Reverse switch system controls",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "cycleGroup": {
+            "value": ["<Alt>F6"],
+            "serial": 0,
+            "flags": [],
+            "name": "cycleGroup",
+            "name[zh_CN]": "直接切换应用窗口",
+            "description": "Switch windows of an app directly",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "cycleGroupBackward": {
+            "value": ["<Shift><Alt>F6"],
+            "serial": 0,
+            "flags": [],
+            "name": "cycleGroupBackward",
+            "name[zh_CN]": "反向直接切换应用窗口",
+            "description": "Reverse switch windows of an app directly",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "cycleWindows": {
+            "value": ["<Alt>Escape"],
+            "serial": 0,
+            "flags": [],
+            "name": "cycleWindows",
+            "name[zh_CN]": "直接切换窗口",
+            "description": "Switch windows directly",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "cycleWindowsBackward": {
+            "value": ["<Shift><Alt>Escape"],
+            "serial": 0,
+            "flags": [],
+            "name": "cycleWindowsBackward",
+            "name[zh_CN]": "反向直接切换窗口",
+            "description": "Reverse switch windows directly",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "cyclePanels": {
+            "value": ["<Control><Alt>Escape"],
+            "serial": 0,
+            "flags": [],
+            "name": "cyclePanels",
+            "name[zh_CN]": "直接切换系统控件",
+            "description": "Switch system controls directly",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "cyclePanelsBackward": {
+            "value": ["<Shift><Control><Alt>Escape"],
+            "serial": 0,
+            "flags": [],
+            "name": "cyclePanelsBackward",
+            "name[zh_CN]": "反向直接切换系统控件",
+            "description": "Reverse switch system controls directly",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "panelMainMenu": {
+            "value": ["<Super>s","<Alt>F1"],
+            "serial": 0,
+            "flags": [],
+            "name": "panelMainMenu",
+            "name[zh_CN]": "显示活动概览",
+            "description": "Show the activities overview",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "panelRunDialog": {
+            "value": ["<Alt>F2"],
+            "serial": 0,
+            "flags": [],
+            "name": "panelRunDialog",
+            "name[zh_CN]": "显示运行命令提示",
+            "description": "Show the run command prompt",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "activateWindowMenu": {
+            "value": ["<Alt>space"],
+            "serial": 0,
+            "flags": [],
+            "name": "activateWindowMenu",
+            "name[zh_CN]": "激活窗口菜单",
+            "description": "Activate the window menu",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "toggleMaximized": {
+            "value": ["<Alt>F10"],
+            "serial": 0,
+            "flags": [],
+            "name": "toggleMaximized",
+            "name[zh_CN]": "切换最大化状态",
+            "description": "Toggle maximization state",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "maximize": {
+            "value": ["<Super>Up"],
+            "serial": 0,
+            "flags": [],
+            "name": "maximize",
+            "name[zh_CN]": "最大化窗口",
+            "description": "Maximize window",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "unmaximize": {
+            "value": ["<Super>Down","<Alt>F5"],
+            "serial": 0,
+            "flags": [],
+            "name": "unmaximize",
+            "name[zh_CN]": "还原窗口",
+            "description": "Restore window",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "minimize": {
+            "value": ["<Super>h"],
+            "serial": 0,
+            "flags": [],
+            "name": "minimize",
+            "name[zh_CN]": "最小化窗口",
+            "description": "Minimize window",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "close": {
+            "value": ["<Alt>F4"],
+            "serial": 0,
+            "flags": [],
+            "name": "close",
+            "name[zh_CN]": "关闭窗口",
+            "description": "Close window",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "beginMove": {
+            "value": ["<Alt>F7"],
+            "serial": 0,
+            "flags": [],
+            "name": "beginMove",
+            "name[zh_CN]": "移动窗口",
+            "description": "Move window",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "beginResize": {
+            "value": ["<Alt>F8"],
+            "serial": 0,
+            "flags": [],
+            "name": "beginResize",
+            "name[zh_CN]": "调整窗口大小",
+            "description": "Resize window",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "moveToWorkspaceFirst": {
+            "value": ["<Super><Shift>Home"],
+            "serial": 0,
+            "flags": [],
+            "name": "moveToWorkspaceFirst",
+            "name[zh_CN]": "移动窗口到第一个工作区",
+            "description": "Move window to workspace 1",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "moveToWorkspaceLast": {
+            "value": ["<Super><Shift>End"],
+            "serial": 0,
+            "flags": [],
+            "name": "moveToWorkspaceLast",
+            "name[zh_CN]": "移动窗口到最后一个工作区",
+            "description": "Move window to last workspace",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "moveToWorkspaceLeft": {
+            "value": ["<Control><Shift><Alt>Left"],
+            "serial": 0,
+            "flags": [],
+            "name": "moveToWorkspaceLeft",
+            "name[zh_CN]": "移动窗口到左侧工作区",
+            "description": "Move window one workspace to the left",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "moveToWorkspaceRight": {
+            "value": ["<Control><Shift><Alt>Right"],
+            "serial": 0,
+            "flags": [],
+            "name": "moveToWorkspaceRight",
+            "name[zh_CN]": "移动窗口到右侧工作区",
+            "description": "Move window one workspace to the right",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "moveToWorkspaceUp": {
+            "value": ["<Super><Shift>Page_Up","<Control><Shift><Alt>Up"],
+            "serial": 0,
+            "flags": [],
+            "name": "moveToWorkspaceUp",
+            "name[zh_CN]": "移动窗口到上方工作区",
+            "description": "Move window one workspace up",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "moveToWorkspaceDown": {
+            "value": ["<Super><Shift>Page_Down","<Control><Shift><Alt>Down"],
+            "serial": 0,
+            "flags": [],
+            "name": "moveToWorkspaceDown",
+            "name[zh_CN]": "移动窗口到下方工作区",
+            "description": "Move window one workspace down",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "moveToMonitorLeft": {
+            "value": ["<Super><Shift>Left"],
+            "serial": 0,
+            "flags": [],
+            "name": "moveToMonitorLeft",
+            "name[zh_CN]": "移动窗口到左侧显示器",
+            "description": "Move window to the next monitor on the left",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "moveToMonitorRight": {
+            "value": ["<Super><Shift>Right"],
+            "serial": 0,
+            "flags": [],
+            "name": "moveToMonitorRight",
+            "name[zh_CN]": "移动窗口到右侧显示器",
+            "description": "Move window to the next monitor on the right",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "moveToMonitorUp": {
+            "value": ["<Super><Shift>Up"],
+            "serial": 0,
+            "flags": [],
+            "name": "moveToMonitorUp",
+            "name[zh_CN]": "移动窗口到上方显示器",
+            "description": "Move window to the next monitor above",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "moveToMonitorDown": {
+            "value": ["<Super><Shift>Down"],
+            "serial": 0,
+            "flags": [],
+            "name": "moveToMonitorDown",
+            "name[zh_CN]": "移动窗口到下方显示器",
+            "description": "Move window to the next monitor below",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "switchInputSource": {
+            "value": ["<Super>space"],
+            "serial": 0,
+            "flags": [],
+            "name": "switchInputSource",
+            "name[zh_CN]": "切换输入法",
+            "description": "Switch input source",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "switchInputSourceBackward": {
+            "value": ["<Shift><Super>space"],
+            "serial": 0,
+            "flags": [],
+            "name": "switchInputSourceBackward",
+            "name[zh_CN]": "反向切换输入法",
+            "description": "Switch input source backward",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "exposeWindows": {
+            "value": ["<Super>w"],
+            "serial": 0,
+            "flags": [],
+            "name": "exposeWindows",
+            "name[zh_CN]": "打开窗口概览",
+            "description": "Shortcut to open the window overview",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "exposeAllWindows": {
+            "value": ["<Super>a"],
+            "serial": 0,
+            "flags": [],
+            "name": "exposeAllWindows",
+            "name[zh_CN]": "打开所有窗口概览",
+            "description": "Shortcut to open the window overview for all windows",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "previewWorkspace": {
+            "value": ["<Super>s"],
+            "serial": 0,
+            "flags": [],
+            "name": "previewWorkspace",
+            "name[zh_CN]": "预览所有工作区",
+            "description": "Preview all workspaces",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "zoomIn": {
+            "value": ["<Super>plus","<Super>KP_Add"],
+            "serial": 0,
+            "flags": [],
+            "name": "zoomIn",
+            "name[zh_CN]": "放大",
+            "description": "Zoom in",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "zoomOut": {
+            "value": ["<Super>minus","<Super>KP_Subtract"],
+            "serial": 0,
+            "flags": [],
+            "name": "zoomOut",
+            "name[zh_CN]": "缩小",
+            "description": "Zoom out",
+            "permissions": "readwrite",
+            "visibility": "private"
+        }
+    }
+}

--- a/misc/dsg-configs/org.deepin.dde.daemon.keyboard.json
+++ b/misc/dsg-configs/org.deepin.dde.daemon.keyboard.json
@@ -1,0 +1,176 @@
+{
+    "magic": "dsg.config.meta",
+    "version": "1.0",
+    "contents": {
+        "user-layout-list": {
+            "value": [],
+            "serial": 0,
+            "flags": [],
+            "name": "user-layout-list",
+            "name[zh_CN]": "用户添加的布局列表",
+            "description": "User Add Layout List",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "layoutOptions": {
+            "value": [],
+            "serial": 0,
+            "flags": [],
+            "name": "layoutOptions",
+            "name[zh_CN]": "布局选项列表",
+            "description": "Layout Option List",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "layout": {
+            "value": "",
+            "serial": 0,
+            "flags": [],
+            "name": "layout",
+            "name[zh_CN]": "键盘布局",
+            "description": "Keyboard Layout",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "layout-scope": {
+            "value": 0,
+            "serial": 0,
+            "flags": [],
+            "name": "layout-scope",
+            "name[zh_CN]": "键盘布局作用域",
+            "description": "Keyboard Layout Scope. Enum values: 0=global, 1=application",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "app-layout-map": {
+            "value": "",
+            "serial": 0,
+            "flags": [],
+            "name": "app-layout-map",
+            "name[zh_CN]": "应用键盘布局映射",
+            "description": "App keyboard layout map",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "shortcutSwitchLayout": {
+            "value": 6,
+            "serial": 0,
+            "flags": [],
+            "name": "shortcutSwitchLayout",
+            "name[zh_CN]": "切换键盘布局快捷键",
+            "description": "Shortcuts for switch keyboard layout. Range: 0-7. Perform bitwise or operation: Ctrl-Shift=1, Alt-Shift=2, Super-Space=4",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "repeatEnabled": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "repeatEnabled",
+            "name[zh_CN]": "启用按键重复",
+            "description": "Enable key repeat",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "click": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "click",
+            "name[zh_CN]": "按键点击声",
+            "description": "Key click sound",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "repeatInterval": {
+            "value": 50,
+            "serial": 0,
+            "flags": [],
+            "name": "repeatInterval",
+            "name[zh_CN]": "按键重复间隔",
+            "description": "Key Repeat Interval. Delay between repeats in milliseconds.",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "delay": {
+            "value": 250,
+            "serial": 0,
+            "flags": [],
+            "name": "delay",
+            "name[zh_CN]": "初始按键重复延迟",
+            "description": "Initial Key Repeat Delay. Initial key repeat delay in milliseconds.",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "click-volume": {
+            "value": 0,
+            "serial": 0,
+            "flags": [],
+            "name": "click-volume",
+            "name[zh_CN]": "点击音量",
+            "description": "Key click volume",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "cursorBlinkTime": {
+            "value": 1200,
+            "serial": 0,
+            "flags": [],
+            "name": "cursorBlinkTime",
+            "name[zh_CN]": "光标闪烁时间",
+            "description": "Cursor blink time in milliseconds",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "capslockToggle": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "capslockToggle",
+            "name[zh_CN]": "大写锁定切换通知",
+            "description": "Control whether show CapsLock notify",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "saveNumlockState": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "saveNumlockState",
+            "name[zh_CN]": "保存数字锁定状态",
+            "description": "Save NumLock state",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "numlockState": {
+            "value": 2,
+            "serial": 0,
+            "flags": [],
+            "name": "numlockState",
+            "name[zh_CN]": "数字锁定状态",
+            "description": "NumLock state. Enum values: 0=off, 1=on, 2=unknown",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "osdAdjustVolumeEnabled": {
+            "value": 0,
+            "serial": 0,
+            "flags": [],
+            "name": "osdAdjustVolumeEnabled",
+            "name[zh_CN]": "音量调节快捷键启用",
+            "description": "Control whether Volume shortcut works. Enum values: 0=enable, 1=forbidden, 2=hidden",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "osdAdjustBrightnessEnabled": {
+            "value": 0,
+            "serial": 0,
+            "flags": [],
+            "name": "osdAdjustBrightnessEnabled",
+            "name[zh_CN]": "亮度调节快捷键启用",
+            "description": "Control whether Brightness shortcut works. Enum values: 0=enable, 1=forbidden, 2=hidden",
+            "permissions": "readwrite",
+            "visibility": "private"
+        }
+    }
+}

--- a/misc/dsg-configs/org.deepin.dde.daemon.power.json
+++ b/misc/dsg-configs/org.deepin.dde.daemon.power.json
@@ -1,3 +1,4 @@
+
 {
     "magic": "dsg.config.meta",
     "version": "1.0",
@@ -250,6 +251,332 @@
             "description": "延时调用HandleIdleOff时间间隔，单位ms",
             "permissions": "readwrite",
             "visibility": "public"
+        },
+        "linePowerScreensaverDelay": {
+            "value": 0,
+            "serial": 0,
+            "flags": [],
+            "name": "linePowerScreensaverDelay",
+            "name[zh_CN]": "插电时显示屏保的超时时间",
+            "description": "line power screen saver delay",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
+        "batteryScreensaverDelay": {
+            "value": 0,
+            "serial": 0,
+            "flags": [],
+            "name": "batteryScreensaverDelay",
+            "name[zh_CN]": "使用电池时显示屏保的超时时间",
+            "description": "battery screen saver delay",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
+        "batteryScreenBlackDelay": {
+            "value": 300,
+            "serial": 0,
+            "flags": [],
+            "name": "batteryScreenBlackDelay",
+            "name[zh_CN]": "使用电池时的屏幕黑屏延时",
+            "description": "battery screen black delay",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
+        "batterySleepDelay": {
+            "value": 900,
+            "serial": 0,
+            "flags": [],
+            "name": "batterySleepDelay",
+            "name[zh_CN]": "使用电池时的休眠延时",
+            "description": "battery sleep delay",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
+        "linePowerScreenBlackDelay": {
+            "value": 900,
+            "serial": 0,
+            "flags": [],
+            "name": "linePowerScreenBlackDelay",
+            "name[zh_CN]": "插电时屏幕黑屏延时",
+            "description": "line power screen black delay",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
+        "linePowerSleepDelay": {
+            "value": 1800,
+            "serial": 0,
+            "flags": [],
+            "name": "linePowerSleepDelay",
+            "name[zh_CN]": "插电时休眠延时",
+            "description": "line power sleep delay",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
+        "linePowerLockDelay": {
+            "value": 900,
+            "serial": 0,
+            "flags": [],
+            "name": "linePowerLockDelay",
+            "name[zh_CN]": "插电时锁屏延时",
+            "description": "line power lock delay",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
+        "batteryLockDelay": {
+            "value": 300,
+            "serial": 0,
+            "flags": [],
+            "name": "batteryLockDelay",
+            "name[zh_CN]": "使用电池时锁屏延时",
+            "description": "battery lock delay",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
+        "adjustBrightnessEnabled": {
+            "value": false,
+            "serial": 0,
+            "flags": [],
+            "name": "adjustBrightnessEnabled",
+            "name[zh_CN]": "启用自动调节亮度",
+            "description": "adjust display brigtness enabled",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
+        "ambientLightAdjustBrightness": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "ambientLightAdjustBrightness",
+            "name[zh_CN]": "通过环境光自动调节亮度",
+            "description": "auto adjust backlight brightness according to ambient light intensity",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
+        "screenBlackLock": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "screenBlackLock",
+            "name[zh_CN]": "关闭屏幕前锁定",
+            "description": "screen black lock",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
+        "sleepLock": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "sleep lock",
+            "name[zh_CN]": "睡眠前锁定",
+            "description": "sleep lock",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
+        "lidClosedSleep": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "lidClosedSleep",
+            "name[zh_CN]": "插电时合盖休眠",
+            "description": "Sleep when close the lid if use line power",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
+        "batteryLidClosedSleep": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "batteryLidClosedSleep",
+            "name[zh_CN]": "使用电池时合盖休眠",
+            "description": "Sleep when close the lid if use battery",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
+        "powerButtonPressedExec": {
+            "value": "dde-shutdown",
+            "serial": 0,
+            "flags": [
+                "global"
+            ],
+            "name": "powerButtonPressedExec",
+            "name[zh_CN]": "电源键按下执行的命令",
+            "description": "power button pressed exec",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
+        "fullscreenWorkaroundAppList": {
+            "value": ["libflash", "chrome", "firefox","mplayer", "operaplugin", "soffice", "wpp", "evince", "vlc", "totem"],
+            "serial": 0,
+            "flags": [],
+            "name": "fullscreenWorkaroundAppList",
+            "name[zh_CN]": "全屏工作模式应用列表",
+            "description": "app in list fullscreen inhbit screensaver",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
+        "usePercentageForPolicy": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "usePercentageForPolicy",
+            "name[zh_CN]": "使用基于电池百分比的策略",
+            "description": "Whether battery percentage based policy should be used. It should work around broken firmwares. It is also more reliable than the time left.",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
+        "powerModuleInitialized": {
+            "value": false,
+            "serial": 0,
+            "flags": [],
+            "name": "powerModuleInitialized",
+            "name[zh_CN]": "电源模块是否初始化",
+            "description": "power module initialized",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
+        "lowPowerNotifyThreshold": {
+            "value": 20,
+            "serial": 0,
+            "flags": [],
+            "name": "lowPowerNotifyThreshold",
+            "name[zh_CN]": "低电量通知阈值",
+            "description": "low power notify threshold",
+            "permissions": "readwrite"
+        },
+        "lowPowerAction": {
+            "value": 1,
+            "serial": 0,
+            "flags": [],
+            "name": "lowPowerAction",
+            "name[zh_CN]": "低电量时系统动作",
+            "description": "0: suspend, 1: hibernate",
+            "permissions": "readwrite"
+        },
+        "percentageAction": {
+            "value": 5,
+            "serial": 0,
+            "flags": [],
+            "name": "percentageAction",
+            "name[zh_CN]": "执行动作的百分比",
+            "description": "system action when battery low",
+            "permissions": "readwrite"
+        },
+        "timeToEmptyLow": {
+            "value": 1200,
+            "serial": 0,
+            "flags": [],
+            "name": "timeToEmptyLow",
+            "name[zh_CN]": "time to empty low",
+            "description": "time to empty low",
+            "permissions": "readwrite"
+        },
+        "timeToEmptyDanger": {
+            "value": 900,
+            "serial": 0,
+            "flags": [],
+            "name": "timeToEmptyDanger",
+            "name[zh_CN]": "time to empty low",
+            "description": "time to empty low",
+            "permissions": "readwrite"
+        },
+        "timeToEmptyCritical": {
+            "value": 600,
+            "serial": 0,
+            "flags": [],
+            "name": "timeToEmptyCritical",
+            "name[zh_CN]": "time to empty low",
+            "description": "time to empty low",
+            "permissions": "readwrite"
+        },
+        "timeToEmptyAction": {
+            "value": 300,
+            "serial": 0,
+            "flags": [],
+            "name": "timeToEmptyAction",
+            "name[zh_CN]": "system action when battery low",
+            "description": "system action when battery low",
+            "permissions": "readwrite"
+        },
+        "linePowerLidClosedAction": {
+            "value": 1,
+            "serial": 0,
+            "flags": [],
+            "name": "linePowerLidClosedAction",
+            "name[zh_CN]": "插电状态下合盖执行的动作",
+            "description": "0:shutdown, 1:suspend, 2:hibernate, 3:turnOffScreen, 4:showSessionUI, 5:doNothing",
+            "permissions": "readwrite"
+        },
+        "linePowerPressPowerButton": {
+            "value": 4,
+            "serial": 0,
+            "flags": [],
+            "name": "linePowerPressPowerButton",
+            "name[zh_CN]": "插电状态下按电源键的动作",
+            "description": "0:shutdown, 1:suspend, 2:hibernate, 3:turnOffScreen, 4:showSessionUI, 5:doNothing",
+            "permissions": "readwrite"
+        },
+        "batteryLidClosedAction": {
+            "value": 1,
+            "serial": 0,
+            "flags": [],
+            "name": "batteryLidClosedAction",
+            "name[zh_CN]": "使用电池时合盖执行的动作",
+            "description": "0:shutdown, 1:suspend, 2:hibernate, 3:turnOffScreen, 4:showSessionUI, 5:doNothing",
+            "permissions": "readwrite"
+        },
+        "batteryPressPowerButton": {
+            "value": 4,
+            "serial": 0,
+            "flags": [],
+            "name": "batteryPressPowerButton",
+            "name[zh_CN]": "使用电池时按电源键执行的动作",
+            "description": "0:shutdown, 1:suspend, 2:hibernate, 3:turnOffScreen, 4:showSessionUI, 5:doNothing",
+            "permissions": "readwrite"
+        },
+        "lowPowerNotifyEnable": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "lowPowerNotifyEnable",
+            "name[zh_CN]": "低电量时打开系统通知",
+            "description": "enable system notify when low power",
+            "permissions": "readwrite"
+        },
+        "saveBrightnessWhilePsm": {
+            "value": "",
+            "serial": 0,
+            "flags": [],
+            "name": "saveBrightnessWhilePsm",
+            "name[zh_CN]": "省电模式时自动降低亮度",
+            "description": "brightness saved while power saving mode enabled",
+            "permissions": "readwrite"
+        },
+        "lightSensorEnabled": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "lightSensorEnabled",
+            "name[zh_CN]": "光感应器开关",
+            "description": "light sensor enabled",
+            "permissions": "readwrite"
+        },
+        "lowPowerPercentInUpdatingNotify": {
+            "value": 50,
+            "serial": 0,
+            "flags":[],
+            "name": "lowPowerPercentInUpdatingNotify",
+            "name[zh_CN]": "更新系统时触发警告的电量",
+            "description": "low power percent in updating notify",
+            "permissions": "readwrite"
+        },
+        "highPerformanceEnabled": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "highPerformanceEnabled",
+            "name[zh_CN]": "高性能模式开关",
+            "description": "high performance enabled",
+            "permissions": "readwrite"
         }
     }
 }

--- a/session/power1/constant.go
+++ b/session/power1/constant.go
@@ -6,60 +6,62 @@ package power
 
 // nolint
 const (
-	gsSchemaPower = "com.deepin.dde.power"
-	// settingKeys
-	settingKeyBatteryScreensaverDelay = "battery-screensaver-delay"
-	settingKeyBatteryScreenBlackDelay = "battery-screen-black-delay"
-	settingKeyBatterySleepDelay       = "battery-sleep-delay"
-	settingKeyBatteryLockDelay        = "battery-lock-delay"
-
-	settingKeyLinePowerScreensaverDelay = "line-power-screensaver-delay"
-	settingKeyLinePowerScreenBlackDelay = "line-power-screen-black-delay"
-	settingKeyLinePowerSleepDelay       = "line-power-sleep-delay"
-	settingKeyLinePowerLockDelay        = "line-power-lock-delay"
-
-	settingKeyAdjustBrightnessEnabled       = "adjust-brightness-enabled"
-	settingKeyAmbientLightAdjuestBrightness = "ambient-light-adjust-brightness"
-	settingKeyScreenBlackLock               = "screen-black-lock"
-	settingKeySleepLock                     = "sleep-lock"
-
-	settingKeyLinePowerLidClosedAction     = "line-power-lid-closed-action"
-	settingKeyLinePowerPressPowerBtnAction = "line-power-press-power-button"
-	settingKeyBatteryLidClosedAction       = "battery-lid-closed-action"
-	settingKeyBatteryPressPowerBtnAction   = "battery-press-power-button"
-	settingKeyLowPowerNotifyEnable         = "low-power-notify-enable"
-	settingKeyLowPowerNotifyThreshold      = "low-power-notify-threshold"
-	settingKeyLowPowerAutoSleepThreshold   = "percentage-action"
-	settingKeyLowPowerAction               = "low-power-action"
-	settingKeyBrightnessDropPercent        = "brightness-drop-percent"
-	settingKeyPowerSavingEnabled           = "power-saving-mode-enabled"
-
-	settingKeyPowerButtonPressedExec = "power-button-pressed-exec"
-
-	settingKeyFullScreenWorkaroundEnabled = "fullscreen-workaround-enabled"
-	settingKeyUsePercentageForPolicy      = "use-percentage-for-policy"
-
-	settingKeyLowPercentage      = "percentage-low"
-	settingKeyDangerlPercentage  = "percentage-danger"
-	settingKeyCriticalPercentage = "percentage-critical"
-	settingKeyActionPercentage   = "percentage-action"
-
-	settingKeyLowTime      = "time-to-empty-low"
-	settingKeyDangerTime   = "time-to-empty-danger"
-	settingKeyCriticalTime = "time-to-empty-critical"
-	settingKeyActionTime   = "time-to-empty-action"
-
-	settingKeySaveBrightnessWhilePsm = "save-brightness-while-psm"
-
-	settingLightSensorEnabled = "light-sensor-enabled"
-	settingKeyMode            = "mode"
-
-	settingKeyHighPerformanceEnabled = "high-performance-enabled"
-
 	// cmd
 	cmdDDELowPower = "/usr/lib/deepin-daemon/dde-lowpower"
 
 	batteryDisplay = "Display"
+)
+
+// dconfig keys
+const (
+	dsettingLinePowerScreensaverDelay            = "linePowerScreensaverDelay"
+	dsettingBatteryScreensaverDelay              = "batteryScreensaverDelay"
+	dsettingPowerSavingModeBrightnessDropPercent = "powerSavingModeBrightnessDropPercent"
+	dsettingBatteryScreenBlackDelay              = "batteryScreenBlackDelay"
+	dsettingBatterySleepDelay                    = "batterySleepDelay"
+	dsettingLinePowerScreenBlackDelay            = "linePowerScreenBlackDelay"
+	dsettingLinePowerSleepDelay                  = "linePowerSleepDelay"
+	dsettingLinePowerLockDelay                   = "linePowerLockDelay"
+	dsettingBatteryLockDelay                     = "batteryLockDelay"
+	dsettingAdjustBrightnessEnabled              = "adjustBrightnessEnabled"
+	dsettingAmbientLightAdjustBrightness         = "ambientLightAdjustBrightness"
+	dsettingScreenBlackLock                      = "screenBlackLock"
+	dsettingSleepLock                            = "sleepLock"
+	dsettingLidClosedSleep                       = "lidClosedSleep"
+	dsettingBatteryLidClosedSleep                = "batteryLidClosedSleep"
+	dsettingPowerButtonPressedExec               = "powerButtonPressedExec"
+	dsettingFullscreenWorkaroundAppList          = "fullscreenWorkaroundAppList"
+	dsettingUsePercentageForPolicy               = "usePercentageForPolicy"
+	dsettingPowerModuleInitialized               = "powerModuleInitialized"
+	dsettingLowPowerNotifyThreshold              = "lowPowerNotifyThreshold"
+	dsettingLowPowerAction                       = "lowPowerAction"
+	dsettingPercentageAction                     = "percentageAction"
+	dsettingTimeToEmptyLow                       = "timeToEmptyLow"
+	dsettingTimeToEmptyDanger                    = "timeToEmptyDanger"
+	dsettingTimeToEmptyCritical                  = "timeToEmptyCritical"
+	dsettingTimeToEmptyAction                    = "timeToEmptyAction"
+	dsettingLinePowerLidClosedAction             = "linePowerLidClosedAction"
+	dsettingLinePowerPressPowerButton            = "linePowerPressPowerButton"
+	dsettingBatteryLidClosedAction               = "batteryLidClosedAction"
+	dsettingBatteryPressPowerButton              = "batteryPressPowerButton"
+	dsettingLowPowerNotifyEnable                 = "lowPowerNotifyEnable"
+	dsettingSaveBrightnessWhilePsm               = "saveBrightnessWhilePsm"
+	dsettingLightSensorEnabled                   = "lightSensorEnabled"
+	dsettingLowPowerPercentInUpdatingNotify      = "lowPowerPercentInUpdatingNotify"
+	dsettingHighPerformanceEnabled               = "highPerformanceEnabled"
+	dsettingsPowerSavingModeEnabled              = "powerSavingModeEnabled"
+	dsettingScheduledShutdownState               = "scheduledShutdownState"
+	dsettingShutdownTime                         = "shutdownTime"
+	dsettingShutdownRepetition                   = "shutdownRepetition"
+	dsettingCustomShutdownWeekDays               = "customShutdownWeekDays"
+	dsettingShutdownCountdown                    = "shutdownCountdown"
+	dsettingNextShutdownTime                     = "nextShutdownTime"
+)
+
+const (
+	DSettingsAppID        = "org.deepin.dde.daemon"
+	DSettingsDisplayName  = "org.deepin.Display"
+	DSettingsAutoChangeWm = "auto-change-deepin-wm"
 )
 
 const (

--- a/session/power1/daemon.go
+++ b/session/power1/daemon.go
@@ -5,9 +5,10 @@
 package power
 
 import (
+	"os"
+
 	"github.com/linuxdeepin/dde-daemon/loader"
 	"github.com/linuxdeepin/go-lib/log"
-	"os"
 )
 
 var logger = log.NewLogger("daemon/session/power")

--- a/session/power1/lid_switch.go
+++ b/session/power1/lid_switch.go
@@ -94,9 +94,9 @@ func (h *LidSwitchHandler) doLidStateChanged(state bool) {
 		onBattery = h.manager.OnBattery
 		var lidCloseAction int32
 		if onBattery {
-			lidCloseAction = m.BatteryLidClosedAction.Get() // 获取合盖操作
+			lidCloseAction = m.BatteryLidClosedAction // 获取合盖操作
 		} else {
-			lidCloseAction = m.LinePowerLidClosedAction.Get() // 获取合盖操作
+			lidCloseAction = m.LinePowerLidClosedAction // 获取合盖操作
 		}
 		switch lidCloseAction {
 		case powerActionShutdown:

--- a/session/power1/manager_ambient_light.go
+++ b/session/power1/manager_ambient_light.go
@@ -16,7 +16,7 @@ func (m *Manager) claimOrReleaseAmbientLight() {
 	logger.Debug("call claimOrReleaseAmbientLight")
 	var shouldClaim bool
 
-	autoAdjustEnabled := m.AmbientLightAdjustBrightness.Get()
+	autoAdjustEnabled := m.AmbientLightAdjustBrightness
 
 	m.PropsMu.RLock()
 	if m.HasAmbientLightSensor &&
@@ -84,7 +84,7 @@ func (m *Manager) releaseAmbientLight() {
 }
 
 func (m *Manager) handleLightLevelChanged(lightLevel float64) {
-	if !m.AmbientLightAdjustBrightness.Get() {
+	if !m.AmbientLightAdjustBrightness {
 		return
 	}
 

--- a/session/power1/manager_events.go
+++ b/session/power1/manager_events.go
@@ -74,7 +74,7 @@ func (m *Manager) handleBeforeSuspend() {
 	m.setDDEBlackScreenActive(true)
 	if m.UseWayland {
 		// 如果是treeland，并且待机休眠唤醒是需要解锁，则将session 给lock
-		if m.SleepLock.Get() {
+		if m.SleepLock {
 			err := m.currentSession.Lock(0)
 			if err != nil {
 				logger.Warning("set session lock failed:", err)
@@ -172,9 +172,9 @@ func (m *Manager) handleWakeupDDELowPowerCheck() {
 			}
 			m.setPropBatteryPercentage(percentage)
 
-			logger.Info(" PrepareForSleep(False) : wakeup,  Battery percentage : ", percentage, m.BatteryPercentage[batteryDisplay], m.warnLevelConfig.ActionPercentage.Get())
+			logger.Info(" PrepareForSleep(False) : wakeup,  Battery percentage : ", percentage, m.BatteryPercentage[batteryDisplay], m.warnLevelConfig.ActionPercentage)
 
-			if percentage <= float64(m.warnLevelConfig.ActionPercentage.Get()) {
+			if percentage <= float64(m.warnLevelConfig.ActionPercentage) {
 				return
 			}
 		}
@@ -268,7 +268,7 @@ func (m *Manager) handleWarnLevelChanged(level WarnLevel) {
 		m.warnLevelCountTicker = newCountTicker(time.Second, func(count int) {
 			if count == 3 {
 				// after 3 seconds, lock and then show dde low power
-				if m.SleepLock.Get() {
+				if m.SleepLock {
 					m.lockWaitShow(5*time.Second, false)
 				}
 			} else if count == 4 {
@@ -277,7 +277,7 @@ func (m *Manager) handleWarnLevelChanged(level WarnLevel) {
 				// after 5 seconds, force suspend
 				m.disableWarnLevelCountTicker()
 
-				if m.LowPowerAction.Get() == lowPowerActionSuspend {
+				if m.LowPowerAction == lowPowerActionSuspend {
 					m.doSuspend()
 				} else {
 					m.doHibernate()

--- a/session/power1/power_dbusutil.go
+++ b/session/power1/power_dbusutil.go
@@ -119,6 +119,253 @@ func (v *Manager) emitPropChangedHasAmbientLightSensor(value bool) error {
 	return v.service.EmitPropertyChanged(v, "HasAmbientLightSensor", value)
 }
 
+func (v *Manager) setPropLinePowerScreensaverDelay(value int) (changed bool) {
+	if v.LinePowerScreensaverDelay != value {
+		v.LinePowerScreensaverDelay = value
+		v.emitPropChangedLinePowerScreensaverDelay(value)
+		return true
+	}
+	return false
+}
+
+func (v *Manager) emitPropChangedLinePowerScreensaverDelay(value int) error {
+	return v.service.EmitPropertyChanged(v, "LinePowerScreensaverDelay", value)
+}
+
+func (v *Manager) setPropLinePowerScreenBlackDelay(value int) (changed bool) {
+	if v.LinePowerScreenBlackDelay != value {
+		v.LinePowerScreenBlackDelay = value
+		v.emitPropChangedLinePowerScreenBlackDelay(value)
+		return true
+	}
+	return false
+}
+
+func (v *Manager) emitPropChangedLinePowerScreenBlackDelay(value int) error {
+	return v.service.EmitPropertyChanged(v, "LinePowerScreenBlackDelay", value)
+}
+
+func (v *Manager) setPropLinePowerSleepDelay(value int) (changed bool) {
+	if v.LinePowerSleepDelay != value {
+		v.LinePowerSleepDelay = value
+		v.emitPropChangedLinePowerSleepDelay(value)
+		return true
+	}
+	return false
+}
+
+func (v *Manager) emitPropChangedLinePowerSleepDelay(value int) error {
+	return v.service.EmitPropertyChanged(v, "LinePowerSleepDelay", value)
+}
+
+func (v *Manager) setPropBatteryScreensaverDelay(value int) (changed bool) {
+	if v.BatteryScreensaverDelay != value {
+		v.BatteryScreensaverDelay = value
+		v.emitPropChangedBatteryScreensaverDelay(value)
+		return true
+	}
+	return false
+}
+
+func (v *Manager) emitPropChangedBatteryScreensaverDelay(value int) error {
+	return v.service.EmitPropertyChanged(v, "BatteryScreensaverDelay", value)
+}
+
+func (v *Manager) setPropBatteryScreenBlackDelay(value int) (changed bool) {
+	if v.BatteryScreenBlackDelay != value {
+		v.BatteryScreenBlackDelay = value
+		v.emitPropChangedBatteryScreenBlackDelay(value)
+		return true
+	}
+	return false
+}
+
+func (v *Manager) emitPropChangedBatteryScreenBlackDelay(value int) error {
+	return v.service.EmitPropertyChanged(v, "BatteryScreenBlackDelay", value)
+}
+
+func (v *Manager) setPropBatterySleepDelay(value int) (changed bool) {
+	if v.BatterySleepDelay != value {
+		v.BatterySleepDelay = value
+		v.emitPropChangedBatterySleepDelay(value)
+		return true
+	}
+	return false
+}
+
+func (v *Manager) emitPropChangedBatterySleepDelay(value int) error {
+	return v.service.EmitPropertyChanged(v, "BatterySleepDelay", value)
+}
+
+func (v *Manager) setPropScreenBlackLock(value bool) (changed bool) {
+	if v.ScreenBlackLock != value {
+		v.ScreenBlackLock = value
+		v.emitPropChangedScreenBlackLock(value)
+		return true
+	}
+	return false
+}
+
+func (v *Manager) emitPropChangedScreenBlackLock(value bool) error {
+	return v.service.EmitPropertyChanged(v, "ScreenBlackLock", value)
+}
+
+func (v *Manager) setPropSleepLock(value bool) (changed bool) {
+	if v.SleepLock != value {
+		v.SleepLock = value
+		v.emitPropChangedSleepLock(value)
+		return true
+	}
+	return false
+}
+
+func (v *Manager) emitPropChangedSleepLock(value bool) error {
+	return v.service.EmitPropertyChanged(v, "SleepLock", value)
+}
+
+func (v *Manager) setPropLinePowerLidClosedAction(value int32) (changed bool) {
+	if v.LinePowerLidClosedAction != value {
+		v.LinePowerLidClosedAction = value
+		v.emitPropChangedLinePowerLidClosedAction(value)
+		return true
+	}
+	return false
+}
+
+func (v *Manager) emitPropChangedLinePowerLidClosedAction(value int32) error {
+	return v.service.EmitPropertyChanged(v, "LinePowerLidClosedAction", value)
+}
+
+func (v *Manager) setPropLinePowerPressPowerBtnAction(value int32) (changed bool) {
+	if v.LinePowerPressPowerBtnAction != value {
+		v.LinePowerPressPowerBtnAction = value
+		v.emitPropChangedLinePowerPressPowerBtnAction(value)
+		return true
+	}
+	return false
+}
+
+func (v *Manager) emitPropChangedLinePowerPressPowerBtnAction(value int32) error {
+	return v.service.EmitPropertyChanged(v, "LinePowerPressPowerBtnAction", value)
+}
+
+func (v *Manager) setPropBatteryLidClosedAction(value int32) (changed bool) {
+	if v.BatteryLidClosedAction != value {
+		v.BatteryLidClosedAction = value
+		v.emitPropChangedBatteryLidClosedAction(value)
+		return true
+	}
+	return false
+}
+
+func (v *Manager) emitPropChangedBatteryLidClosedAction(value int32) error {
+	return v.service.EmitPropertyChanged(v, "BatteryLidClosedAction", value)
+}
+
+func (v *Manager) setPropBatteryPressPowerBtnAction(value int32) (changed bool) {
+	if v.BatteryPressPowerBtnAction != value {
+		v.BatteryPressPowerBtnAction = value
+		v.emitPropChangedBatteryPressPowerBtnAction(value)
+		return true
+	}
+	return false
+}
+
+func (v *Manager) emitPropChangedBatteryPressPowerBtnAction(value int32) error {
+	return v.service.EmitPropertyChanged(v, "BatteryPressPowerBtnAction", value)
+}
+
+func (v *Manager) setPropLinePowerLockDelay(value int) (changed bool) {
+	if v.LinePowerLockDelay != value {
+		v.LinePowerLockDelay = value
+		v.emitPropChangedLinePowerLockDelay(value)
+		return true
+	}
+	return false
+}
+
+func (v *Manager) emitPropChangedLinePowerLockDelay(value int) error {
+	return v.service.EmitPropertyChanged(v, "LinePowerLockDelay", value)
+}
+
+func (v *Manager) setPropBatteryLockDelay(value int) (changed bool) {
+	if v.BatteryLockDelay != value {
+		v.BatteryLockDelay = value
+		v.emitPropChangedBatteryLockDelay(value)
+		return true
+	}
+	return false
+}
+
+func (v *Manager) emitPropChangedBatteryLockDelay(value int) error {
+	return v.service.EmitPropertyChanged(v, "BatteryLockDelay", value)
+}
+
+func (v *Manager) setPropLowPowerNotifyEnable(value bool) (changed bool) {
+	if v.LowPowerNotifyEnable != value {
+		v.LowPowerNotifyEnable = value
+		v.emitPropChangedLowPowerNotifyEnable(value)
+		return true
+	}
+	return false
+}
+
+func (v *Manager) emitPropChangedLowPowerNotifyEnable(value bool) error {
+	return v.service.EmitPropertyChanged(v, "LowPowerNotifyEnable", value)
+}
+
+func (v *Manager) setPropLowPowerNotifyThreshold(value int32) (changed bool) {
+	if v.LowPowerNotifyThreshold != value {
+		v.LowPowerNotifyThreshold = value
+		v.emitPropChangedLowPowerNotifyThreshold(value)
+		return true
+	}
+	return false
+}
+
+func (v *Manager) emitPropChangedLowPowerNotifyThreshold(value int32) error {
+	return v.service.EmitPropertyChanged(v, "LowPowerNotifyThreshold", value)
+}
+
+func (v *Manager) setPropLowPowerAutoSleepThreshold(value int32) (changed bool) {
+	if v.LowPowerAutoSleepThreshold != value {
+		v.LowPowerAutoSleepThreshold = value
+		v.emitPropChangedLowPowerAutoSleepThreshold(value)
+		return true
+	}
+	return false
+}
+
+func (v *Manager) emitPropChangedLowPowerAutoSleepThreshold(value int32) error {
+	return v.service.EmitPropertyChanged(v, "LowPowerAutoSleepThreshold", value)
+}
+
+func (v *Manager) setPropLowPowerAction(value int32) (changed bool) {
+	if v.LowPowerAction != value {
+		v.LowPowerAction = value
+		v.emitPropChangedLowPowerAction(value)
+		return true
+	}
+	return false
+}
+
+func (v *Manager) emitPropChangedLowPowerAction(value int32) error {
+	return v.service.EmitPropertyChanged(v, "LowPowerAction", value)
+}
+
+func (v *Manager) setPropAmbientLightAdjustBrightness(value bool) (changed bool) {
+	if v.AmbientLightAdjustBrightness != value {
+		v.AmbientLightAdjustBrightness = value
+		v.emitPropChangedAmbientLightAdjustBrightness(value)
+		return true
+	}
+	return false
+}
+
+func (v *Manager) emitPropChangedAmbientLightAdjustBrightness(value bool) error {
+	return v.service.EmitPropertyChanged(v, "AmbientLightAdjustBrightness", value)
+}
+
 func (v *Manager) setPropIsHighPerformanceSupported(value bool) (changed bool) {
 	if v.IsHighPerformanceSupported != value {
 		v.IsHighPerformanceSupported = value

--- a/session/power1/sync_config.go
+++ b/session/power1/sync_config.go
@@ -13,8 +13,8 @@ type syncConfig struct {
 func (sc *syncConfig) Get() (interface{}, error) {
 	return &syncData{
 		Version:         "1.0",
-		ScreenBlackLock: sc.m.ScreenBlackLock.Get(),
-		SleepLock:       sc.m.SleepLock.Get(),
+		ScreenBlackLock: sc.m.ScreenBlackLock,
+		SleepLock:       sc.m.SleepLock,
 	}, nil
 }
 
@@ -24,8 +24,8 @@ func (sc *syncConfig) Set(data []byte) error {
 	if err != nil {
 		return err
 	}
-	sc.m.ScreenBlackLock.Set(v.ScreenBlackLock)
-	sc.m.SleepLock.Set(v.SleepLock)
+	sc.m.ScreenBlackLock = v.ScreenBlackLock
+	sc.m.SleepLock = v.SleepLock
 	return nil
 }
 


### PR DESCRIPTION
Change all places that use gsettings to dconfig for storage

pms: TASK-374909

## Summary by Sourcery

Migrate backend configuration storage from GSettings to dconfig across power and keybinding daemons

Enhancements:
- Migrate power service persistence to dconfig: replace GSettings, gsprop and gio.Settings with dsync.Config and ConfigManager in power manager and submodules
- Refactor keybinding module to use ConfigManager for loading, saving and watching shortcuts, replacing GSettingsShortcut with ShortcutObject and initDconfig logic
- Remove all GIO/gsettings and gsprop dependencies, switch to native Go types for D-Bus properties and simplify reset logic using dconfig
- Introduce utility functions for safe conversion of dconfig variant data to Go types and handle dconfig signals for live configuration updates