### PR TITLE
chore: update changelog to 6.1.87

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+dde-daemon (6.1.87) unstable; urgency=medium
+
+  * perf: remove wallpaper blur and effect features and migrate
+    ImageBlur1 DBus call
+  * perf: cleanup systemd service dependencies for dde-session-daemon
+
+ -- zhangkun <zhangkun2@uniontech.com>  Fri, 24 Apr 2026 09:58:17 +0800
+
 dde-daemon (6.1.86) unstable; urgency=medium
 
   * feat: add event logging for display and input devices


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 6.1.87

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 6.1.87
- 目标分支: master

## Summary by Sourcery

Documentation:
- Refresh Debian changelog entries to reflect version 6.1.87.