### PR TITLE
fix: remove early returns when monitor modes are empty

### DIFF
--- a/display1/manager.go
+++ b/display1/manager.go
@@ -1345,9 +1345,6 @@ func (m *Manager) addMonitor(monitorInfo *MonitorInfo) error {
 		monitorInfo.CurrentMode,
 	})
 	monitor.setPropModes(monitor.Modes)
-	if len(monitor.Modes) == 0 {
-		return errors.New("the monitor modes is nil")
-	}
 	m.updateBestmodeRefreshRate(monitor, preferredMode)
 	monitor.X = monitorInfo.X
 	monitor.Y = monitorInfo.Y
@@ -1452,9 +1449,6 @@ func (m *Manager) updateMonitor(monitorInfo *MonitorInfo) {
 		monitorInfo.CurrentMode,
 	})
 	monitor.setPropModes(monitor.Modes)
-	if len(monitor.Modes) == 0 {
-		return
-	}
 	bestMode := m.updateBestmodeRefreshRate(monitor, preferredMode)
 	monitor.setPropBestMode(bestMode)
 	var preferredModes []ModeInfo


### PR DESCRIPTION
Eliminate error return and early exit in addMonitor/updateMonitor when modes list is empty, allowing fallthrough to best mode update and downstream processing. This prevents unnecessary failures or skips when a monitor temporarily lacks mode information, enabling graceful handling by relying on the existing best mode update logic that can handle empty modes.

Log: Fixed monitor mode handling to avoid early returns on empty modes

Influence:
1. Test adding a monitor with empty modes and verify no error is returned
2. Test updating a monitor with empty modes and confirm subsequent processing continues
3. Verify best mode refresh rate is still computed correctly
4. Ensure no regression in normal monitor addition/update with valid modes

fix: 移除显示器模式为空时的提前返回

在 addMonitor/updateMonitor 中，当显示器模式列表为空时，移除错误返回和提
前退出，允许继续执行最佳模式更新和后续处理。这避免了因显示器临时缺少模式
信息导致的非必要失败或跳过，通过依赖已有的能处理空模式列表的最佳模式更新
逻辑实现优雅处理。

Log: 修复显示器模式为空时提前返回的问题

Influence:
1. 测试添加空模式的显示器，确认不会返回错误
2. 测试更新空模式的显示器，确认后续处理继续执行
3. 验证最佳刷新率计算仍能正常完成
4. 确保正常添加/更新有效模式的显示器没有回归问题

PMS: BUG-359569
Change-Id: I949058b03417b91fa0af902938ffc022f08f939d