### PR TITLE
fix: resolve touchpad state persistence issue after system restart

### DIFF
--- a/inputdevices1/touchpad.go
+++ b/inputdevices1/touchpad.go
@@ -187,7 +187,6 @@ func (tpad *Touchpad) init() {
 				if !hasValue {
 					return
 				}
-				tpad.TPadEnable.Set(value)
 				tpad.enable(tpad.TPadEnable.Get())
 			})
 			if enabled, err := sysTouchPad.Enable().Get(0); err != nil {
@@ -198,7 +197,9 @@ func (tpad *Touchpad) init() {
 		}
 	}
 
-	tpad.enable(tpad.TPadEnable.Get())
+	currentState := tpad.TPadEnable.Get()
+	tpad.TPadEnable.Set(!currentState)
+	tpad.enable(currentState)
 	tpad.enableLeftHanded()
 	tpad.enableNaturalScroll()
 	tpad.enableEdgeScroll()


### PR DESCRIPTION
- Removed redundant TPadEnable.Set() call in system touchpad signal handler to prevent overriding user preferences
- Added temporary state toggle mechanism in init() to force hardware state synchronization
- Ensured user's touchpad disable setting is properly applied to hardware during initialization

Log: fix touchpad remaining functional after restart when disabled in settings
pms: BUG-329389