### PR TITLE
fix(bluetooth): prevent path traversal in OBEX file receive

### DIFF
--- a/bluetooth1/obex_agent.go
+++ b/bluetooth1/obex_agent.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -162,6 +163,38 @@ func (a *obexAgent) unregisterAgent() {
 	}
 }
 
+// validateFilename validates that the filename is safe and does not contain
+// path traversal sequences. Only pure filenames are accepted.
+//
+// Security: Prevents path traversal attacks where a malicious remote device
+// sends filenames like "../.config/autostart/evil.desktop" to write files
+// outside the intended download directory.
+func validateFilename(name string) error {
+	// Reject empty filename
+	if name == "" {
+		return errors.New("empty filename")
+	}
+
+	// Reject special directory names
+	if name == "." || name == ".." {
+		return errors.New("invalid filename: . or ..")
+	}
+
+	// Reject path separators - filename must not contain '/' or '\'
+	// This prevents absolute paths and relative path traversal
+	if strings.ContainsAny(name, "/\\") {
+		return errors.New("path separator not allowed in filename")
+	}
+
+	// Ensure the name is a pure filename, not a path
+	// filepath.Base("../foo") returns "foo", which != "../foo"
+	if filepath.Base(name) != name {
+		return errors.New("not a pure filename")
+	}
+
+	return nil
+}
+
 // AuthorizePush 用于请求用户接收文件
 func (a *obexAgent) AuthorizePush(transferPath dbus.ObjectPath) (tempFileName string, busErr *dbus.Error) {
 	logger.Infof("dbus call obexAgent AuthorizePush with transferPath %v", transferPath)
@@ -177,6 +210,16 @@ func (a *obexAgent) AuthorizePush(transferPath dbus.ObjectPath) (tempFileName st
 		logger.Warning(err)
 		return "", dbusutil.ToError(err)
 	}
+
+	// Security: Validate filename to prevent path traversal attacks.
+	// The remote device should only send a pure filename (e.g., "photo.jpg"),
+	// not a path (e.g., "../.config/autostart/evil.desktop").
+	// Reject any filename containing path separators or ".." sequences.
+	if err := validateFilename(oriFilename); err != nil {
+		logger.Warning("rejected unsafe filename from remote device:", oriFilename, "reason:", err)
+		return "", dbusutil.ToError(errors.New("invalid filename"))
+	}
+
 	tempFileName = randFileName(oriFilename)
 	if len(tempFileName) > 255 {
 		tempFileName = tempFileName[:255]
@@ -424,6 +467,17 @@ func (a *obexAgent) receiveProgress(transfer *transferObj) {
 }
 
 func moveTempFile(src, dest string) string {
+	// Security: Check if destination is a symlink to prevent symlink attacks.
+	// A malicious local user could create a symlink in the download directory
+	// pointing to a sensitive file (e.g., ~/.bashrc, ~/.config/autostart/*.desktop).
+	// Use os.Lstat to detect symlinks without following them.
+	if fi, err := os.Lstat(dest); err == nil {
+		if fi.Mode()&os.ModeSymlink != 0 {
+			logger.Error("refusing to overwrite symlink:", dest)
+			return ""
+		}
+	}
+
 	count := 0
 	suffix := filepath.Ext(dest)
 	fileName := strings.TrimSuffix(dest, suffix)

--- a/bluetooth1/obex_agent_test.go
+++ b/bluetooth1/obex_agent_test.go
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package bluetooth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateFilename(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		// Normal filenames - should pass
+		{"normal jpg", "photo.jpg", false},
+		{"normal pdf", "document.pdf", false},
+		{"with spaces", "my document.pdf", false},
+		{"with dots", "file.name.txt", false},
+		{"with underscores", "my_file.txt", false},
+		{"with hyphens", "my-file.txt", false},
+		{"chinese filename", "照片.jpg", false},
+		{"long name", "a]very_long_filename_with_many_characters.txt", false},
+
+		// Path traversal attacks - should reject
+		{"relative traversal", "../.config/autostart/evil.desktop", true},
+		{"double traversal", "../../etc/passwd", true},
+		{"triple traversal", "../../../tmp/evil", true},
+		{"absolute path unix", "/etc/passwd", true},
+		{"absolute path home", "/home/user/.bashrc", true},
+		{"windows path backslash", "..\\windows\\system32", true},
+		{"windows path forward", "..\\..\\windows\\system32", true},
+		{"mixed separators", "../foo/bar", true},
+		{"separator in middle", "foo/bar", true},
+		{"backslash in middle", "foo\\bar", true},
+
+		// Edge cases - should reject
+		{"empty string", "", true},
+		{"just dot", ".", true},
+		{"just dotdot", "..", true},
+		{"just slash", "/", true},
+		{"just backslash", "\\", true},
+		{"dot with slash", "./", true},
+		{"dotdot with slash", "../", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateFilename(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err, "expected error for input: %q", tt.input)
+			} else {
+				assert.NoError(t, err, "unexpected error for input: %q", tt.input)
+			}
+		})
+	}
+}
+
+func TestValidateFilenameSecurity(t *testing.T) {
+	// Specific security-focused tests
+
+	t.Run("prevents path traversal to autostart", func(t *testing.T) {
+		err := validateFilename("../.config/autostart/evil.desktop")
+		assert.Error(t, err)
+	})
+
+	t.Run("prevents path traversal to ssh", func(t *testing.T) {
+		err := validateFilename("../../.ssh/authorized_keys")
+		assert.Error(t, err)
+	})
+
+	t.Run("prevents absolute path to sensitive file", func(t *testing.T) {
+		err := validateFilename("/etc/passwd")
+		assert.Error(t, err)
+	})
+
+	t.Run("prevents windows style path traversal", func(t *testing.T) {
+		err := validateFilename("..\\..\\windows\\system32\\config\\sam")
+		assert.Error(t, err)
+	})
+
+	t.Run("accepts normal filename", func(t *testing.T) {
+		err := validateFilename("vacation_photo.jpg")
+		assert.NoError(t, err)
+	})
+
+	t.Run("accepts filename with spaces", func(t *testing.T) {
+		err := validateFilename("my vacation photo.jpg")
+		assert.NoError(t, err)
+	})
+
+	t.Run("accepts filename with unicode", func(t *testing.T) {
+		err := validateFilename("照片.jpg")
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
1. Add validateFilename() to reject filenames with path separators
2. Block relative/absolute path traversal attacks (../, /etc/passwd)
3. Prevent symlink attacks by checking destination before move
4. Add comprehensive unit tests for filename validation

Log: Fix path traversal vulnerability in Bluetooth OBEX file receive

fix(bluetooth): 修复蓝牙 OBEX 文件接收路径遍历漏洞

1. 添加 validateFilename() 拒绝包含路径分隔符的文件名
2. 阻止相对/绝对路径遍历攻击（../、/etc/passwd）
3. 移动文件前检查目标是否为符号链接，防止符号链接攻击
4. 添加文件名验证的完整单元测试

Log: 修复蓝牙 OBEX 文件接收路径遍历漏洞

## Summary by Sourcery

Harden Bluetooth OBEX file reception against path traversal and symlink-based attacks.

Bug Fixes:
- Validate incoming OBEX filenames to reject path traversal, absolute paths, and unsafe directory markers.
- Prevent overwriting of symlink destinations when moving received files.

Tests:
- Add comprehensive unit tests to cover valid filenames and multiple path traversal and security edge cases for filename validation.