### PR TITLE
refactor: migrate audio configuration from gsettings to dconfig

### DIFF
--- a/audio1/audio_events.go
+++ b/audio1/audio_events.go
@@ -15,7 +15,6 @@ import (
 	notifications "github.com/linuxdeepin/go-dbus-factory/session/org.freedesktop.notifications"
 	"github.com/linuxdeepin/go-lib/dbusutil"
 	"github.com/linuxdeepin/go-lib/gettext"
-	"github.com/linuxdeepin/go-lib/gsettings"
 	"github.com/linuxdeepin/go-lib/pulse"
 )
 
@@ -766,38 +765,6 @@ func (a *Audio) handleServerEvent(eventType int) {
 		a.updateDefaultSink(server.DefaultSinkName)
 		a.updateDefaultSource(server.DefaultSourceName)
 	}
-}
-
-func (a *Audio) listenGSettingVolumeIncreaseChanged() {
-	gsettings.ConnectChanged(gsSchemaAudio, gsKeyVolumeIncrease, func(val string) {
-		volInc := a.settings.GetBoolean(gsKeyVolumeIncrease)
-		if volInc {
-			a.MaxUIVolume = increaseMaxVolume
-		} else {
-			a.MaxUIVolume = normalMaxVolume
-		}
-		gMaxUIVolume = a.MaxUIVolume
-		err := a.emitPropChangedMaxUIVolume(a.MaxUIVolume)
-		if err != nil {
-			logger.Warning("changed Max UI Volume failed: ", err)
-		} else {
-			sink := a.getDefaultSink()
-			if sink == nil {
-				logger.Warning("default sink is nil")
-				return
-			}
-			GetConfigKeeper().SetIncreaseVolume(a.getCardNameById(sink.Card), sink.ActivePort.Name, volInc)
-		}
-	})
-}
-
-func (a *Audio) listenGSettingDeviceManageChanged() {
-	gsettings.ConnectChanged(gsSchemaControlCenter, gsKeyDeviceManager, func(val string) {
-		if a.enableAutoSwitchPort != a.controlCenterDeviceManager.Get() {
-			a.controlCenterDeviceManager.Set(a.enableAutoSwitchPort)
-			logger.Info("listenGSettingDeviceManageChanged set a.enableAutoSwitchPort to a.controlCenterDeviceManager. value : ", a.enableAutoSwitchPort)
-		}
-	})
 }
 
 // 外部修改ReducecNoise时触发回调，响应实际降噪开关

--- a/common/dconfig/dconfig.go
+++ b/common/dconfig/dconfig.go
@@ -137,6 +137,25 @@ func (dConfig *DConfig) GetValueStringList(key string) ([]string, error) {
 	return nil, fmt.Errorf("unsupported type for string slice conversion: %T", value)
 }
 
