### PR TITLE
refactor: remove saving mode brightness drop percent handling

### DIFF
--- a/session/power1/manager.go
+++ b/session/power1/manager.go
@@ -925,8 +925,6 @@ func (m *Manager) initDsg() {
 					logger.Info("Set ScheduledShutdownState property", m.ScheduledShutdownState)
 				}
 			}
-		case dsettingPowerSavingModeBrightnessDropPercent:
-			m.savingModeBrightnessDropPercent = int32(transTypeToInt(data.Value(), 0))
 		case dsettingLinePowerScreensaverDelay:
 			m.LinePowerScreensaverDelay = int(transTypeToInt(data.Value(), 0))
 		case dsettingBatteryScreensaverDelay:
@@ -1049,8 +1047,6 @@ func (m *Manager) savePowerDsgConfig(key string) (err error) {
 		value = m.ShutdownTime
 	case dsettingScheduledShutdownState:
 		value = m.ScheduledShutdownState
-	case dsettingPowerSavingModeBrightnessDropPercent:
-		value = m.savingModeBrightnessDropPercent
 	case dsettingLinePowerScreensaverDelay:
 		value = m.LinePowerScreensaverDelay
 	case dsettingBatteryScreensaverDelay:


### PR DESCRIPTION
Removed handling of dsettingPowerSavingModeBrightnessDropPercent from dsg initialization and save config functions
The savingModeBrightnessDropPercent configuration is now managed and saved in system/power module
This module only listens to dbus property changes for brightness adjustment without modifying or monitoring this configuration Keeps the codebase clean by removing redundant functionality that is handled elsewhere

refactor: 移除省电模式亮度降低百分比处理

从 dsg 初始化和保存配置函数中移除了
dsettingPowerSavingModeBrightnessDropPercent 的处理
savingModeBrightnessDropPercent 配置现在由 system/power 模块管理和保存 本模块仅监听 dbus 属性变化进行亮度调整，不修改或监控此配置
通过移除在其他地方处理的功能冗余保持代码库整洁

pms: BUG-332287