### PR TITLE
fix: Resolve the issue where the shortcut keys stop working after bei…

### DIFF
--- a/keybinding1/manager_ifc.go
+++ b/keybinding1/manager_ifc.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2018 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -292,14 +292,14 @@ func (m *Manager) ClearShortcutKeystrokes(id string, type0 int32) *dbus.Error {
 	if shortcut == nil {
 		return dbusutil.ToError(ErrShortcutNotFound{id, type0})
 	}
+	m.enableListenDConifigChanged(false)
 	m.shortcutManager.ModifyShortcutKeystrokes(shortcut, nil)
 	err := shortcut.SaveKeystrokes()
+	m.enableListenDConifigChanged(true)
 	if err != nil {
 		return dbusutil.ToError(err)
 	}
-	if shortcut.ShouldEmitSignalChanged() {
-		m.emitShortcutSignal(shortcutSignalChanged, shortcut)
-	}
+	m.emitShortcutSignal(shortcutSignalChanged, shortcut)
 	return nil
 }
 
@@ -468,18 +468,17 @@ func (m *Manager) AddShortcutKeystroke(id string, type0 int32, keystroke string)
 	}
 
 	// 添加所有 keystroke
+	m.enableListenDConifigChanged(false)
 	for _, ksToAdd := range keystrokesToAdd {
 		m.shortcutManager.AddShortcutKeystroke(shortcut, ksToAdd)
 	}
 
 	err = shortcut.SaveKeystrokes()
+	m.enableListenDConifigChanged(true)
 	if err != nil {
 		return dbusutil.ToError(err)
 	}
-	if shortcut.ShouldEmitSignalChanged() {
-		m.emitShortcutSignal(shortcutSignalChanged, shortcut)
-	}
-
+	m.emitShortcutSignal(shortcutSignalChanged, shortcut)
 	return nil
 }
 
@@ -500,14 +499,14 @@ func (m *Manager) DeleteShortcutKeystroke(id string, type0 int32, keystroke stri
 	}
 	logger.Debug("keystroke:", ks.DebugString())
 
+	m.enableListenDConifigChanged(false)
 	m.shortcutManager.DeleteShortcutKeystroke(shortcut, ks)
 	err = shortcut.SaveKeystrokes()
+	m.enableListenDConifigChanged(true)
 	if err != nil {
 		return dbusutil.ToError(err)
 	}
-	if shortcut.ShouldEmitSignalChanged() {
-		m.emitShortcutSignal(shortcutSignalChanged, shortcut)
-	}
+	m.emitShortcutSignal(shortcutSignalChanged, shortcut)
 	return nil
 }
 


### PR DESCRIPTION
…ng modified.

1. Disable the DConfig change monitoring before modifying the shortcut keys to prevent recursive updates.
2. Re-enable the monitoring after the shortcut keys are saved.
3. Always send the shortcut key change signal and remove the conditional judgment. Log: Fixed the issue where the shortcut keys stopped working after being modified.

fix: 修复修改快捷键后快捷键失效的问题

1. 修改快捷键前禁用 DConfig 变更监听，防止递归更新
2. 快捷键保存完成后重新启用监听
3. 始终发送快捷键变更信号，移除条件判断

Log: 修复修改快捷键后快捷键失效的问题
PMS: BUG-355747
PMS: BUG-359143

## Summary by Sourcery

Ensure shortcut key changes reliably emit change notifications without interfering with DConfig change monitoring.

Bug Fixes:
- Prevent shortcut keys from becoming inactive after being modified by disabling DConfig listeners during keystroke updates and re-enabling them afterwards.
- Always emit shortcut change signals after keystroke modifications so consumers consistently receive updates.