### PR TITLE
refactor: improve display mode filtering and selection logic

### DIFF
--- a/display1/display_test.go
+++ b/display1/display_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -58,7 +58,7 @@ func Test_filterModeInfos(t *testing.T) {
 			Height: 768,
 			Rate:   60.1,
 		},
-	}, filterModeInfos(modes, ModeInfo{}))
+	}, filterModeInfos(modes, []ModeInfo{}))
 
 	// --------------------------
 	modes = []ModeInfo{
@@ -78,11 +78,21 @@ func Test_filterModeInfos(t *testing.T) {
 		},
 	}
 	assert.Equal(t, modes, filterModeInfos(modes,
-		ModeInfo{Id: 2,
-			name:   "1024x768i",
-			Width:  1024,
-			Height: 768,
-			Rate:   60.1,
+		[]ModeInfo{
+			{
+				Id:     1,
+				name:   "1024x768",
+				Width:  1024,
+				Height: 768,
+				Rate:   60.1,
+			},
+			{
+				Id:     2,
+				name:   "1024x768i",
+				Width:  1024,
+				Height: 768,
+				Rate:   60.1,
+			},
 		}))
 
 	// --------------------------
@@ -111,20 +121,20 @@ func Test_filterModeInfos(t *testing.T) {
 	}
 	assert.Equal(t, []ModeInfo{
 		{
-			Id:     1,
-			name:   "1024x768",
-			Width:  1024,
-			Height: 768,
-			Rate:   60.1,
-		},
-		{
 			Id:     3,
 			name:   "1024x768",
 			Width:  1024,
 			Height: 768,
 			Rate:   60.3,
 		},
-	}, filterModeInfos(modes, ModeInfo{}))
+		{
+			Id:     2,
+			name:   "1024x768",
+			Width:  1024,
+			Height: 768,
+			Rate:   60.10000001,
+		},
+	}, filterModeInfos(modes, []ModeInfo{}))
 
 	// --------------------------
 	// 混合
@@ -164,15 +174,15 @@ func Test_filterModeInfos(t *testing.T) {
 			Height: 768,
 			Rate:   60.3,
 		},
-	}
-	assert.Equal(t, []ModeInfo{
 		{
-			Id:     1,
+			Id:     6,
 			name:   "1024x768",
 			Width:  1024,
 			Height: 768,
-			Rate:   60.1,
+			Rate:   60.3,
 		},
+	}
+	assert.Equal(t, []ModeInfo{
 		{
 			Id:     3,
 			name:   "1024x768",
@@ -180,5 +190,12 @@ func Test_filterModeInfos(t *testing.T) {
 			Height: 768,
 			Rate:   60.3,
 		},
-	}, filterModeInfos(modes, ModeInfo{}))
+		{
+			Id:     2,
+			name:   "1024x768",
+			Width:  1024,
+			Height: 768,
+			Rate:   60.10000001,
+		},
+	}, filterModeInfos(modes, []ModeInfo{}))
 }

--- a/display1/manager.go
+++ b/display1/manager.go
@@ -1194,7 +1194,7 @@ func (m *Manager) init() {
 }
 
 // 过滤掉部分模式，尽量不过滤掉 saveMode。
