### PR TITLE
fix: 修复修改快捷键后快捷键失效的问题

### DIFF
--- a/keybinding1/manager_ifc.go
+++ b/keybinding1/manager_ifc.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2018 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -292,6 +292,13 @@ func (m *Manager) ClearShortcutKeystrokes(id string, type0 int32) *dbus.Error {
 	if shortcut == nil {
 		return dbusutil.ToError(ErrShortcutNotFound{id, type0})
 	}
+	// 临时关闭监听，避免自身写入触发的 gsettings 变更信号覆盖刚设置的状态
+	m.enableListenDConifigChanged(false)
+	defer func() {
+		time.AfterFunc(100*time.Millisecond, func() {
+			m.enableListenDConifigChanged(true)
+		})
+	}()
 	m.shortcutManager.ModifyShortcutKeystrokes(shortcut, nil)
 	err := shortcut.SaveKeystrokes()
 	if err != nil {
@@ -466,7 +473,13 @@ func (m *Manager) AddShortcutKeystroke(id string, type0 int32, keystroke string)
 			return dbusutil.ToError(errKeystrokeUsed)
 		}
 	}
-
+	// 临时关闭监听，避免自身写入触发的 gsettings 变更信号覆盖刚设置的状态
+	m.enableListenDConifigChanged(false)
+	defer func() {
+		time.AfterFunc(100*time.Millisecond, func() {
+			m.enableListenDConifigChanged(true)
+		})
+	}()
 	// 添加所有 keystroke
 	for _, ksToAdd := range keystrokesToAdd {
 		m.shortcutManager.AddShortcutKeystroke(shortcut, ksToAdd)
@@ -499,7 +512,13 @@ func (m *Manager) DeleteShortcutKeystroke(id string, type0 int32, keystroke stri
 		return dbusutil.ToError(err)
 	}
 	logger.Debug("keystroke:", ks.DebugString())
-
+	// 临时关闭监听，避免自身写入触发的 gsettings 变更信号覆盖刚设置的状态
+	m.enableListenDConifigChanged(false)
+	defer func() {
+		time.AfterFunc(100*time.Millisecond, func() {
+			m.enableListenDConifigChanged(true)
+		})
+	}()
 	m.shortcutManager.DeleteShortcutKeystroke(shortcut, ks)
 	err = shortcut.SaveKeystrokes()
 	if err != nil {


### PR DESCRIPTION
设置完后，又响应了dconfig变化，把设置好的快捷键设置为[]

这是一个时序问题，修改快捷键是先把快捷键清空，然后添加新的快捷键，这两个操作都会触发dconfig的变化 如果dconfig变化过慢，这两个dconfig值改变信号晚于这两个操作就会出现bug现象

Log: 修改快捷键清除和添加以及信号处理存在的时序问题
Influence: 设置代码中的时序
PMS: BUG-355747
Change-Id: I5e15121105a26dfa5687387e7ec97ad862f1e8da

## Summary by Sourcery

Bug Fixes:
- Prevent shortcut settings from being overwritten by delayed gsettings/dconfig change signals when clearing, adding, or deleting keystrokes.