### PR TITLE
refactor: rename power control binary and remove TLP paths

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -79,7 +79,7 @@ Depends:
  network-manager,
  procps,
  rfkill,
- tlp,
+ deepin-power-control (>= 2.0.1),
  xdotool,
  x11-utils,
  xkb-data,
@@ -96,7 +96,6 @@ Provides:
 Recommends:
  flatpak,
  iio-sensor-proxy,
- tlp,
  proxychains4,
  mesa-utils,
 Suggests:

--- a/misc/systemd/services/system/dde-system-daemon.service
+++ b/misc/systemd/services/system/dde-system-daemon.service
@@ -125,11 +125,6 @@ ReadWritePaths=-/var/lib/dde-daemon/apps
 ReadWritePaths=-/tmp
 ReadWritePaths=-/home
 
-# TLP
-ReadWritePaths=-/usr/share/tlp/deepin-system-power-control/
-ReadWritePaths=-/etc/tlp.d/
-ReadWritePaths=-/run/tlp/
-
 OOMScoreAdjust=-500
 Nice=-5
 [Install]

--- a/system/power1/manager_powersave.go
+++ b/system/power1/manager_powersave.go
@@ -60,7 +60,7 @@ func (m *Manager) setDSPCState(state DSPCMode) {
 		Type:        "oneshot",
 		Description: "Transient Unit set deepin system power control",
 		Environment: []string{},
-		Commands:    []string{"/usr/sbin/deepin-system-power-control", "set", string(state)},
+		Commands:    []string{"/usr/sbin/deepin-power-control", "set", string(state)},
 	}
 	err = unitInfo.StartTransientUnit()
 	if err != nil {


### PR DESCRIPTION
1. Rename power control binary from 'deepin-system-power-control' to 'deepin-power-control' in manager_powersave.go
2. Remove TLP-related ReadWritePaths entries from systemd service file as they are no longer needed
3. Clean up service configuration to match the new binary naming convention

Influence:
1. Verify the power control binary exists at the new path /usr/sbin/ deepin-power-control
2. Test power save mode switching functionality to ensure the new binary is invoked correctly
3. Verify systemd service starts without sandboxing violations
4. Check that TLP-related functionality still works if needed, or confirm it's properly deprecated
5. Test system power management operations after the binary rename

refactor: 重命名电源控制二进制文件并移除 TLP 路径

1. 在 manager_powersave.go 中将电源控制二进制文件从 'deepin-system- power-control' 重命名为 'deepin-power-control'
2. 从 systemd 服务文件中移除不再需要的 TLP 相关 ReadWritePaths 配置
3. 清理服务配置以匹配新的二进制文件命名规范

Influence:
1. 验证电源控制二进制文件存在于新路径 /usr/sbin/deepin-power-control
2. 测试省电模式切换功能，确保新二进制文件被正确调用
3. 验证 systemd 服务启动时没有沙箱违规错误
4. 检查 TLP 相关功能是否仍正常工作，或确认其已被正确弃用
5. 测试二进制文件重命名后的系统电源管理操作 PMS: TASK-379971
Change-Id: I79cb430aa55b815d1621ebe04a237b5e7792591c

Change-Id: I534116c9eca012362e99cb92f92107246e97ad87

## Summary by Sourcery

Rename the power control binary used by the power management daemon and align the systemd service configuration with the new naming while dropping obsolete TLP-specific paths.

Enhancements:
- Update power save manager to invoke the renamed /usr/sbin/deepin-power-control binary instead of the old deepin-system-power-control path.
- Simplify dde-system-daemon systemd service configuration by removing no-longer-needed TLP-related path settings and matching the new binary name.