### PR TITLE
fix: Notification bar progress indicator anomaly

### DIFF
--- a/bluetooth1/obex_agent.go
+++ b/bluetooth1/obex_agent.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2018 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -312,7 +312,9 @@ func (a *obexAgent) receiveProgress(transfer *transferObj) {
 			// 传送完成，移动到下载目录
 			realFileName := moveTempFile(oriFilepath, filepath.Join(receiveBaseDir, transfer.oriFilename))
 
-			newID := a.notifyProgress(a.notify, a.notifyID, realFileName, transfer.deviceName, 100)
+			// Use the last progress notification id as replaces_id so
+			// the progress bubble (e.g. 99%) won't linger after completion.
+			newID := a.notifyProgress(a.notify, currentID, realFileName, transfer.deviceName, 100)
 
 			notifyMu.Lock()
 			a.notifyID = newID
@@ -455,12 +457,11 @@ func (a *obexAgent) notifyProgress(notify notifications.Notifications, replaceID
 			logger.Warning("failed to send notify:", err)
 		}
 	} else {
-		notify.CloseNotification(0, replaceID)
 		actions = []string{"_view", gettext.Tr("View")}
 		hints := map[string]dbus.Variant{"x-deepin-action-_view": dbus.MakeVariant("dde-file-manager,--show-item," + filename)}
 		notifyID, err = notify.Notify(0,
 			gettext.Tr("dde-control-center"),
-			0,
+			replaceID,
 			notifyIconBluetoothConnected,
 			fmt.Sprintf(gettext.Tr("You have received files from %q successfully"), device),
 			gettext.Tr("Done"),
@@ -485,10 +486,9 @@ func (a *obexAgent) notifyFailed(notify notifications.Notifications, replaceID u
 		body = gettext.Tr("Bluetooth connection failed")
 	}
 
-	notify.CloseNotification(0, replaceID)
 	notifyID, err := notify.Notify(0,
 		gettext.Tr("dde-control-center"),
-		0,
+		replaceID,
 		notifyIconBluetoothConnectFailed,
 		summary,
 		body,

--- a/gesture1/gesture_action.go
+++ b/gesture1/gesture_action.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2018 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -109,11 +109,11 @@ func (m *Manager) doHandle4Or5FingersSwipeDown() error {
 }
 
 func (m *Manager) doMaximizeActiveWindow() error {
-	return m.wm.MaximizeActiveWindow(0)
+	return m.wm.PerformAction(0, wmActionToggleMaximize)
 }
 
 func (m *Manager) doUnMaximizeActiveWindow() error {
-	return m.wm.UnMaximizeActiveWindow(0)
+	return m.wm.PerformAction(0, wmActionToggleMaximize)
 }
 
 func (m *Manager) doMinimize() error {


### PR DESCRIPTION
log: Incorrect replaces_id used when sending the “Received Successfully” notification upon completion (or failure to use the ID from the progress bar notification), causing the 99% progress notification to remain unchanged and persist on the desktop. When the status changes to complete, first read the current `a.notifyID` within the lock and save it as `currentID`. Then use this `currentID` as the `replaces_id` to send the 100% completion notification. This ensures the completion notification replaces the last progress notification (including the 99% progress notification).

pms: bug-351711

Translated with DeepL.com (free version)

## Summary by Sourcery

Fix Bluetooth file transfer notifications to correctly replace in-progress toasts on completion and align gesture window maximize behavior with the generic window manager action API.

Bug Fixes:
- Ensure the Bluetooth file transfer completion notification correctly replaces the last in-progress notification so partially completed progress bubbles do not linger.
- Use the existing window manager toggle maximize action for gesture-based maximize/unmaximize to keep behavior consistent.

Enhancements:
- Simplify notification handling by relying on the notification system's replace ID mechanism instead of manually closing previous notifications.