+func (dConfig *DConfig) GetValueInt64List(key string) ([]int64, error) {
+	value, err := dConfig.GetValue(key)
+	if err != nil {
+		return nil, err
+	}
+	if variantSlice, ok := value.([]dbus.Variant); ok {
+		result := make([]int64, len(variantSlice))
+		for i, variant := range variantSlice {
+			if iv, ok := variant.Value().(int64); ok {
+				result[i] = iv
+			} else {
+				return nil, fmt.Errorf("variant at index %d is not a int64: %T", i, variant.Value())
+			}
+		}
+		return result, nil
+	}
+	return nil, fmt.Errorf("unsupported type for int64 slice conversion: %T", value)
+}
+
 func (dConfig *DConfig) GetValue(key string) (interface{}, error) {
 	if dConfig.manager == nil {
 		return nil, fmt.Errorf("dConfig not inited")

--- a/misc/dsg-configs/org.deepin.dde.daemon.audio.json
+++ b/misc/dsg-configs/org.deepin.dde.daemon.audio.json
@@ -109,6 +109,116 @@
       "description": "audio channel mono enabled set",
       "permissions": "readwrite",
       "visibility": "private"
+    },
+    "firstRun": {
+      "value": true,
+      "serial": 0,
+      "flags": [],
+      "name": "firstRun",
+      "name[zh_CN]": "是否已初始化",
+      "description": "If no initialized, do it, otherwise nothing to do.",
+      "description[zh_CN]": "如果未初始化则执行初始化，否则不执行任何操作",
+      "permissions": "readwrite",
+      "visibility": "private"
+    },
+    "inputVolume": {
+      "value": 50,
+      "serial": 0,
+      "flags": [],
+      "name": "inputVolume",
+      "name[zh_CN]": "输入音量百分比",
+      "description": "Input volume percentage range 0 ~ 100",
+      "description[zh_CN]": "输入音量百分比范围 0 ~ 100",
+      "permissions": "readwrite",
+      "visibility": "private"
+    },
+    "outputVolume": {
+      "value": 50,
+      "serial": 0,
+      "flags": [],
+      "name": "outputVolume",
+      "name[zh_CN]": "输出音量百分比",
+      "description": "Output volume percentage range 0 ~ 100",
+      "description[zh_CN]": "输出音量百分比范围 0 ~ 100",
+      "permissions": "readwrite",
+      "visibility": "private"
+    },
+    "headphoneOutputVolume": {
+      "value": 50,
+      "serial": 0,
+      "flags": [],
+      "name": "headphoneOutputVolume",
+      "name[zh_CN]": "耳机输出音量百分比",
+      "description": "Headphone output volume percentage range 0 ~ 100",
+      "description[zh_CN]": "耳机输出音量百分比范围 0 ~ 100",
+      "permissions": "readwrite",
+      "visibility": "private"
+    },
+    "headphoneUnplugAutoPause": {
+      "value": true,
+      "serial": 0,
+      "flags": [],
+      "name": "headphoneUnplugAutoPause",
+      "name[zh_CN]": "耳机拔出自动暂停",
+      "description": "Auto pause media when headphone unplug",
+      "description[zh_CN]": "耳机拔出时自动暂停媒体播放",
+      "permissions": "readwrite",
+      "visibility": "private"
+    },
+    "volumeIncrease": {
+      "value": false,
+      "serial": 0,
+      "flags": [],
+      "name": "volumeIncrease",
+      "name[zh_CN]": "音量增强开关",
+      "description": "if true, max volume be 1.5 ,else 1.0",
+      "description[zh_CN]": "如果为true，最大音量为1.5，否则为1.0",
+      "permissions": "readwrite",
+      "visibility": "private"
+    },
+    "outputVolumeMax": {
+      "value": 150,
+      "serial": 0,
+      "flags": [],
+      "name": "outputVolumeMax",
+      "name[zh_CN]": "输出音量最大百分比",
+      "description": "The max percentage for output volume",
+      "description[zh_CN]": "输出音量的最大百分比",
+      "permissions": "readwrite",
+      "visibility": "private"
+    },
+    "disableAutoMute": {
+      "value": false,
+      "serial": 0,
+      "flags": [],
+      "name": "disableAutoMute",
+      "name[zh_CN]": "禁用自动静音",
+      "description": "Whether to disable ALSA Mixer Auto-Mute Mode",
+      "description[zh_CN]": "是否禁用ALSA混音器自动静音模式",
+      "permissions": "readwrite",
+      "visibility": "private"
+    },
+    "reduceInputNoise": {
+      "value": false,
+      "serial": 0,
+      "flags": [],
+      "name": "reduceInputNoise",
+      "name[zh_CN]": "降低输入噪音",
+      "description": "Whether to reduce input noise",
+      "description[zh_CN]": "是否降低输入噪音",
+      "permissions": "readwrite",
+      "visibility": "private"
+    },
+    "outputAutoSwitchCountMax": {
+      "value": 50,
+      "serial": 0,
+      "flags": [],
+      "name": "outputAutoSwitchCountMax",
+      "name[zh_CN]": "输出自动切换最大计数",
+      "description": "The output auto swich count max",
+      "description[zh_CN]": "输出自动切换的最大计数",
+      "permissions": "readwrite",
+      "visibility": "private"
     }
   }
 }


### PR DESCRIPTION
1. Replaced gsettings with dconfig for all audio configuration management
2. Removed gio and gsprop dependencies, using unified dconfig interface
3. Updated configuration keys from gsettings schema to dconfig format
4. Added dconfig support for control-center sound settings
5. Simplified configuration value handling with type-specific dconfig methods
6. Removed legacy gsettings change listeners and replaced with dconfig valueChanged signals
7. Added GetValueInt64List method to dconfig for handling int64 arrays
8. Updated dsg-configs with new audio configuration keys and values

refactor: 将音频配置从 gsettings 迁移到 dconfig

1. 使用 dconfig 替换所有音频配置管理，替代原有的 gsettings
2. 移除 gio 和 gsprop 依赖，使用统一的 dconfig 接口
3. 将配置键从 gsettings 模式更新为 dconfig 格式
4. 为控制中心声音设置添加 dconfig 支持
5. 使用类型特定的 dconfig 方法简化配置值处理
6. 移除旧的 gsettings 变更监听器，替换为 dconfig 值变更信号
7. 在 dconfig 中添加 GetValueInt64List 方法用于处理 int64 数组
8. 更新 dsg-configs 配置文件，添加新的音频配置键和值

pms: TASK-381277