### PR TITLE
fix: prevent GTK window size change on daemon exit

### DIFF
--- a/xsettings1/xsettings_dpi.go
+++ b/xsettings1/xsettings_dpi.go
@@ -73,7 +73,20 @@ func (m *XSManager) updateDPI() {
 
 func (m *XSManager) updateXResources() {
 	scaleFactor := m.cfgHelper.GetDouble(gsKeyScaleFactor)
-	xftDpi := int(DPI_FALLBACK * scaleFactor)
+	windowScale := m.cfgHelper.GetInt(gsKeyWindowScale)
+	
+	var xftDpi int
+	if windowScale > 1 {
+		// Mixed scaling mode: Keep XResources Xft.dpi consistent with xsettings Gdk/UnscaledDPI
+		// This prevents DPI jumping when daemon exits, as GTK will use the same base DPI value
+		xftDpi = DPI_FALLBACK  // 96 - matches Gdk/UnscaledDPI (96*1024)/1024
+		logger.Debugf("Mixed scaling mode: windowScale=%d, setting Xft.dpi=%d to match Gdk/UnscaledDPI", windowScale, xftDpi)
+	} else {
+		// Pure DPI scaling mode: Normal DPI scaling
+		xftDpi = int(DPI_FALLBACK * scaleFactor)
+		logger.Debugf("Pure DPI scaling mode: scaleFactor=%.2f, setting Xft.dpi=%d", scaleFactor, xftDpi)
+	}
+	
 	updateXResources(xresourceInfos{
 		&xresourceInfo{
 			key:   "Xcursor.theme",


### PR DESCRIPTION
Fixed an issue where GTK application windows would resize when the
daemon exits by ensuring consistent DPI handling between xsettings and
XResources. In mixed scaling mode (windowScale > 1), Xft.dpi is now
set to match Gdk/UnscaledDPI (96) instead of being scaled, preventing
DPI value jumps when the daemon terminates. This maintains visual
consistency across daemon restarts.

Log: Fixed GTK application window resizing issue when display service
restarts

Influence:
1. Test GTK application window behavior during daemon restart
2. Verify window size remains consistent in mixed scaling mode
3. Check DPI values in xsettings and XResources match
4. Test both pure DPI scaling and mixed scaling modes
5. Verify no visual regression in application appearance

fix: 修复守护进程退出时GTK窗口大小变化问题

修复了守护进程退出时GTK应用窗口会调整大小的问题，通过确保xsettings和
XResources之间的DPI处理一致性。在混合缩放模式（windowScale > 1）下，
Xft.dpi现在设置为匹配Gdk/UnscaledDPI（96）而不是进行缩放，防止守护进程终
止时DPI值跳变。这确保了守护进程重启期间的视觉一致性。

Log: 修复显示服务重启时GTK应用窗口调整大小问题

Influence:
1. 测试守护进程重启期间的GTK应用窗口行为
2. 验证混合缩放模式下窗口大小保持一致性
3. 检查xsettings和XResources中的DPI值是否匹配
4. 测试纯DPI缩放和混合缩放两种模式
5. 验证应用外观没有视觉回归

PMS: BUG-329809
