### PR TITLE
fix: initialize power saving brightness drop percent

### DIFF
--- a/session/power1/manager.go
+++ b/session/power1/manager.go
@@ -967,6 +967,10 @@ func (m *Manager) initDsg() {
 			m.LowPowerNotifyThreshold = int32(transTypeToInt(data.Value(), 0))
 		case dsettingPercentageAction:
 			m.LowPowerAutoSleepThreshold = int32(transTypeToInt(data.Value(), 0))
+		case dsettingPowerSavingModeBrightnessDropPercent:
+			if init {
+				m.savingModeBrightnessDropPercent = int32(transTypeToInt(data.Value(), 0))
+			}
 		}
 
 		// m.scheduledShutdownSwitch(false, false)


### PR DESCRIPTION
1. Added initialization for savingModeBrightnessDropPercent in initDsg function
2. Only sets the value during initial configuration (when init is true)
3. Uses existing transTypeToInt helper function for conversion

Influence:
1. Verify power saving mode brightness adjustment works correctly
2. Test with different brightness drop percentage values
3. Check behavior when changing power saving settings

fix: 初始化省电模式亮度降低百分比

1. 在initDsg函数中添加了对savingModeBrightnessDropPercent的初始化
2. 仅在初始配置时设置该值(当init为true时)
3. 使用现有的transTypeToInt辅助函数进行转换

pms: bug-335141 bug-335147
Influence:
1. 验证省电模式亮度调整功能是否正常工作
2. 测试不同的亮度降低百分比值
3. 检查更改省电设置时的行为

## Summary by Sourcery

Initialize the power saving mode brightness drop percentage during the initial DSG configuration using the existing conversion helper to ensure proper adjustment behavior.

Bug Fixes:
- Initialize savingModeBrightnessDropPercent in initDsg to ensure correct power saving brightness adjustment

Enhancements:
- Limit brightness drop percent assignment to initial configuration
- Use transTypeToInt helper for consistent value conversion