### PR TITLE
refactor: migrate display settings from gsettings to dconfig

### DIFF
--- a/display1/brightness.go
+++ b/display1/brightness.go
@@ -111,7 +111,7 @@ func (m *Manager) changeBrightness(raised bool) error {
 }
 
 func (m *Manager) getSavedBrightnessTable() (map[string]float64, error) {
-	value := m.settings.GetString(gsKeyBrightness)
+	value := m.getBrightness()
 	if value == "" {
 		return nil, nil
 	}
@@ -131,18 +131,24 @@ func (m *Manager) initBrightness() {
 	m.Brightness = brightnessTable
 }
 
-func (m *Manager) getBrightnessSetter() string {
+func (m *Manager) getBrightnessSetter() int {
 	// NOTE: 特殊处理龙芯笔记本亮度设置问题
 	blDir := "/sys/class/backlight/loongson"
 	_, err := os.Stat(blDir)
 	if err == nil {
 		_, err := os.Stat(filepath.Join(blDir, "device/edid"))
 		if err != nil {
-			return "backlight"
+			return brightness.BrightnessSetterBacklight
 		}
 	}
 
-	return m.settings.GetString(gsKeySetter)
+	v, err := m.displayConfigMgr.Value(0, DSettingsKeyBrightnessSetter)
+	if err != nil {
+		logger.Warning(err)
+		return brightness.BrightnessSetterAuto
+	}
+
+	return int(v.Value().(int64))
 }
 
 // see also: gnome-desktop/libgnome-desktop/gnome-rr.c

--- a/display1/brightness/brightness.go
+++ b/display1/brightness/brightness.go
@@ -24,9 +24,9 @@ func SetUseWayland(value bool) {
 }
 
 const (
-	SetterAuto      = "auto"
-	SetterGamma     = "gamma"
-	SetterBacklight = "backlight"
+	BrightnessSetterAuto      = 0 // auto
+	BrightnessSetterGamma     = 1 // gamma
+	BrightnessSetterBacklight = 2 // backlight
 )
 
 var logger = log.NewLogger("daemon/display/brightness")
@@ -42,7 +42,7 @@ func InitBacklightHelper() {
 	helper = backlight.NewBacklight(sysBus)
 }
 
-func Set(brightness float64, temperature int, setter string, isBuiltin bool, outputId uint32, conn *x.Conn) error {
+func Set(brightness float64, temperature int, setter int, isBuiltin bool, outputId uint32, conn *x.Conn) error {
 	if brightness < 0 {
 		brightness = 0
 	} else if brightness > 1 {
@@ -79,28 +79,28 @@ func Set(brightness float64, temperature int, setter string, isBuiltin bool, out
 
 	setFn := setGamma
 	switch setter {
-	case SetterBacklight:
+	case BrightnessSetterBacklight:
 		setFn = setBlGamma
-	case SetterAuto:
+	case BrightnessSetterAuto:
 		if isBuiltin && supportBacklight() {
 			setFn = setBlGamma
 		}
-		//case SetterGamma
+		//case BrightnessSetterGamma
 	}
 	return setFn()
 }
 
 // unused function
-//func Get(setter string, isButiltin bool, outputId uint32, conn *x.Conn) (float64, error) {
+//func Get(setter int, isButiltin bool, outputId uint32, conn *x.Conn) (float64, error) {
 //	output := randr.Output(outputId)
 //	switch setter {
-//	case SetterBacklight:
+//	case BrightnessSetterBacklight:
 //		return getBacklightOnlyOne()
-//	case SetterGamma:
+//	case BrightnessSetterGamma:
 //		return 1, nil
 //	}
 //
-//	// case SetterAuto
+//	// case BrightnessSetterAuto
 //	if isButiltin {
 //		if supportBacklight(output, conn) {
 //			return getBacklight(output, conn)

--- a/display1/main.go
+++ b/display1/main.go
@@ -12,7 +12,6 @@ import (
 	"github.com/godbus/dbus/v5"
 	"github.com/linuxdeepin/dde-daemon/loader"
 	"github.com/linuxdeepin/go-lib/dbusutil"
-	"github.com/linuxdeepin/go-lib/gsettings"
 	"github.com/linuxdeepin/go-lib/log"
 	x "github.com/linuxdeepin/go-x11-client"
 )
@@ -80,11 +79,6 @@ func (*daemon) Start() error {
 			logger.Warning("start display part2 failed:", err)
 		}
 	}()
-
-	err = gsettings.StartMonitor()
-	if err != nil {
-		logger.Warning("gsettings start monitor failed:", err)
-	}
 
 	sysBus, err := dbus.SystemBus()
 	if err != nil {

--- a/misc/dsg-configs/org.deepin.Display.json
+++ b/misc/dsg-configs/org.deepin.Display.json
@@ -2,41 +2,181 @@
   "magic": "dsg.config.meta",
   "version": "1.0",
   "contents": {
-    "auto-color-temperature": {
+    "autoColorTemperature": {
       "value": "6500:3500",
       "serial": 0,
       "flags": [],
       "name": "auto color temperature",
+      "name[zh_CN]": "自动色温调节",
       "description": "Automatically adjust color temperature",
+      "description[zh_CN]": "自动调节屏幕色温",
       "permissions": "readwrite",
       "visibility": "private"
     },
-    "default-temperature-manual": {
+    "defaultTemperatureManual": {
       "value": 3500,
       "serial": 0,
       "flags": [],
       "name": "default temperature manual",
+      "name[zh_CN]": "手动模式下的色温默认值",
       "description": "default temperature by manual",
+      "description[zh_CN]": "手动模式下的默认色温值",
       "permissions": "readwrite",
       "visibility": "private"
     },
-    "custom-mode-time": {
+    "customModeTime": {
       "value": "22:00-7:00",
       "serial": 0,
       "flags": [],
       "name": "Color Temperature Custom Mode Time",
+      "name[zh_CN]": "色温自定义模式时间范围",
       "description": "Recording the time for custom mode",
+      "description[zh_CN]": "记录自定义模式的时间设置",
       "permissions": "readwrite",
       "visibility": "private"
     },
-    "color-temperature-mode-on": {
+    "colorTemperatureModeOn": {
       "value": 2,
       "serial": 0,
       "flags": [],
       "name": "Color Temperature Mode On",
+      "name[zh_CN]": "色温模式开关",
       "description": "Recording the mode for last time",
+      "description[zh_CN]": "记录上次使用的色温模式",
       "permissions": "readwrite",
       "visibility": "private"
+    },
+    "brightnessSetter": {
+      "value": 0,
+      "serial": 0,
+      "flags": [],
+      "name": "brightness setter",
+      "name[zh_CN]": "亮度设置方式",
+      "description": "The method for setting brightness. 0: auto, 1: gamma, 2: backlight",
+      "description[zh_CN]": "设置亮度的方法。0: 自动, 1: 伽马值, 2: 背光",
+      "permissions": "readwrite",
+      "visibility": "public"
+    },
+    "displayMode": {
+      "value": 2,
+      "serial": 0,
+      "flags": [],
+      "name": "display mode",
+      "name[zh_CN]": "显示模式",
+      "description": "The multi monitors display mode. 0: custom, 1: mirrors, 2: extend, 3: onlyone, 4: unknow",
+      "description[zh_CN]": "多显示器显示模式。0: 自定义, 1: 镜像, 2: 扩展, 3: 仅一个, 4: 未知",
+      "permissions": "readwrite",
+      "visibility": "public"
+    },
+    "brightness": {
+      "value": "",
+      "serial": 0,
+      "flags": [],
+      "name": "brightness",
+      "name[zh_CN]": "亮度设置",
+      "description": "The monitor brightness",
+      "description[zh_CN]": "显示器亮度设置",
+      "permissions": "readwrite",
+      "visibility": "public"
+    },
+    "mapOutput": {
+      "value": "",
+      "serial": 0,
+      "flags": [],
+      "name": "map output",
+      "name[zh_CN]": "输出显示器映射",
+      "description": "Output monitor map",
+      "description[zh_CN]": "输出显示器映射关系",
+      "permissions": "readwrite",
+      "visibility": "public"
+    },
+    "rateFilter": {
+      "value": "{\"1002:6611\": {\"1920*1080\": [59.94, 30, 29.97, 25, 24, 23.98],\"1680*945\": [60.02]},\"1002:6779\": {\"1920*1080\": [30,29.97,25,24,23.98]}}",
+      "serial": 0,
+      "flags": [],
+      "name": "rate filter",
+      "name[zh_CN]": "刷新率过滤器",
+      "description": "Screen refresh rate filter in JSON",
+      "description[zh_CN]": "屏幕刷新率过滤器配置（JSON格式）",
+      "permissions": "readwrite",
+      "visibility": "public"
+    },
+    "primary": {
+      "value": "",
+      "serial": 0,
+      "flags": [],
+      "name": "primary output",
+      "name[zh_CN]": "主屏",
+      "description": "The primary output",
+      "description[zh_CN]": "主显示输出设备",
+      "permissions": "readwrite",
+      "visibility": "public"
+    },
+    "currentCustomMode": {
+      "value": "",
+      "serial": 0,
+      "flags": [],
+      "name": "current custom mode",
+      "name[zh_CN]": "当前自定义模式",
+      "description": "The id of config only in custom mode",
+      "description[zh_CN]": "自定义模式下的配置ID",
+      "permissions": "readwrite",
+      "visibility": "public"
+    },
+    "blacklist": {
+      "value": [],
+      "serial": 0,
+      "flags": [],
+      "name": "blacklist",
+      "name[zh_CN]": "不支持的屏幕",
+      "description": "Filter some invalid outputs",
+      "description[zh_CN]": "过滤一些无效的输出设备",
+      "permissions": "readwrite",
+      "visibility": "public"
+    },
+    "priority": {
+      "value": [],
+      "serial": 0,
+      "flags": [],
+      "name": "priority",
+      "name[zh_CN]": "输出优先级",
+      "description": "Outputs priority, the first will be primary",
+      "description[zh_CN]": "输出设备优先级，第一个将作为主输出",
+      "permissions": "readwrite",
+      "visibility": "public"
+    },
+    "colorTemperatureMode": {
+      "value": 0,
+      "serial": 0,
+      "flags": [],
+      "name": "color temperature mode",
+      "name[zh_CN]": "色温调节模式",
+      "description": "Method of adjust color temperature. 0: normal, 1: auto, 2: manual",
+      "description[zh_CN]": "色温调节方式。0: 正常, 1: 自动, 2: 手动",
+      "permissions": "readwrite",
+      "visibility": "public"
+    },
+    "rotateScreenTimeDelay": {
+      "value": 500,
+      "serial": 0,
+      "flags": [],
+      "name": "rotate screen time delay",
+      "name[zh_CN]": "屏幕旋转延时",
+      "description": "Rotate the screen when the delay ends (range: 0-10000ms)",
+      "description[zh_CN]": "屏幕旋转延时结束后执行旋转（范围：0-10000毫秒）",
+      "permissions": "readwrite",
+      "visibility": "public"
+    },
+    "customDisplayMode": {
+      "value": 1,
+      "serial": 0,
+      "flags": [],
+      "name": "custom display mode",
+      "name[zh_CN]": "自定义显示模式",
+      "description": "The mode of custom display (range: 1-2)",
+      "description[zh_CN]": "自定义显示模式类型（范围：1-2）",
+      "permissions": "readwrite",
+      "visibility": "public"
     }
   }
 }


### PR DESCRIPTION
1. Replaced gsettings with dconfig for all display-related settings management
2. Changed brightness setter from string type to int type with constants (Auto=0, Gamma=1, Backlight=2)
3. Added comprehensive dconfig schema with all display settings including brightness, display mode, color temperature, etc
4. Implemented proper config value retrieval methods with error handling and default values
5. Removed gsettings monitoring and replaced with dconfig value change signals
6. Updated touchscreen mapping to use dconfig instead of gsettings
7. Added Chinese translations for all config items in the schema file

refactor: 将显示设置从 gsettings 迁移到 dconfig

1. 将所有显示相关设置管理从 gsettings 替换为 dconfig
2. 将亮度设置器从字符串类型改为整型常量（自动=0，伽马=1，背光=2）
3. 添加了完整的 dconfig 模式，包含亮度、显示模式、色温等所有显示设置
4. 实现了带有错误处理和默认值的配置值获取方法
5. 移除了 gsettings 监控，替换为 dconfig 值变更信号
6. 更新了触摸屏映射以使用 dconfig 而非 gsettings
7. 在模式文件中为所有配置项添加了中文翻译

pms: TASK-374909