### PR TITLE
fix: 解决蓝牙文件传输拒绝后，依旧在传输的问题

### DIFF
--- a/bluetooth1/obex_agent.go
+++ b/bluetooth1/obex_agent.go
@@ -167,7 +167,11 @@ func (a *obexAgent) AuthorizePush(transferPath dbus.ObjectPath) (tempFileName st
 	if !accepted {
 		err = errors.New("session declined")
 		logger.Warning(err)
-		return "", dbusutil.ToError(err)
+		dbusErr := &dbus.Error{
+			Name: "org.bluez.obex.Error.Rejected",
+			Body: []interface{}{err.Error()},
+		}
+		return "", dbusErr
 	}
 	// 设置未文件不能传输状态
 	a.b.setPropTransportable(false)


### PR DESCRIPTION
拒绝文件传输后，obex是匹配错误名称：org.bluez.obex.Error.Rejected，所以不能用其他error。所以要指定改错误名。

Log: 拒绝文件传输指定dbus的错误名
PMS: BUG-284631