### PR TITLE
chore: update changelog to 6.1.88

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-daemon (6.1.88) unstable; urgency=medium
+
+  * fix(bluetooth): prevent path traversal in OBEX file receive
+
+ -- zhangkun <zhangkun2@uniontech.com>  Fri, 08 May 2026 15:03:28 +0800
+
 dde-daemon (6.1.87) unstable; urgency=medium
 
   * perf: remove wallpaper blur and effect features and migrate


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 6.1.88

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 6.1.88
- 目标分支: master
