### PR TITLE
fix: Password authentication is required when system was waked up

### DIFF
--- a/session/power1/manager.go
+++ b/session/power1/manager.go
@@ -208,6 +208,13 @@ type Manager struct {
 	delayInActive                             bool
 	delayWakeupInterval                       uint32
 	delayHandleIdleOffIntervalWhenScreenBlack uint32
+
+	// 睡眠前屏幕保护是否正在运行
+	screensaverWasRunning bool
+	// 睡眠前屏幕保护恢复时是否需要密码
+	screensaverLockAtAwake bool
+	// 是否已在进入待机流程前抓取过屏幕保护状态
+	screensaverStateCaptured bool
 }
 
 var _manager *Manager


### PR DESCRIPTION
Password authentication is required when the system suspend from lock widget,
 even if wake-up switch is turned on which password authentication is not required.
即使打开了唤醒免密码,但是从锁屏界面待机唤醒后,仍然需要认证.

Log: as title
Pms: STORY-39325

## Summary by Sourcery

Capture and respect the screensaver's lock-at-awake and running state before suspend so that the system only prompts for a password on wakeup if the screensaver was active and configured to lock, thereby honoring the wake-up no-password setting

Bug Fixes:
- Honor the wake-up no-password setting when suspending from the lock widget by properly capturing and respecting the screensaver’s lock-at-awake flag

Enhancements:
- Add DBus helpers to query generic screensaver properties (isRunning, lockScreenAtAwake)
- Introduce captureScreensaverStateIfNeeded to record screensaver state and integrate it into all suspend paths and the power_save_plan
- Modify wakeup handler to conditionally display the lock screen only if the screensaver was running and required a password on wakeup