### PR TITLE
fix: add debounce for volume feedback and optimize port change detection

### DIFF
--- a/audio1/audio_events.go
+++ b/audio1/audio_events.go
@@ -334,7 +334,7 @@ func (a *Audio) handleCardRemoved(idx uint32) {
 		logger.Debugf("card %d removed", idx)
 		return
 	}
-	logger.Infof("card <%s:%d> added", oldCard.core.Name, idx)
+	logger.Infof("card <%s:%d> removed", oldCard.core.Name, idx)
 	a.cards, _ = a.cards.delete(idx)
 	cards := a.cards.string()
 	a.setPropCards(cards)
@@ -407,10 +407,13 @@ func (a *Audio) handleSinkAdded(idx uint32) {
 		sink.ActivePort = port
 	}
 
+	var isNewSink bool
+	var portChanged bool
 	if _, exist := a.sinks[idx]; exist {
-		a.sinks[idx].update(sink)
+		portChanged = a.sinks[idx].update(sink)
 	} else {
 		a.addSink(sink)
+		isNewSink = true
 	}
 
 	if sink.Name == monoSinkName && a.Mono {
@@ -419,7 +422,10 @@ func (a *Audio) handleSinkAdded(idx uint32) {
 	} else if !isPhysicalDevice(sink.Name) {
 		return
 	} else if a.checkCardIsReady(sink.Card) {
-		a.autoSwitchPort()
+		// 只有新增sink或端口列表/活跃端口变化时才触发自动切换
+		if isNewSink || portChanged {
+			a.autoSwitchPort()
+		}
 	}
 }
 
@@ -458,12 +464,14 @@ func (a *Audio) handleSinkChanged(idx uint32) {
 		return
 	}
 	logger.Infof("sink <%s:%d> changed", sink.Name, idx)
+	var portChanged bool
 	if _, ok := a.sinks[idx]; ok {
-		a.sinks[idx].update(sink)
+		portChanged = a.sinks[idx].update(sink)
 	}
 	// 处理场景： 当sink的端口可用性发生变化时，切换端口
 	// cardchange事件也会触发，但是处理不了，因为这时sink可能还没更新，无可用端口
-	if isPhysicalDevice(sink.Name) && a.checkCardIsReady(sink.Card) {
+	// 只有当端口列表或活跃端口发生变化时，才触发自动切换
+	if portChanged && isPhysicalDevice(sink.Name) && a.checkCardIsReady(sink.Card) {
 		a.autoSwitchPort()
 	}
 
@@ -501,10 +509,13 @@ func (a *Audio) handleSourceAdded(idx uint32) {
 		logger.Debugf("skip %s source update", source.Name)
 		return
 	}
+	var isNewSource bool
+	var portChanged bool
 	if _, exist := a.sources[idx]; exist {
-		a.sources[idx].update(source)
+		portChanged = a.sources[idx].update(source)
 	} else {
 		a.addSource(source)
+		isNewSource = true
 	}
 	a.updatePropSources()
 
@@ -515,7 +526,10 @@ func (a *Audio) handleSourceAdded(idx uint32) {
 		// 其他的虚拟通道不做自动切换处理
 		return
 	} else if a.checkCardIsReady(source.Card) {
-		a.autoSwitchInputPort()
+		// 只有新增source或端口列表/活跃端口变化时才触发自动切换
+		if isNewSource || portChanged {
+			a.autoSwitchInputPort()
+		}
 	}
 
 }
@@ -555,12 +569,14 @@ func (a *Audio) handleSourceChanged(idx uint32) {
 	}
 	logger.Infof("source <%s:%d> changed", source.Name, idx)
 
+	var portChanged bool
 	if _, ok := a.sources[idx]; ok {
-		a.sources[idx].update(source)
+		portChanged = a.sources[idx].update(source)
 	}
 	// 处理场景： 当source的端口可用性发生变化时，切换端口
 	// cardchange事件也会触发，但是处理不了，因为这时source可能还没更新，无可用端口
-	if isPhysicalDevice(source.Name) && a.checkCardIsReady(source.Card) {
+	// 只有当端口列表或活跃端口发生变化时，才触发自动切换
+	if portChanged && isPhysicalDevice(source.Name) && a.checkCardIsReady(source.Card) {
 		a.autoSwitchInputPort()
 	}
 }

