### PR TITLE
chore: update changelog to 6.1.86

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+dde-daemon (6.1.86) unstable; urgency=medium
+
+  * feat: add event logging for display and input devices
+  * refactor: rename power control binary and remove TLP paths
+  * refactor: improve display mode filtering logic
+  * fix: 修复修改快捷键后快捷键失效的问题
+  * fix: add debounce for volume feedback and optimize port change
+    detection
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 23 Apr 2026 21:46:10 +0800
+
 dde-daemon (6.1.85) unstable; urgency=medium
 
   * i18n: Updates for project Deepin Desktop Environment (#1083)


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 6.1.86

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 6.1.86
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump Debian changelog to version 6.1.86 targeting master.