### PR TITLE
perf: cleanup systemd service dependencies for dde-session-daemon

### DIFF
--- a/misc/systemd/services/user/org.dde.session.Daemon1.service
+++ b/misc/systemd/services/user/org.dde.session.Daemon1.service
@@ -4,11 +4,8 @@ RefuseManualStart=no
 RefuseManualStop=no
 CollectMode=inactive-or-failed
 
-Requisite=dde-session-pre.target
 PartOf=dde-session-pre.target
 Before=dde-session-pre.target
-
-Before=dde-session@x11.service
 
 Wants=treeland-xwayland.service
 After=treeland-xwayland.service


### PR DESCRIPTION
- Remove obsolete Requisite=dde-session-pre.target.
- Remove Before=dde-session@x11.service as it's no longer needed in the modern session startup flow.

- 移除过时的 Requisite=dde-session-pre.target。
- 移除不再需要的 Before=dde-session@x11.service，现代会话启动流程中已不再需要此依赖。

Log: cleanup systemd service dependencies for dde-session-daemon
Pms: TASK-384099
Change-Id: I490024d27482d3d02aa68846c822c642b3b563a5