### PR TITLE
refactor: migrate locale settings from GSettings to DConfig

### DIFF
--- a/langselector1/main.go
+++ b/langselector1/main.go
@@ -7,9 +7,8 @@ package langselector
 import (
 	"time"
 
-	"github.com/linuxdeepin/go-gir/gio-2.0"
+	"github.com/linuxdeepin/dde-daemon/common/dconfig"
 	"github.com/linuxdeepin/go-lib/dbusutil"
-	"github.com/linuxdeepin/go-lib/gsettings"
 	"github.com/linuxdeepin/go-lib/log"
 	"github.com/linuxdeepin/go-lib/strv"
 )
@@ -44,7 +43,6 @@ func Run() {
 
 	initNotifyTxt()
 	lang.connectSettingsChanged()
-	err = gsettings.StartMonitor()
 	if err != nil {
 		logger.Warning("failed to start monitor settings:", err)
 	}
@@ -59,11 +57,17 @@ func Run() {
 
 func GetLocales() []string {
 	currentLocale := getCurrentUserLocale()
-	settings := gio.NewSettings(gsSchemaLocale)
-	locales := settings.GetStrv(gsKeyLocales)
+	dconfig, err := dconfig.NewDConfig(dconfigAppID, dconfigLocaleId, "")
+	if err != nil {
+		logger.Warning("failed to new dconfig:", err)
+	}
+	locales, err := dconfig.GetValueStringList(dconfigKeyLocales)
+	if err != nil {
+		logger.Warning("failed to get locales:", err)
+		return nil
+	}
 	if !strv.Strv(locales).Contains(currentLocale) {
 		locales = append(locales, currentLocale)
 	}
-	settings.Unref()
 	return locales
 }

--- a/misc/dsg-configs/org.deepin.dde.daemon.locale.json
+++ b/misc/dsg-configs/org.deepin.dde.daemon.locale.json
@@ -1,0 +1,16 @@
+{
+    "magic": "dsg.config.meta",
+    "version": "1.0",
+    "contents": {
+        "locales": {
+            "value": [],
+            "serial": 0,
+            "flags": [],
+            "name": "language list",
+            "name[zh_CN]": "语言列表",
+            "description": "language list",
+            "permissions": "readwrite",
+            "visibility": "private"
+        }
+    }
+}


### PR DESCRIPTION
Replaced GSettings with DConfig for managing locale settings to align with the new configuration system. Added new DConfig JSON configuration file for locale settings. Updated all locale-related operations to use DConfig API instead of GSettings. This change improves configuration management consistency across the system and provides better integration with the deepin configuration framework.

重构：将区域设置从 GSettings 迁移到 DConfig

使用 DConfig 替换 GSettings 来管理区域设置，以符合新的配置系统。为区域设
置添加了新的 DConfig JSON 配置文件。更新了所有与区域设置相关的操作，使用
DConfig API 替代 GSettings。这一变化提高了系统配置管理的一致性，并提供了
与深度配置框架更好的集成。

pms: TASK-381277