-func (m *Manager) filterModeInfos(modeInfos []ModeInfo, saveMode ModeInfo) []ModeInfo {
+func (m *Manager) filterModeInfos(modeInfos []ModeInfo, saveMode []ModeInfo) []ModeInfo {
 	result := filterModeInfosByRefreshRate(filterModeInfos(modeInfos, saveMode), m.getRateFilterMap())
 	return result
 }
@@ -1336,12 +1336,16 @@ func (m *Manager) addMonitor(monitorInfo *MonitorInfo) error {
 		Model:              monitorInfo.Model,
 		AvailableFillModes: monitorInfo.AvailableFillModes,
 	}
-
-	monitor.Modes = m.filterModeInfos(monitorInfo.Modes, monitorInfo.PreferredMode)
-	monitor.BestMode = getBestMode(monitor.Modes, monitorInfo.PreferredMode)
-	if !monitor.BestMode.isZero() {
-		monitor.PreferredModes = []ModeInfo{monitor.BestMode}
+	preferredMode := monitorInfo.PreferredMode
+	monitor.Modes = m.filterModeInfos(monitorInfo.Modes, []ModeInfo{
+		preferredMode,
+		monitorInfo.CurrentMode,
+	})
+	monitor.setPropModes(monitor.Modes)
+	if len(monitor.Modes) == 0 {
+		return errors.New("the monitor modes is nil")
 	}
+	m.updateBestmodeRefreshRate(monitor, preferredMode)
 	monitor.X = monitorInfo.X
 	monitor.Y = monitorInfo.Y
 	monitor.Width = monitorInfo.Width
@@ -1376,6 +1380,40 @@ func (m *Manager) addMonitor(monitorInfo *MonitorInfo) error {
 	return nil
 }
 
+func (m *Manager) updateBestmodeRefreshRate(monitor *Monitor, preferredMode ModeInfo) (bestMode ModeInfo) {
+	logger.Infof("updateBestmodeRefreshRate monitor name: %s, preferredMode: %v", monitor.Name, preferredMode)
+	var preferredModes []ModeInfo
+	for _, mode := range monitor.Modes {
+		if mode.Width == preferredMode.Width && mode.Height == preferredMode.Height {
+			preferredModes = append(preferredModes, mode)
+		}
+	}
+
+	// 如果没有匹配到与 preferredMode 同分辨率的模式，则使用 monitor.Modes 中的第一个模式
+	if len(preferredModes) == 0 {
+		if len(monitor.Modes) == 0 {
+			logger.Warning("updateBestmodeRefreshRate: monitor.Modes is empty, return preferredMode")
+			bestMode = preferredMode
+			monitor.BestMode = bestMode
+			return bestMode
+		}
+		bestMode = monitor.Modes[0]
+		monitor.BestMode = bestMode
+		logger.Warningf("updateBestmodeRefreshRate: no mode found with preferred resolution %dx%d, fallback to first mode %v", preferredMode.Width, preferredMode.Height, bestMode)
+		return bestMode
+	}
+
+	// 使用preferredModes中Rate最大的值
+	for _, mode := range preferredModes {
+		if bestMode.Id == 0 || mode.Rate > bestMode.Rate {
+			bestMode = mode
+		}
+	}
+	monitor.BestMode = bestMode
+	logger.Info("updateBestmodeRefreshRate bestMode : ", bestMode)
+	return bestMode
+}
+
 // updateMonitor 根据 outputInfo 中的信息更新 dbus 上的 Monitor 对象的属性
 func (m *Manager) updateMonitor(monitorInfo *MonitorInfo) {
 	m.monitorMapMu.Lock()
@@ -1405,8 +1443,16 @@ func (m *Manager) updateMonitor(monitorInfo *MonitorInfo) {
 	monitor.setPropAvailableFillModes(monitorInfo.AvailableFillModes)
 	monitor.setPropManufacturer(monitorInfo.Manufacturer)
 	monitor.setPropModel(monitorInfo.Model)
-	monitor.setPropModes(m.filterModeInfos(monitorInfo.Modes, monitorInfo.PreferredMode))
-	bestMode := getBestMode(monitor.Modes, monitorInfo.PreferredMode)
+	preferredMode := monitorInfo.PreferredMode
+	monitor.Modes = m.filterModeInfos(monitorInfo.Modes, []ModeInfo{
+		preferredMode,
+		monitorInfo.CurrentMode,
+	})
+	monitor.setPropModes(monitor.Modes)
+	if len(monitor.Modes) == 0 {
+		return
+	}
+	bestMode := m.updateBestmodeRefreshRate(monitor, preferredMode)
 	monitor.setPropBestMode(bestMode)
 	var preferredModes []ModeInfo
 	if !bestMode.isZero() {

--- a/display1/mode.go
+++ b/display1/mode.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2018 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -7,6 +7,7 @@ package display1
 import (
 	"math"
 	"regexp"
+	"sort"
 	"strconv"
 
 	"github.com/linuxdeepin/go-lib/strv"
@@ -58,26 +59,38 @@ func toModeInfo(info randr.ModeInfo) ModeInfo {
 var regMode = regexp.MustCompile(`^(\d+)x(\d+)(\D+)$`)
 
 // 过滤重复的模式，一定要保留 saveMode。
-func filterModeInfos(modes []ModeInfo, saveMode ModeInfo) []ModeInfo {
+func filterModeInfos(modes []ModeInfo, saveModes []ModeInfo) []ModeInfo {
 	result := make([]ModeInfo, 0, len(modes))
-	var filteredModeNames strv.Strv
+	remaining := make([]ModeInfo, 0, len(modes))
 	for idx := range modes {
 		mode := modes[idx]
-		// TODO 也许这个实现不够好
-		if mode.Id == saveMode.Id {
-			// not skip
-			result = append(result, mode)
-			continue
+		found := false
+		for _, saveMode := range saveModes {
+			if mode.Id == saveMode.Id {
+				// not skip
+				result = append(result, mode)
+				found = true
+				break
+			}
 		}
+		if !found {
+			remaining = append(remaining, mode)
+		}
+	}
+	// 从大到小排序,避免保留较大id的mode
+	sort.Sort(sort.Reverse(ModeInfos(remaining)))
+	var filteredModeNames strv.Strv
+	for idx := range remaining {
+		mode := remaining[idx]
+		// TODO 也许这个实现不够好
 		// 是否被过滤掉
 		skip := false
-
 		if filteredModeNames.Contains(mode.name) {
 			skip = true
 		} else {
 			match := regMode.FindStringSubmatch(mode.name)
 			if match != nil {
-				m := findFirstMode(modes, func(mode1 ModeInfo) bool {
+				m := findFirstMode(remaining, func(mode1 ModeInfo) bool {
 					return mode.Width == mode1.Width &&
 						mode.Height == mode1.Height &&
 						len(mode1.name) > 0 &&
@@ -98,7 +111,7 @@ func filterModeInfos(modes []ModeInfo, saveMode ModeInfo) []ModeInfo {
 						formatRate(mode.Rate) == formatRate(mode1.Rate)
 				})
 				if !m.isZero() {
-					//logger.Debugf("compare mode: %s, find m: %s",
+					// logger.Debugf("compare mode: %s, find m: %s",
 					//	spew.Sdump(mode), spew.Sdump(m))
 					skip = true
 				}
@@ -106,9 +119,9 @@ func filterModeInfos(modes []ModeInfo, saveMode ModeInfo) []ModeInfo {
 		}
 
 		if skip {
-			//logger.Debugf("filterModeInfos skip mode %d|%x %s %.2f", mode.Id, mode.Id, mode.name, mode.Rate)
+			logger.Debugf("filterModeInfos skip mode %d|%x %s %.2f", mode.Id, mode.Id, mode.name, mode.Rate)
 		} else {
-			//logger.Debugf("add mode %d|%x %s %.2f", mode.Id, mode.Id, mode.name, mode.Rate)
+			logger.Debugf("add mode %d|%x %s %.2f", mode.Id, mode.Id, mode.name, mode.Rate)
 			result = append(result, mode)
 		}
 	}
@@ -228,21 +241,6 @@ func getPreferredMode(modes []ModeInfo, modeId uint32) ModeInfo {
 	return ModeInfo{}
 }
 
-func getBestMode(modes []ModeInfo, preferredMode ModeInfo) ModeInfo {
-	mode := findMode(modes, preferredMode.Id)
-	if !mode.isZero() {
-		return mode
-	}
-	mode = getFirstModeBySize(modes, preferredMode.Width, preferredMode.Height)
-	if !mode.isZero() {
-		return mode
-	}
-	if len(modes) > 0 {
-		return modes[0]
-	}
-	return ModeInfo{}
-}
-
 func getFirstModeBySize(modes []ModeInfo, width, height uint16) ModeInfo {
 	for _, modeInfo := range modes {
 		if modeInfo.Width == width && modeInfo.Height == height {
@@ -256,7 +254,7 @@ func getFirstModeBySizeRate(modes []ModeInfo, width, height uint16, rate float64
 	roundedRate := math.Round(rate * 100)
 	for _, modeInfo := range modes {
 		if modeInfo.Width == width && modeInfo.Height == height &&
-			math.Round(modeInfo.Rate * 100) == roundedRate {
+			math.Round(modeInfo.Rate*100) == roundedRate {
 			return modeInfo
 		}
 	}


### PR DESCRIPTION
refactor: improve display mode filtering logic
1. Changed filterModeInfos to accept a slice of saveModes instead of
single saveMode
2. Now preserves both preferredMode and currentMode during filtering
3. Added updateBestmodeRefreshRate to select highest refresh rate for
preferred resolution
4. Removed deprecated getBestMode function
5. Added sorting of remaining modes to keep larger IDs
6. Added debug logging for filtered modes
7. Updated copyright years to 2022 - 2026
8. Added empty modes validation in addMonitor and updateMonitor
functions

Influence:
1. Test monitor detection and mode listing functionality
2. Verify that preferred mode and current mode are preserved during
filtering
3. Test best mode selection with highest refresh rate for preferred
resolution
4. Verify monitor hot-plug scenarios
5. Test display mode switching between different resolutions and refresh
rates
6. Verify handling of monitors with empty or invalid mode lists

refactor: 改进显示模式过滤逻辑

1. 修改 filterModeInfos 函数参数，从单个 saveMode 改为 saveModes 切片
2. 现在同时保留 preferredMode 和 currentMode
3. 新增 updateBestmodeRefreshRate 函数，用于选择首选分辨率下的最高刷新率
4. 移除已弃用的 getBestMode 函数
5. 添加剩余模式排序逻辑以保留较大的 ID
6. 添加过滤模式的调试日志
7. 更新版权年份至 2022 - 2026
8. 在 addMonitor 和 updateMonitor 函数中添加空模式列表校验

Influence:
1. 测试显示器检测和模式列表功能
2. 验证过滤过程中首选模式和当前模式是否被正确保留
3. 测试首选分辨率下最高刷新率的选择逻辑
4. 验证显示器热插拔场景
5. 测试不同分辨率和刷新率之间的显示模式切换
6. 验证空或无效模式列表的显示器处理

PMS: BUG-356365
Change-Id: I2d292473056614ab8b865cf835b61e8f262cb7d9