### PR TITLE
fix: correct logger method call in sync config

### DIFF
--- a/audio1/sync_config.go
+++ b/audio1/sync_config.go
@@ -84,7 +84,7 @@ func (sc *syncConfig) Get() (interface{}, error) {
 		value, err := s.GetValueBool(key)
 		if err != nil {
 			// 记录日志或处理错误
-			logger.Warning("Failed to get boolean for key %s: %v, using default %v", key, err, defaultValue)
+			logger.Warningf("Failed to get boolean for key %s: %v, using default %v", key, err, defaultValue)
 			return defaultValue
 		}
 		return value


### PR DESCRIPTION
Changed logger.Warning to logger.Warningf to properly format the log message with parameters
The original call was missing the 'f' suffix required for formatted logging methods
This ensures error messages are properly formatted with the key, error, and default value

fix: 修复同步配置中的日志记录器方法调用

将 logger.Warning 改为 logger.Warningf 以正确格式化带参数的日志消息 原始调用缺少格式化日志方法所需的 'f' 后缀
确保错误消息能够正确格式化显示键、错误和默认值

## Summary by Sourcery

Bug Fixes:
- Use logger.Warningf instead of logger.Warning to correctly format messages with parameters