### PR TITLE
feat: add event logging for display and input devices

### DIFF
--- a/display1/event_log.go
+++ b/display1/event_log.go
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package display1
+
+import (
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/linuxdeepin/dde-daemon/session/eventlog"
+)
+
+// Event ID for display screen (10-digit number)
+const EventTidDisplayScreen = 1000600015
+
+// Debounce delay for display screen events
+const displayEventDebounceDelay = 1 * time.Second
+
+// displayEventLogger manages debounced event logging
+type displayEventLogger struct {
+	mu       sync.Mutex
+	timer    *time.Timer
+	lastData struct {
+		screenCount    int
+		displayMode    byte
+		primaryMonitor string
+	}
+}
+
+var displayLogger = &displayEventLogger{}
+
+// getDisplayModeString converts DisplayMode to string for logging
+func getDisplayModeString(mode byte, monitorName string) string {
+	switch mode {
+	case DisplayModeMirror:
+		return "MERGE"
+	case DisplayModeExtend:
+		return "EXTEND"
+	case DisplayModeOnlyOne:
+		// 单屏模式，返回显示器名称
+		if monitorName != "" {
+			return monitorName
+		}
+		return "single"
+	default:
+		return "custom"
+	}
+}
+
+// LogDisplayScreen logs display screen information with debounce
+func LogDisplayScreen(screenCount int, displayMode byte, primaryMonitor string) {
+	displayLogger.mu.Lock()
+	defer displayLogger.mu.Unlock()
+
+	// Store the latest data
+	displayLogger.lastData.screenCount = screenCount
+	displayLogger.lastData.displayMode = displayMode
+	displayLogger.lastData.primaryMonitor = primaryMonitor
+
+	// If timer exists, reset it; otherwise create a new one
+	if displayLogger.timer != nil {
+		displayLogger.timer.Reset(displayEventDebounceDelay)
+		return
+	}
+
+	displayLogger.timer = time.AfterFunc(displayEventDebounceDelay, func() {
+		displayLogger.mu.Lock()
+		data := displayLogger.lastData
+		displayLogger.mu.Unlock()
+
+		// Actually write the log
+		message := map[string]string{
+			"screen_count": strconv.Itoa(data.screenCount),
+			"display_mode": getDisplayModeString(data.displayMode, data.primaryMonitor),
+		}
+
+		eventData := &eventlog.EventLogData{
+			Tid:     EventTidDisplayScreen,
+			Target:  "display_screen",
+			Message: message,
+		}
+
+		if eventlog.WriteEventLog(eventData) {
+			logger.Debug("EventLog: display screen - count:", data.screenCount, "mode:", data.displayMode)
+		}
+	})
+}
+
+// LogOnStartup logs the current display state on startup with a delay
+func LogOnStartup(screenCount int, displayMode byte, primaryMonitor string) {
+	// Delay logging to ensure the event log system is ready
+	// The debounce mechanism in LogDisplayScreen will handle duplicate logs
+	time.AfterFunc(5*time.Second, func() {
+		LogDisplayScreen(screenCount, displayMode, primaryMonitor)
+	})
+}

--- a/display1/manager.go
+++ b/display1/manager.go
@@ -1191,6 +1191,9 @@ func (m *Manager) init() {
 		// 没有内建屏,不监听内核信号
 		logger.Info("built-in screen does not exist")
 	}
+
+	// 埋点：启动时记录屏幕信息
+	m.logDisplayScreenEvent()
 }
 
 // 过滤掉部分模式，尽量不过滤掉 saveMode。
@@ -1511,6 +1514,9 @@ func (m *Manager) handleMonitorConnectedChanged(monitor *Monitor, connected bool
 		// 断开
 		m.updateBuiltinMonitorOnDisconnected(monitor.ID)
 	}
+
+	// 埋点：屏幕接入或拔出时记录
+	m.logDisplayScreenEvent()
 }
 
 func (m *Manager) buildConfigForModeMirror(monitors Monitors) (monitorCfgs SysMonitorConfigs, err error) {
@@ -1945,6 +1951,9 @@ func (m *Manager) switchModeAux(mode, oldMode byte, monitorsId monitorsId, monit
 			return err
 		}
 	}
+
+	// 埋点：设置显示模式时记录
+	m.logDisplayScreenEvent()
 
 	return nil
 }
