### PR TITLE
feat: able to control if we should register tray selectionmanager via DConfig

### DIFF
--- a/misc/dsg-configs/org.deepin.dde.daemon.trayicon.json
+++ b/misc/dsg-configs/org.deepin.dde.daemon.trayicon.json
@@ -1,0 +1,17 @@
+{
+    "magic": "dsg.config.meta",
+    "version": "1.0",
+    "contents": {
+        "traySelectionManagerScope": {
+            "value": "x11-only",
+            "serial": 0,
+            "flags": [],
+            "name": "traySelectionManagerScope",
+            "name[zh_CN]": "托盘 Selection Manager 注册范围",
+            "description": "Control when to register tray selection manager: never, x11-only, wayland-only, always",
+            "description[zh_CN]": "控制何时注册托盘 Selection Manager：never（不注册）、x11-only（仅 X11）、wayland-only（仅 Wayland）、always（始终注册）",
+            "permissions": "readwrite",
+            "visibility": "public"
+        }
+    }
+}

--- a/trayicon1/daemon.go
+++ b/trayicon1/daemon.go
@@ -1,13 +1,14 @@
-// SPDX-FileCopyrightText: 2018 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 package trayicon
 
 import (
-	"github.com/godbus/dbus/v5"
 	"os"
 
+	"github.com/godbus/dbus/v5"
+	"github.com/linuxdeepin/dde-daemon/common/dconfig"
 	"github.com/linuxdeepin/dde-daemon/loader"
 	"github.com/linuxdeepin/go-lib/dbusutil"
 	"github.com/linuxdeepin/go-lib/log"
@@ -23,6 +24,17 @@ type Daemon struct {
 
 const moduleName = "trayicon"
 
+const (
+	dconfigAppID                 = "org.deepin.dde.daemon"
+	dconfigTrayIconID            = "org.deepin.dde.daemon.trayicon"
+	dconfigKeyTraySelectionScope = "traySelectionManagerScope"
+
+	scopeNever       = "never"
+	scopeX11Only     = "x11-only"
+	scopeWaylandOnly = "wayland-only"
+	scopeAlways      = "always"
+)
+
 func NewDaemon(logger *log.Logger) *Daemon {
 	daemon := new(Daemon)
 	daemon.ModuleBase = loader.NewModuleBase(moduleName, daemon, logger)
@@ -37,6 +49,40 @@ func (d *Daemon) Name() string {
 	return moduleName
 }
 
+func shouldRegisterTraySelectionManager(scope string) bool {
+	sessionType := os.Getenv("XDG_SESSION_TYPE")
+	isWayland := sessionType == "wayland"
+
+	switch scope {
+	case scopeNever:
+		return false
+	case scopeX11Only:
+		return !isWayland
+	case scopeWaylandOnly:
+		return isWayland
+	case scopeAlways:
+		return true
+	default:
+		return !isWayland
+	}
+}
+
+func getTraySelectionManagerScope() string {
+	trayIconDConfig, err := dconfig.NewDConfig(dconfigAppID, dconfigTrayIconID, "")
+	if err != nil {
+		logger.Warning("failed to create trayicon dconfig:", err)
+		return scopeNever
+	}
+
+	scope, err := trayIconDConfig.GetValueString(dconfigKeyTraySelectionScope)
+	if err != nil {
+		logger.Warning("failed to get tray selection manager scope:", err)
+		return scopeNever
+	}
+
+	return scope
+}
+
 func (d *Daemon) Start() error {
 	var err error
 	service := loader.GetService()
@@ -48,8 +94,10 @@ func (d *Daemon) Start() error {
 	d.sigLoop = dbusutil.NewSignalLoop(sessionBus, 10)
 	d.sigLoop.Start()
 
-	if os.Getenv("XDG_SESSION_TYPE") != "wayland" {
-		// init x conn
+	// Enable this on both x11 and wayland(for xwayland support)
+	// #region init x conn
+	scope := getTraySelectionManagerScope()
+	if shouldRegisterTraySelectionManager(scope) {
 		XConn, err = x.NewConn()
 		if err != nil {
 			return err
@@ -79,6 +127,7 @@ func (d *Daemon) Start() error {
 			return err
 		}
 	}
+	// #endregion
 
 	if os.Getenv("DDE_DISABLE_STATUS_NOTIFIER_WATCHER") != "1" {
 		d.snw = newStatusNotifierWatcher(service, d.sigLoop)


### PR DESCRIPTION
为 wayland 会话也初始化 Xembed 托盘支持.

## Summary by Sourcery

Enhancements:
- Gate X connection and tray selection manager initialization behind an internal flag instead of disabling it entirely on Wayland sessions.