### PR TITLE
fix: touchpad cannot be properly disabled

### DIFF
--- a/inputdevices1/touchpad.go
+++ b/inputdevices1/touchpad.go
@@ -202,7 +202,7 @@ func (tpad *Touchpad) init() {
 
 	currentState := tpad.TPadEnable.Get()
 	tpad.TPadEnable.Set(!currentState)
-	tpad.enable(!currentState)
+	tpad.enable(currentState)
 	tpad.enableLeftHanded()
 	tpad.enableNaturalScroll()
 	tpad.enableEdgeScroll()
@@ -565,7 +565,12 @@ func (tpad *Touchpad) initTouchpadDConfig() error {
 		logger.Debugf("Touchpad dconfig value changed: %s", key)
 		switch key {
 		case dconfigKeyTouchpadEnabled:
-			tpad.enable(true)
+			enabled, err := tpad.dsgTouchpadConfig.GetValueBool(dconfigKeyTouchpadEnabled)
+			if err != nil {
+				logger.Warningf("Failed to get touchpad enabled value from dconfig: %v", err)
+			} else {
+				tpad.enable(enabled)
+			}
 		case dconfigKeyTouchpadLeftHanded:
 			tpad.enableLeftHanded()
 		case dconfigKeyTouchpadDisableTyping:


### PR DESCRIPTION
- Fix inverted enable state causing auto re-enable
- Read actual config value to respect user setting

Log: touchpad cannot be properly disabled
pms: BUG-333935

## Summary by Sourcery

Fix inverted touchpad enable logic during initialization and respect the actual dconfig setting to allow proper disabling

Bug Fixes:
- Correct the initial enable call to use the true current state instead of its inverse
- Fetch and apply the actual dconfig 'touchpad enabled' value instead of always enabling on change