@@ -3300,3 +3309,23 @@ func (m *Manager) tryToChangeScaleFactor(monitorWidth, monitorHeight uint16) {
 		m.xsManager.SetScaleFactor(0, recommendScaleFactor)
 	}
 }
+
+
+// logDisplayScreenEvent records display screen information for event logging
+func (m *Manager) logDisplayScreenEvent() {
+	monitors := m.getConnectedMonitors()
+	screenCount := len(monitors)
+
+	// 获取当前显示模式
+	displayMode := m.DisplayMode
+
+	// 获取主显示器名称
+	primaryMonitor := m.Primary
+	if primaryMonitor == "" && len(monitors) > 0 {
+		primaryMonitor = monitors[0].Name
+	}
+
+	// 使用延迟日志确保事件系统就绪
+	LogOnStartup(screenCount, displayMode, primaryMonitor)
+}
+

--- a/inputdevices1/event_log.go
+++ b/inputdevices1/event_log.go
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package inputdevices
+
+import (
+	"time"
+
+	"github.com/linuxdeepin/dde-daemon/session/eventlog"
+)
+
+// Event IDs for input devices (10-digit numbers)
+const (
+	// Combined event ID for natural scroll settings on startup
+	EventTidNaturalScroll = 1000600013 // 自然滚动设置（触控板和鼠标合并）
+)
+
+// LogNaturalScroll logs natural scroll state for both touchpad and mouse in one event
+// Used for startup logging to reduce log entries
+func LogNaturalScroll(touchpadNaturalScroll, mouseNaturalScroll bool) {
+	data := &eventlog.EventLogData{
+		Tid:    EventTidNaturalScroll,
+		Target: "natural_scroll",
+		Message: map[string]string{
+			"touchpad_natural_scroll": boolToString(touchpadNaturalScroll),
+			"mouse_natural_scroll":    boolToString(mouseNaturalScroll),
+		},
+	}
+	if eventlog.WriteEventLog(data) {
+		logger.Debug("EventLog: natural scroll - touchpad:", touchpadNaturalScroll, "mouse:", mouseNaturalScroll)
+	}
+}
+
+// LogTouchpadNaturalScroll logs touchpad natural scroll state (for runtime changes)
+func LogTouchpadNaturalScroll(enabled bool) {
+	data := &eventlog.EventLogData{
+		Tid:    EventTidNaturalScroll,
+		Target: "natural_scroll",
+		Message: map[string]string{
+			"touchpad_natural_scroll": boolToString(enabled),
+		},
+	}
+	if eventlog.WriteEventLog(data) {
+		logger.Debug("EventLog: touchpad natural scroll:", enabled)
+	}
+}
+
+// LogMouseNaturalScroll logs mouse natural scroll state (for runtime changes)
+func LogMouseNaturalScroll(enabled bool) {
+	data := &eventlog.EventLogData{
+		Tid:    EventTidNaturalScroll,
+		Target: "natural_scroll",
+		Message: map[string]string{
+			"mouse_natural_scroll": boolToString(enabled),
+		},
+	}
+	if eventlog.WriteEventLog(data) {
+		logger.Debug("EventLog: mouse natural scroll:", enabled)
+	}
+}
+
+func boolToString(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+// LogOnStartup logs the current state on startup with a delay
+// Both touchpad and mouse natural scroll states are logged in one combined event
+func LogOnStartup(touchpadNaturalScroll, mouseNaturalScroll bool) {
+	// Delay logging to ensure the event log system is ready
+	time.AfterFunc(5*time.Second, func() {
+		LogNaturalScroll(touchpadNaturalScroll, mouseNaturalScroll)
+	})
+}

--- a/inputdevices1/manager.go
+++ b/inputdevices1/manager.go
@@ -224,6 +224,9 @@ func (m *Manager) init() {
 		SetGlobalMouse(m.mouse)
 
 		m.trackPoint.init()
+
+		// Log natural scroll states on startup
+		LogOnStartup(m.tpad.NaturalScroll.Get(), m.mouse.NaturalScroll.Get())
 	}
 
 	m.setWheelSpeed()

--- a/inputdevices1/mouse.go
+++ b/inputdevices1/mouse.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2018 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -211,6 +211,8 @@ func (m *Mouse) enableNaturalScroll() {
 				v.Id, v.Name, err)
 		}
 	}
+	// Log event
+	LogMouseNaturalScroll(enabled)
 }
 
 func (m *Mouse) enableMidBtnEmu() {

--- a/inputdevices1/touchpad.go
+++ b/inputdevices1/touchpad.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2018 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -321,6 +321,8 @@ func (tpad *Touchpad) enableNaturalScroll() {
 				v.Id, v.Name, err)
 		}
 	}
