### PR TITLE
fix: 解决焦点在控制中心更新模块，仍有更新的横幅通知的问题

### DIFF
--- a/lastore1/agent.go
+++ b/lastore1/agent.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 
 	"github.com/godbus/dbus/v5"
-	ControlCenter "github.com/linuxdeepin/go-dbus-factory/session/com.deepin.dde.ControlCenter"
+	ControlCenter "github.com/linuxdeepin/go-dbus-factory/session/org.deepin.dde.controlcenter1"
 	kwayland "github.com/linuxdeepin/go-dbus-factory/session/org.deepin.dde.kwayland1"
 	lastore "github.com/linuxdeepin/go-dbus-factory/system/org.deepin.dde.lastore1"
 	"github.com/linuxdeepin/go-lib/dbusutil"
@@ -18,8 +18,8 @@ import (
 
 const (
 	// lastore agent的interface name
-	sessionAgentInterface = "com.deepin.lastore.Agent"
-	sessionAgentPath      = "/com/deepin/lastore/agent"
+	sessionAgentInterface = "org.deepin.dde.Lastore1.Agent"
+	sessionAgentPath      = "/org/deepin/dde/Lastore1/Agent"
 )
 
 // 对应org.deepin.dde.Network1.GetProxy方法的key值

--- a/lastore1/agent_ifc.go
+++ b/lastore1/agent_ifc.go
@@ -100,7 +100,7 @@ func (a *Agent) SendNotify(sender dbus.Sender, appName string, replacesId uint32
 					if err == nil {
 						if strings.Contains(name, "dde-control-center") {
 							// 焦点在控制中心上,需要判断是否为更新模块
-							currentModule, err := a.controlCenter.CurrentModule().Get(0)
+							currentModule, err := a.controlCenter.Page().Get(0)
 							if err != nil {
 								logger.Warning(err)
 							} else if currentModule == "update" {
@@ -121,7 +121,7 @@ func (a *Agent) SendNotify(sender dbus.Sender, appName string, replacesId uint32
 				logger.Warning(err)
 			} else if strings.Contains(string(output), "dde-control-center") {
 				// 焦点在控制中心上,需要判断是否为更新模块
-				currentModule, err := a.controlCenter.CurrentModule().Get(0)
+				currentModule, err := a.controlCenter.Page().Get(0)
 				if err != nil {
 					logger.Warning(err)
 				} else if currentModule == "update" {

--- a/lastore1/lastore.go
+++ b/lastore1/lastore.go
@@ -80,7 +80,7 @@ func (l *Lastore) destroy() {
 }
 
 func (l *Lastore) GetInterfaceName() string {
-	return "com.deepin.LastoreSessionHelper"
+	return "org.deepin.dde.LastoreSessionHelper1"
 }
 
 func (*Lastore) IsDiskSpaceSufficient() (result bool, busErr *dbus.Error) {


### PR DESCRIPTION
1. 更新模块支持更新中断自动回滚，去掉中断检查。
2. 更新注册的agent的名称和更新模块的名称对不上

Log: 去掉更新中断检查，修改agent的名称
PMS: BUG-313895
Influence: lastore-agent

## Summary by Sourcery

Streamline Lastore's update handling by removing outdated interruption checks and aligning DBus interface and constant names

Bug Fixes:
- Prevent stale update banners when focus is on the control center's update module by removing legacy interruption handling

Enhancements:
- Standardize daemon AppID and name constants to org.deepin.dde.lastore
- Align agent's DBus interface name, session path, and ControlCenter calls to use org.deepin.dde.controlcenter1 and the Page() method
- Update LastoreSessionHelper interface name to org.deepin.dde.LastoreSessionHelper1