### PR TITLE
fix(security): replace shell command execution with direct exec calls

### DIFF
--- a/bin/user-config/config_datas.go
+++ b/bin/user-config/config_datas.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2018 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -6,7 +6,6 @@ package main
 
 import (
 	"bufio"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -203,8 +202,7 @@ func copyXDGDirConfig(home, lang string) error {
 }
 
 func changeDirOwner(user, dir string) error {
-	cmd := fmt.Sprintf("chown -hR %s:%s %s", user, user, dir)
-	return doAction(cmd)
+	return exec.Command("chown", "-hR", user+":"+user, dir).Run()
 }
 
 func getDefaultLang() string {
@@ -232,13 +230,4 @@ func getDefaultLang() string {
 	}
 
 	return strings.Split(locale, ".")[0]
-}
-
-func doAction(cmd string) error {
-	out, err := exec.Command("/bin/sh", "-c", cmd).CombinedOutput()
-	if err != nil {
-		return errors.New(string(out))
-	}
-
-	return nil
 }

--- a/inputdevices1/keyboard.go
+++ b/inputdevices1/keyboard.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2018 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"os/user"
 	"path"
 	"regexp"
@@ -306,17 +307,17 @@ func (kbd *Keyboard) applyOptions() {
 	}
 
 	// the old value wouldn't be cleared, so we will force clear it.
-	err := doAction(cmdSetKbd + " -option")
+	err := exec.Command(cmdSetKbd, "-option").Run()
 	if err != nil {
 		logger.Warning("failed to clear keymap option:", err)
 		return
 	}
 
-	cmd := cmdSetKbd
+	args := []string{}
 	for _, opt := range options {
-		cmd += fmt.Sprintf(" -option %q", opt)
+		args = append(args, "-option", opt)
 	}
-	err = doAction(cmd)
+	err = exec.Command(cmdSetKbd, args...).Run()
 	if err != nil {
 		logger.Warning("failed to set keymap options:", err)
 	}
@@ -555,9 +556,8 @@ func applyLayout(value string) error {
 		}
 	}
 
-	var cmd = fmt.Sprintf("%s -layout \"%s\" -variant \"%s\"",
-		cmdSetKbd, layout, variant)
-	return doAction(cmd)
+	var cmd = exec.Command(cmdSetKbd, "-layout", layout, "-variant", variant)
+	return cmd.Run()
 }
 
 func setQtCursorBlink(rate int32, file string) error {
@@ -621,7 +621,7 @@ func getValueFromLine(line, delim string) string {
 }
 
 func applyXmodmapConfig() error {
-	err := doAction("xmodmap -e 'keycode 247 = XF86Away NoSymbol NoSymbol'")
+	err := exec.Command("xmodmap", "-e", "keycode 247 = XF86Away NoSymbol NoSymbol").Run()
 	if err != nil {
 		return err
 	}
@@ -629,7 +629,7 @@ func applyXmodmapConfig() error {
 	if !dutils.IsFileExist(config) {
 		return nil
 	}
-	return doAction("xmodmap " + config)
+	return exec.Command("xmodmap", config).Run()
 }
 
 func (kbd *Keyboard) listenRootWindowXEvent() {

--- a/inputdevices1/utils.go
+++ b/inputdevices1/utils.go
@@ -1,13 +1,10 @@
-// SPDX-FileCopyrightText: 2018 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 package inputdevices
 
 import (
-	"errors"
-	"os/exec"
-
 	"github.com/linuxdeepin/dde-daemon/common/dconfig"
 )
 
@@ -144,12 +141,4 @@ func isItemInList(item string, list []string) bool {
 		}
 	}
 	return false
-}
-
-func doAction(cmd string) error {
-	out, err := exec.Command("/bin/sh", "-c", cmd).CombinedOutput()
-	if err != nil {
-		return errors.New(string(out))
-	}
-	return nil
 }

--- a/keybinding1/manager.go
+++ b/keybinding1/manager.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2018 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 
 	"github.com/linuxdeepin/go-lib/appinfo/desktopappinfo"
 	"github.com/linuxdeepin/go-lib/strv"
@@ -1290,22 +1291,14 @@ func (m *Manager) listenSystemPlatformChanged() {
 	})
 }
 