--- a/audio1/card.go
+++ b/audio1/card.go
@@ -347,6 +347,9 @@ const (
 
 func (card *Card) doDiff(oldCard *Card, autoPause bool) ChangeType {
 	var changed ChangeType = NoChange
+	if card.Name != oldCard.Name {
+		logger.Infof("card name changed from %s to %s", oldCard.Name, card.Name)
+	}
 	pc := card.core
 	// 检查配置文件变化
 	if card.ActiveProfile != nil {
@@ -358,7 +361,7 @@ func (card *Card) doDiff(oldCard *Card, autoPause bool) ChangeType {
 	}
 	// 检查配置文件列表变化
 	if len(oldCard.Profiles) != len(card.Profiles) {
-		logger.Infof("card %s profiles changed", card.Name)
+		logger.Infof("card %s profiles list length changed from %d to %d", card.Name, len(oldCard.Profiles), len(card.Profiles))
 		changed |= ProfileChanged
 	}
 

--- a/audio1/sink.go
+++ b/audio1/sink.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strconv"
 	"sync"
+	"time"
 
 	dbus "github.com/godbus/dbus/v5"
 	"github.com/linuxdeepin/go-lib/dbusutil"
@@ -54,7 +55,14 @@ type Sink struct {
 
 	// 当前是否是可插拔sink
 	pluggable bool
+
+	// volumeFeedbackTimer 音量变化音效播放定时器
+	volumeFeedbackTimer *time.Timer
 }
+
+const (
+	volumeFeedbackTimeout = 500 * time.Millisecond
+)
 
 func newSink(sinkInfo *pulse.Sink, audio *Audio) *Sink {
 	s := &Sink{
@@ -127,7 +135,7 @@ func (s *Sink) SetVolume(value float64, isPlay bool) *dbus.Error {
 	s.audio.context().SetSinkVolumeByIndex(s.index, cv)
 
 	if isPlay {
-		s.playFeedback()
+		s.resetVolumeFeedbackTimer()
 	}
 	return nil
 }
@@ -289,41 +297,83 @@ func (*Sink) GetInterfaceName() string {
 	return dbusInterface + ".Sink"
 }
 
-func (s *Sink) update(sinkInfo *pulse.Sink) {
+func (s *Sink) update(sinkInfo *pulse.Sink) (portChanged bool) {
 	s.PropsMu.Lock()
-	s.Name = sinkInfo.Name
-	s.Description = sinkInfo.Description
-	s.Card = sinkInfo.Card
-	s.BaseVolume = sinkInfo.BaseVolume.ToPercent()
+	if s.Name != sinkInfo.Name {
+		logger.Debugf("sink %s name changed from %s to %s", s.Name, s.Name, sinkInfo.Name)
+		s.Name = sinkInfo.Name
+	}
+	if s.Description != sinkInfo.Description {
+		logger.Debugf("sink %s description changed from %s to %s", s.Name, s.Description, sinkInfo.Description)
+		s.Description = sinkInfo.Description
+	}
+	if s.Card != sinkInfo.Card {
+		logger.Debugf("sink %s card changed from %d to %d", s.Name, s.Card, sinkInfo.Card)
+		s.Card = sinkInfo.Card
+	}
+	newBaseVolume := sinkInfo.BaseVolume.ToPercent()
+	if s.BaseVolume != newBaseVolume {
+		logger.Debugf("sink %s base volume changed from %v to %v", s.Name, s.BaseVolume, newBaseVolume)
+		s.BaseVolume = newBaseVolume
+	}
+	if s.cVolume.Avg() != sinkInfo.Volume.Avg() {
+		logger.Debugf("sink %s volume changed from %v to %v", s.Name, s.cVolume.Avg(), sinkInfo.Volume.Avg())
+		if s.volumeFeedbackTimer != nil {
+			s.volumeFeedbackTimer.Stop()
+			s.volumeFeedbackTimer.Reset(volumeFeedbackTimeout)
+		}
+	}
 	s.cVolume = sinkInfo.Volume
 	s.channelMap = sinkInfo.ChannelMap
 
+	if s.Mute != sinkInfo.Mute {
+		logger.Debugf("sink %s mute changed from %t to %t", s.Name, s.Mute, sinkInfo.Mute)
+	}
 	s.setPropMute(sinkInfo.Mute)
 	s.setPropVolume(floatPrecision(sinkInfo.Volume.Avg()))
 
 	s.setPropSupportFade(false)
-	s.setPropFade(sinkInfo.Volume.Fade(sinkInfo.ChannelMap))
+	newFade := sinkInfo.Volume.Fade(sinkInfo.ChannelMap)
+	if s.Fade != newFade {
+		logger.Debugf("sink %s fade changed from %v to %v", s.Name, s.Fade, newFade)
+	}
+	s.setPropFade(newFade)
+
 	s.setPropSupportBalance(true)
-	s.setPropBalance(sinkInfo.Volume.Balance(sinkInfo.ChannelMap))
+	newBalance := sinkInfo.Volume.Balance(sinkInfo.ChannelMap)
+	if s.Balance != newBalance {
+		logger.Debugf("sink %s balance changed from %v to %v", s.Name, s.Balance, newBalance)
+	}
+	s.setPropBalance(newBalance)
 
 	newActivePort := toPort(sinkInfo.ActivePort)
-	var activePortChanged bool
 
-	s.setPropPorts(toPorts(sinkInfo.Ports))
-	activePortChanged = s.setPropActivePort(newActivePort)
+	newPorts := toPorts(sinkInfo.Ports)
+	if !portsEqual(s.Ports, newPorts) {
+		portChanged = true
+		logger.Debugf("sink %s ports changed from %v to %v", s.Name, s.Ports, newPorts)
+	}
+	s.setPropPorts(newPorts)
+
+	if s.ActivePort.Name != newActivePort.Name {
+		portChanged = true
+		logger.Debugf("sink %s active port changed from %s to %s", s.Name, s.ActivePort.Name, newActivePort.Name)
+		s.setPropActivePort(newActivePort)
+	}
 
 	s.props = sinkInfo.PropList
 	s.PropsMu.Unlock()
 
 	defaultSink := s.audio.defaultSink
 	if defaultSink != nil {
-		if activePortChanged && defaultSink.Name == s.Name {
+		if portChanged && defaultSink.Name == s.Name {
 			logger.Debugf("default sink update active port %s", sinkInfo.ActivePort.Name)
 			a := s.audio
 			a.resumeSinkConfig(s)
 		}
 	}
 
+	return
 }
 
 func (s *Sink) GetMeter() (meter dbus.ObjectPath, busErr *dbus.Error) {
@@ -336,4 +386,14 @@ func (s *Sink) playFeedback() {
 	name := s.Name
 	s.PropsMu.RUnlock()
 	playFeedbackWithDevice(name)
+}
+
+func (s *Sink) resetVolumeFeedbackTimer() {
+	if s.volumeFeedbackTimer != nil {
+		s.volumeFeedbackTimer.Stop()
+	}
+	s.volumeFeedbackTimer = time.AfterFunc(volumeFeedbackTimeout, func() {
+		s.volumeFeedbackTimer = nil
+		s.playFeedback()
+	})
 }

--- a/audio1/source.go
+++ b/audio1/source.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2018 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -252,42 +252,77 @@ func (*Source) GetInterfaceName() string {
 	return dbusInterface + ".Source"
 }
 
-func (s *Source) update(sourceInfo *pulse.Source) {
+func (s *Source) update(sourceInfo *pulse.Source) (portChanged bool) {
 	s.PropsMu.Lock()
+	if s.cVolume.Avg() != sourceInfo.Volume.Avg() {
+		logger.Debugf("source %s volume changed from %v to %v", s.Name, s.cVolume.Avg(), sourceInfo.Volume.Avg())
+	}
 	s.cVolume = sourceInfo.Volume
 	s.channelMap = sourceInfo.ChannelMap
-	s.Name = sourceInfo.Name
-	s.Description = sourceInfo.Description
-	s.Card = sourceInfo.Card
-	s.BaseVolume = sourceInfo.BaseVolume.ToPercent()
+	if s.Name != sourceInfo.Name {
+		logger.Debugf("source %s name changed from %s to %s", s.Name, s.Name, sourceInfo.Name)
+		s.Name = sourceInfo.Name
+	}
+	if s.Description != sourceInfo.Description {
+		logger.Debugf("source %s description changed from %s to %s", s.Name, s.Description, sourceInfo.Description)
+		s.Description = sourceInfo.Description
+	}
+	if s.Card != sourceInfo.Card {
+		logger.Debugf("source %s card changed from %d to %d", s.Name, s.Card, sourceInfo.Card)
+		s.Card = sourceInfo.Card
+	}
+	newBaseVolume := sourceInfo.BaseVolume.ToPercent()
+	if s.BaseVolume != newBaseVolume {
+		logger.Debugf("source %s base volume changed from %v to %v", s.Name, s.BaseVolume, newBaseVolume)
+		s.BaseVolume = newBaseVolume
+	}
 
 	s.setPropVolume(floatPrecision(sourceInfo.Volume.Avg()))
+	if s.Mute != sourceInfo.Mute {
+		logger.Debugf("source %s mute changed from %t to %t", s.Name, s.Mute, sourceInfo.Mute)
+	}
 	s.setPropMute(sourceInfo.Mute)
 
 	//TODO: handle this
 	s.setPropSupportFade(false)
-	s.setPropFade(sourceInfo.Volume.Fade(sourceInfo.ChannelMap))
-	s.setPropSupportBalance(true)
-	s.setPropBalance(sourceInfo.Volume.Balance(sourceInfo.ChannelMap))
+	newFade := sourceInfo.Volume.Fade(sourceInfo.ChannelMap)
+	if s.Fade != newFade {
+		logger.Debugf("source %s fade changed from %v to %v", s.Name, s.Fade, newFade)
+	}
+	s.setPropFade(newFade)
 
-	var ports []Port
-	for _, p := range sourceInfo.Ports {
-		ports = append(ports, toPort(p))
+	s.setPropSupportBalance(true)
+	newBalance := sourceInfo.Volume.Balance(sourceInfo.ChannelMap)
+	if s.Balance != newBalance {
+		logger.Debugf("source %s balance changed from %v to %v", s.Name, s.Balance, newBalance)
+	}
+	s.setPropBalance(newBalance)
+
+	newPorts := toPorts(sourceInfo.Ports)
+	if !portsEqual(s.Ports, newPorts) {
+		portChanged = true
+		logger.Debugf("source %s ports changed from %v to %v", s.Name, s.Ports, newPorts)
+		s.setPropPorts(newPorts)
 	}
 
-	s.setPropPorts(ports)
-	activePortChanged := s.setPropActivePort(toPort(sourceInfo.ActivePort))
+	newActivePort := toPort(sourceInfo.ActivePort)
+	if s.ActivePort.Name != newActivePort.Name {
+		portChanged = true
+		logger.Debugf("source %s active port changed from %s to %s", s.Name, s.ActivePort.Name, newActivePort.Name)
+		s.setPropActivePort(newActivePort)
+	}
 
 	s.PropsMu.Unlock()
 
 	defaultSource := s.audio.defaultSource
 	if defaultSource != nil {
-		if activePortChanged && defaultSource.Name == s.Name {
+		if portChanged && defaultSource.Name == s.Name {
 			logger.Debugf("default source update active port %s", sourceInfo.ActivePort.Name)
 			s.audio.resumeSourceConfig(s)
 		}
 	}
 
+	return
 }
 
 func (s *Source) setMute(v bool) {


### PR DESCRIPTION
1. Add 500ms debounce timer for volume feedback sound to prevent event blocking
2. Volume feedback now only plays after user stops adjusting for 500ms
3. Optimize sink/source update to return portChanged flag
4. Only trigger autoSwitchPort when port actually changes (new device or port change)
5. Fix typo in card removed log message (was "added")
6. Add detailed logging for property changes in sink/source/card updates

fix: 添加音量反馈防抖动并优化端口变化检测

1. 为音量反馈音效添加500毫秒防抖定时器，防止事件阻塞
2. 音量反馈音效现在只在用户停止调整500毫秒后播放
3. 优化sink/source的update方法，返回portChanged标志
4. 仅在端口实际变化时（新设备或端口变化）触发autoSwitchPort
5. 修复card移除日志中的错误（原为"added"）
6. 为sink/source/card的属性变化添加详细日志

Influence:
1. Test continuous volume adjustment and verify no stuttering
2. Verify volume feedback plays only once after adjustment stops
3. Test rapid volume changes and confirm smooth response
4. Verify auto port switching still works for new devices
5. Test port change detection with physical audio devices
6. Monitor logs for correct port change detection
7. Verify no unnecessary auto-switch operations during normal use

Influence:
1. 测试连续调节音量，验证无卡顿现象
2. 验证音量反馈音效只在调节停止后播放一次
3. 测试快速调节音量，确认响应流畅
4. 验证新设备插入时自动端口切换仍正常工作
5. 使用物理音频设备测试端口变化检测
6. 检查日志中端口变化检测是否正确
7. 验证正常使用时不会触发不必要的自动切换操作

PMS: BUG-349793
Change-Id: If9a1b292c79343b3e803be4e7a7074aeb41baad5