### PR TITLE
fix: handle dconfig initialization failure properly

### DIFF
--- a/audio1/audio.go
+++ b/audio1/audio.go
@@ -246,7 +246,6 @@ func newAudio(service *dbusutil.Service) *Audio {
 	a.dccSoundDconfig, err = dconfig.NewDConfig(dconfigDccAppid, dconfigSoundId, "")
 	if err != nil {
 		logger.Warningf("NewDccDConfig failed: %v", err)
-		return a
 	}
 
 	a.audioDConfig.Reset(dsgKeyInputVolume)
@@ -272,7 +271,9 @@ func newAudio(service *dbusutil.Service) *Audio {
 	}
 	gMaxUIVolume = a.MaxUIVolume
 
-	a.controlCenterDeviceManager.Bind(a.dccSoundDconfig, dsgkeySoundShowDeviceManager)
+	if a.dccSoundDconfig != nil {
+		a.controlCenterDeviceManager.Bind(a.dccSoundDconfig, dsgkeySoundShowDeviceManager)
+	}
 
 	a.sessionSigLoop = dbusutil.NewSignalLoop(service.Conn(), 10)
 	a.syncConfig = dsync.NewConfig("audio", &syncConfig{a: a},
@@ -2115,7 +2116,7 @@ func (a *Audio) setEnableAutoSwitchPort(value bool) {
 	a.enableAutoSwitchPort = value
 	a.PropsMu.Unlock()
 
-	if a.enableAutoSwitchPort != a.controlCenterDeviceManager.Get() {
+	if a.dccSoundDconfig != nil && a.enableAutoSwitchPort != a.controlCenterDeviceManager.Get() {
 		a.controlCenterDeviceManager.Set(a.enableAutoSwitchPort)
 		logger.Info("setEnableAutoSwitchPort set a.enableAutoSwitchPort to a.controlCenterDeviceManager. value : ", a.enableAutoSwitchPort)
 	}

--- a/audio1/audio_events.go
+++ b/audio1/audio_events.go
@@ -805,22 +805,7 @@ func (a *Audio) writeReduceNoise(write *dbusutil.PropertyWrite) *dbus.Error {
 }
 
 func (a *Audio) writeKeyPausePlayer(write *dbusutil.PropertyWrite) *dbus.Error {
-	pausePlayer, ok := write.Value.(bool)
-	if !ok {
-		return dbusutil.ToError(errors.New("type is not bool"))
-	}
-	systemBus, err := dbus.SystemBus()
-	if err != nil {
-		return dbus.MakeFailedError(err)
-	}
-
-	systemConnObj := systemBus.Object("org.desktopspec.ConfigManager", a.configManagerPath)
-	err = systemConnObj.Call("org.desktopspec.ConfigManager.Manager.setValue", 0, dsgkeyPausePlayer, dbus.MakeVariant(pausePlayer)).Err
-	if err != nil {
-		return dbusutil.ToError(errors.New("dconfig Cannot set value " + dsgkeyPausePlayer))
-	}
-	a.setPropPausePlayer(pausePlayer)
-	return nil
+	return dbusutil.ToError(a.audioDConfig.SetValue(dsgkeyPausePlayer, write.Value))
 }
 
 func (a *Audio) notifyBluezCardPortInsert(card *Card) {

--- a/misc/dsg-configs/org.deepin.dde.daemon.audio.json
+++ b/misc/dsg-configs/org.deepin.dde.daemon.audio.json
@@ -3,7 +3,7 @@
   "version": "1.0",
   "contents": {
     "pausePlayer": {
-      "value": true,
+      "value": false,
       "serial":0,
       "flags" : [],
       "name": "PlayerPause",


### PR DESCRIPTION
1. Remove early return when dccSoundDconfig initialization fails to allow audio service to continue functioning
2. Add nil checks before using dccSoundDconfig to prevent null pointer exceptions
3. Simplify pause player configuration by using audioDConfig directly instead of manual DBus calls
4. Change default pausePlayer value from true to false in configuration
5. Partial Revert: 75e72fd1cd22939e8d42487600aadc4876494f48

修复：正确处理 dconfig 初始化失败情况

1. 移除 dccSoundDconfig 初始化失败时的提前返回，确保音频服务能继续运行
2. 在使用 dccSoundDconfig 前添加空值检查，防止空指针异常
3. 简化暂停播放器配置，直接使用 audioDConfig 替代手动 DBus 调用
4. 将配置中 pausePlayer 的默认值从 true 改为 false
5. 部分revert: 75e72fd1cd22939e8d42487600aadc4876494f48，后续在os-config中覆盖配置

pms: BUG-335209

## Summary by Sourcery

Handle DConfig initialization failures gracefully, simplify pause player configuration, adjust default pausePlayer setting, and partly revert a previous commit.

Bug Fixes:
- Allow audio service to continue running when DConfig initialization fails
- Add nil checks to prevent null pointer exceptions when using DConfig

Enhancements:
- Simplify pause player configuration by using audioDConfig.SetValue instead of manual DBus calls
- Change default pausePlayer configuration value from true to false

Chores:
- Partially revert commit 75e72fd1cd22939e8d42487600aadc4876494f48