### PR TITLE
fix: correct touchpad enable function parameter

### DIFF
--- a/inputdevices1/touchpad.go
+++ b/inputdevices1/touchpad.go
@@ -187,7 +187,7 @@ func (tpad *Touchpad) init() {
 				if !hasValue {
 					return
 				}
-				tpad.enable(tpad.TPadEnable.Get())
+				tpad.enable(value)
 			})
 			if enabled, err := sysTouchPad.Enable().Get(0); err != nil {
 				logger.Warning(err)


### PR DESCRIPTION
- Updated touchpad.go to use the received value parameter instead of re-fetching from TPadEnable

Log: correct touchpad enable function parameter
pms: BUG-329389

## Summary by Sourcery

Bug Fixes:
- Use the received value in tpad.enable instead of re-fetching TPadEnable.Get()