### PR TITLE
refactor: remove xsettings dependency

### DIFF
--- a/inputdevices1/manager.go
+++ b/inputdevices1/manager.go
@@ -199,9 +199,7 @@ Shift_R,Down,Shift_R|Button5
 
 func (m *Manager) init() {
 	// 初始化dconfig并同步配置
-	if err := initDConfig(); err == nil {
-		syncFromDConfig()
-	} else {
+	if err := initDConfig(); err != nil {
 		logger.Warning("dconfig init failed, using default settings")
 	}
 


### PR DESCRIPTION
1. Remove xsettings-related code including schema, settings object and synchronization logic
2. Simplify xsSetInt32 function to only update dconfig without xsettings interaction
3. Remove syncFromDConfig function that was used to sync from dconfig to xsettings
4. Update initialization logic to only handle dconfig errors without sync operation
5. Clean up unused imports and variables related to xsettings

These changes were made because xsettings is no longer needed in the system configuration management. The functionality now relies solely on dconfig for configuration storage and synchronization, simplifying the codebase and removing unnecessary dependencies.

refactor: 移除 xsettings 依赖

1. 移除与 xsettings 相关的代码，包括模式、设置对象和同步逻辑
2. 简化 xsSetInt32 函数，仅更新 dconfig 而不与 xsettings 交互
3. 移除用于从 dconfig 同步到 xsettings 的 syncFromDConfig 函数
4. 更新初始化逻辑，仅处理 dconfig 错误而不执行同步操作
5. 清理与 xsettings 相关的未使用导入和变量

这些更改是因为系统配置管理不再需要 xsettings。功能现在完全依赖 dconfig
进行配置存储和同步，简化了代码库并移除了不必要的依赖。

pms: BUG-335329

## Summary by Sourcery

Remove xsettings dependency and simplify configuration management to rely solely on dconfig.

Enhancements:
- Remove xsettings-related code including schema constant, settings object, locks, and synchronization logic
- Simplify xsSetInt32 to only update dconfig without interacting with xsettings
- Remove syncFromDConfig function and eliminate initial synchronization in Manager.init
- Update initialization logic to only handle dconfig errors without sync operations
- Clean up unused imports and variables related to xsettings