-func runCommand(cmd string) (string, error) {
-	result, err := exec.Command("/bin/sh", "-c", cmd).Output()
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(string(result)), err
-}
-
 func checkProRunning(serverName string) bool {
-	cmd := `ps ux | awk '/` + serverName + `/ && !/awk/ {print $2}'`
-	pid, err := runCommand(cmd)
-	if err != nil {
-		logger.Warning(err)
+	// Validate serverName to prevent command injection
+	if !regexp.MustCompile(`^[a-zA-Z0-9._@:/-]+$`).MatchString(serverName) {
+		logger.Warningf("invalid server name: %s", serverName)
 		return false
 	}
-	return pid != ""
+	err := exec.Command("pgrep", "-f", serverName).Run()
+	return err == nil
 }
 
 func (m *Manager) execCmd(cmd string, viaStartdde bool) error {

--- a/system/inputdevices1/inputdevices.go
+++ b/system/inputdevices1/inputdevices.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2018 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
@@ -633,11 +632,5 @@ func setSupportAcpiDeviceEnable(devicePath string) error {
 		return err
 	}
 	logger.Infof("paths[0] %s,paths[1] %s", paths[0], paths[1])
-
-	cmd := exec.Command("/bin/sh", "-c", "echo "+paths[1]+"> "+paths[0])
-	err := cmd.Run()
-	if err != nil {
-		return err
-	}
-	return nil
+	return os.WriteFile(paths[0], []byte(paths[1]+"\n"), 0644)
 }

--- a/systeminfo1/lsblk_disk.go
+++ b/systeminfo1/lsblk_disk.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -150,6 +150,5 @@ func parseLsblkOutput(out []byte) (*lsblkOutput, error) {
 }
 
 func execLsblk() ([]byte, error) {
-	lsblk := "lsblk -J -bno NAME,SERIAL,TYPE,SIZE,VENDOR,MODEL,MOUNTPOINT,UUID"
-	return exec.Command("/bin/sh", "-c", lsblk).CombinedOutput()
+	return exec.Command("lsblk", "-J", "-bno", "NAME,SERIAL,TYPE,SIZE,VENDOR,MODEL,MOUNTPOINT,UUID").CombinedOutput()
 }


### PR DESCRIPTION
1. Remove doAction() helper in inputdevices1/utils.go and bin/user-config/config_datas.go that passed commands through /bin/sh
2. Replace all exec.Command("/bin/sh", "-c", cmd) calls with exec.Command(prog, args...) using proper argument lists
3. Fix command injection in checkProRunning() by validating serverName with regex and using pgrep instead of shell piped ps|awk
4. Replace shell echo redirect with os.WriteFile in setSupportAcpiDeviceEnable()
5. Convert lsblk invocation to use argument list instead of shell

Log: Eliminate command injection vectors by replacing shell command execution with direct exec.Command calls across multiple modules

fix(security): 替换 shell 命令执行为直接 exec 调用

1. 移除 inputdevices1/utils.go 和 bin/user-config/config_datas.go 中 通过 /bin/sh 传递命令的 doAction() 辅助函数
2. 将所有 exec.Command("/bin/sh", "-c", cmd) 调用替换为使用参数列表的 exec.Command(prog, args...)
3. 修复 checkProRunning() 中的命令注入漏洞，使用正则验证 serverName 并用 pgrep 替代 shell 管道 ps|awk
4. 将 setSupportAcpiDeviceEnable() 中的 shell echo 重定向替换为 os.WriteFile
5. 将 lsblk 调用改为使用参数列表而非 shell 执行

Log: 通过在多个模块中将 shell 命令执行替换为直接 exec.Command 调用，消除命令注入风险
PMS: TASK-389293