+	// Log event
+	LogTouchpadNaturalScroll(enabled)
 }
 
 func (tpad *Touchpad) setScrollDistance() {

--- a/session/eventlog/event_sdk.cpp
+++ b/session/eventlog/event_sdk.cpp
@@ -1,13 +1,18 @@
-// SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include <dlfcn.h>
+#include <fstream>
 #include <iostream>
+#include <string>
 
 #include "event_sdk.h"
 
 using namespace std;
+
+// Enable logging for current system version (debug only, remove before release)
+// #define DDE_EVENTLOG_DEBUG_ENABLE_CURRENT_VERSION
 
 typedef bool (*Initialize)(const std::string &packagename, bool enable_sig);
 typedef void (*WriteEventLog)(const std::string &eventdata);
@@ -15,11 +20,45 @@ typedef void (*WriteEventLog)(const std::string &eventdata);
 WriteEventLog fp_writeEventLog = nullptr;
 void *handler = nullptr;
 
+// Check if event logging should be enabled based on system edition
+// Only UosProfessional is enabled by default
+// Reads /etc/os-version to determine edition
+static bool shouldEnableEventLog()
+{
+#ifdef DDE_EVENTLOG_DEBUG_ENABLE_CURRENT_VERSION
+    // Debug mode: enable for current system version
+    return true;
+#else
+    // Production mode: only enable for UosProfessional edition
+    // Read /etc/os-version and check EditionName
+    ifstream osVersion("/etc/os-version");
+    if (!osVersion.is_open()) {
+        return false;
+    }
+
+    string line;
+    while (getline(osVersion, line)) {
+        // Look for EditionName=Professional
+        if (line.find("EditionName=") == 0) {
+            string edition = line.substr(12); // Skip "EditionName="
+            osVersion.close();
+            return edition == "Professional";
+        }
+    }
+    osVersion.close();
+    return false;
+#endif
+}
+
 int InitEventSDK() {
+    if (!shouldEnableEventLog()) {
+        return EVENT_LOG_DISABLED;
+    }
+
     handler = dlopen("/usr/lib/libdeepin-event-log.so", RTLD_LAZY);
     if (handler == NULL) {
         std::cout << "dlerror = " << dlerror() << std::endl;
-        return -1;
+        return EVENT_LOG_ERROR;
     }
     auto fp_initialize = (Initialize)dlsym(handler, "Initialize");
     fp_writeEventLog = (WriteEventLog)dlsym(handler, "WriteEventLog");
@@ -28,16 +67,23 @@ int InitEventSDK() {
         dlclose(handler);
         fp_initialize = nullptr;
         fp_writeEventLog = nullptr;
-        return -1;
+        return EVENT_LOG_ERROR;
     }
-    return 0;
+    return EVENT_LOG_SUCCESS;
 }
 
 void CloseEventLog() {
-    dlclose(handler);
+    if (handler) {
+        dlclose(handler);
+        handler = nullptr;
+    }
 }
 
-void writeEventLog(const char *log,int isDebug) {
+void writeEventLog(const char *log, int isDebug) {
+    if (!shouldEnableEventLog()) {
+        return;
+    }
+
     if (isDebug) {
         cout << log << endl;
     }

--- a/session/eventlog/event_sdk.h
+++ b/session/eventlog/event_sdk.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -8,6 +8,11 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// Return codes for InitEventSDK
+#define EVENT_LOG_SUCCESS  0  // Initialization succeeded
+#define EVENT_LOG_DISABLED 1  // Logging disabled (non-Professional edition)
+#define EVENT_LOG_ERROR   -1  // Initialization failed
 
 int InitEventSDK();
 void writeEventLog(const char *log, int isDebug);

--- a/session/eventlog/event_sdk_wrapper.go
+++ b/session/eventlog/event_sdk_wrapper.go
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package eventlog
+
+// #cgo CXXFLAGS:-O2 -std=c++11
+// #cgo CFLAGS: -W -Wall -fstack-protector-all -fPIC
+// #cgo LDFLAGS:-ldl
+// #include <stdlib.h>
+// #include "event_sdk.h"
+import "C"
+import (
+	"encoding/json"
+	"sync"
+	"unsafe"
+)
+
+var (
+	sdkInitMu   sync.Mutex
+	sdkInited   bool
+	sdkDisabled bool // Cached disabled state to avoid repeated init attempts
+)
+
+// EventLogData represents the event log data structure
+type EventLogData struct {
+	Tid     int64             `json:"tid"`
+	Target  string            `json:"target"`
+	Message map[string]string `json:"message"`
+}
+
+// InitEventSDK initializes the event log SDK.
+// It returns true if initialization succeeded or was already done.
+func InitEventSDK() bool {
+	sdkInitMu.Lock()
+	defer sdkInitMu.Unlock()
+
+	if sdkInited {
+		return true
+	}
+
+	if sdkDisabled {
+		return false
+	}
+
+	ret := C.InitEventSDK()
+	switch ret {
+	case C.EVENT_LOG_SUCCESS:
+		sdkInited = true
+		return true
+	case C.EVENT_LOG_DISABLED:
+		sdkDisabled = true
+		return false
+	default:
+		logger.Warning("failed to initialize event SDK:", ret)
+		return false
+	}
+}
+
+// CloseEventSDK closes the event log SDK.
+func CloseEventSDK() {
+	sdkInitMu.Lock()
+	defer sdkInitMu.Unlock()
+
+	if sdkInited {
+		C.CloseEventLog()
+		sdkInited = false
+	}
+}
+
+// WriteEventLog writes an event log with the given data.
+// It returns false if the SDK is not initialized.
+func WriteEventLog(data *EventLogData) bool {
+	if !InitEventSDK() {
+		return false
+	}
+
+	content, err := json.Marshal(data)
+	if err != nil {
+		logger.Warning("failed to marshal event log data:", err)
+		return false
+	}
+
+	cStr := C.CString(string(content))
+	defer C.free(unsafe.Pointer(cStr))
+
+	C.writeEventLog(cStr, 0)
+	return true
+}
+
+// WriteEventLogSimple writes an event log with tid, target and a single key-value message.
+func WriteEventLogSimple(tid int64, target, key, value string) bool {
+	return WriteEventLog(&EventLogData{
+		Tid:    tid,
+		Target: target,
+		Message: map[string]string{
+			key: value,
+		},
+	})
+}

--- a/session/eventlog/module.go
+++ b/session/eventlog/module.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -12,7 +12,6 @@ package eventlog
 import "C"
 import (
 	"errors"
-	"fmt"
 	"sync"
 	"unsafe"
 
@@ -108,10 +107,8 @@ func start() error {
 	if has {
 		return errors.New("do not need to start eventlog")
 	}
-	ret := C.InitEventSDK()
-	if ret != 0 {
-		err := fmt.Errorf("failed to initialize event SDK:%d", ret)
-		return err
+	if !InitEventSDK() {
+		return errors.New("failed to initialize event SDK")
 	}
 	return nil
 }
@@ -128,7 +125,7 @@ func (m *Module) Stop() error {
 }
 
 func stop() error {
-	C.CloseEventLog()
+	CloseEventSDK()
 	_collectorMap = make(map[string]BaseCollector)
 	return nil
 }


### PR DESCRIPTION
Add event logging functionality for display screen changes and input device natural scroll settings. Implement debounce mechanism for display events to reduce log entries during rapid mode changes. Merge touchpad and mouse natural scroll logs on startup.

- Add display screen event logging with 1s debounce
- Add input devices natural scroll event logging
- Update copyright years to 2026

添加显示器和输入设备的事件日志功能。为显示器事件实现防抖机制，
减少快速模式切换时的日志条目。启动时合并触控板和鼠标的自然滚动日志。

PMS: TASK-388657

## Summary by Sourcery

Add centralized SDK wrapper–based event logging for display configurations and input device natural scroll settings, with conditional enablement by system edition and debounced startup/runtime reporting.

New Features:
- Record display screen configuration changes (startup, mode switch, monitor plug/unplug) as structured event logs with debounce to reduce rapid mode-change noise.
- Log touchpad and mouse natural scroll states, including a combined startup event and separate runtime change events for each device.

Enhancements:
- Introduce a Go wrapper around the C++ event log SDK with JSON payload support, thread-safe initialization, and safe shutdown semantics.
- Conditionally enable event logging based on system edition by reading /etc/os-version and restricting logging to Professional editions by default.
- Improve robustness of SDK teardown by guarding dlclose with a null check and resetting the handler pointer.

Chores:
- Update SPDX copyright years across touched files to 2026.