### PR TITLE
fix(inputdevices): refactor natural scroll event logging for accurate…

### DIFF
--- a/inputdevices1/event_log.go
+++ b/inputdevices1/event_log.go
@@ -5,44 +5,30 @@
 package inputdevices
 
 import (
-	"time"
-
 	"github.com/linuxdeepin/dde-daemon/session/eventlog"
 )
 
 // Event IDs for input devices (10-digit numbers)
 const (
-	// Combined event ID for natural scroll settings on startup
-	EventTidNaturalScroll = 1000610009 // 自然滚动设置（触控板和鼠标合并）
+	EventTidNaturalScroll = 1000610009 // 自然滚动设置
 )
 
-// LogNaturalScroll logs natural scroll state for both touchpad and mouse in one event
-// Used for startup logging to reduce log entries
-func LogNaturalScroll(touchpadNaturalScroll, mouseNaturalScroll bool) {
+// LogTouchpadNaturalScroll logs touchpad natural scroll state
+// When touchpad is not present, pass hasTouchpad=false to report empty value
+func LogTouchpadNaturalScroll(enabled bool, hasTouchpad bool) {
+	value := ""
+	if hasTouchpad {
+		value = boolToString(enabled)
+	}
 	data := &eventlog.EventLogData{
 		Tid:    EventTidNaturalScroll,
 		Target: "natural_scroll",
 		Message: map[string]string{
-			"touchpad_natural_scroll": boolToString(touchpadNaturalScroll),
-			"mouse_natural_scroll":    boolToString(mouseNaturalScroll),
+			"touchpad_scroll_native_on": value,
 		},
 	}
 	if eventlog.WriteEventLog(data) {
-		logger.Debug("EventLog: natural scroll - touchpad:", touchpadNaturalScroll, "mouse:", mouseNaturalScroll)
-	}
-}
-
-// LogTouchpadNaturalScroll logs touchpad natural scroll state (for runtime changes)
-func LogTouchpadNaturalScroll(enabled bool) {
-	data := &eventlog.EventLogData{
-		Tid:    EventTidNaturalScroll,
-		Target: "natural_scroll",
-		Message: map[string]string{
-			"touchpad_natural_scroll": boolToString(enabled),
-		},
-	}
-	if eventlog.WriteEventLog(data) {
-		logger.Debug("EventLog: touchpad natural scroll:", enabled)
+		logger.Debug("EventLog: touchpad natural scroll:", value)
 	}
 }
 
@@ -52,7 +38,7 @@ func LogMouseNaturalScroll(enabled bool) {
 		Tid:    EventTidNaturalScroll,
 		Target: "natural_scroll",
 		Message: map[string]string{
-			"mouse_natural_scroll": boolToString(enabled),
+			"mouse_scroll_native_on": boolToString(enabled),
 		},
 	}
 	if eventlog.WriteEventLog(data) {
@@ -65,13 +51,4 @@ func boolToString(b bool) string {
 		return "true"
 	}
 	return "false"
-}
-
-// LogOnStartup logs the current state on startup with a delay
-// Both touchpad and mouse natural scroll states are logged in one combined event
-func LogOnStartup(touchpadNaturalScroll, mouseNaturalScroll bool) {
-	// Delay logging to ensure the event log system is ready
-	time.AfterFunc(5*time.Second, func() {
-		LogNaturalScroll(touchpadNaturalScroll, mouseNaturalScroll)
-	})
 }

--- a/inputdevices1/manager.go
+++ b/inputdevices1/manager.go
@@ -225,8 +225,9 @@ func (m *Manager) init() {
 
 		m.trackPoint.init()
 
-		// Log natural scroll states on startup
-		LogOnStartup(m.tpad.NaturalScroll.Get(), m.mouse.NaturalScroll.Get())
+		// Log natural scroll states separately on startup
+		LogMouseNaturalScroll(m.mouse.NaturalScroll.Get())
+		LogTouchpadNaturalScroll(m.tpad.NaturalScroll.Get(), m.tpad.Exist)
 	}
 
 	m.setWheelSpeed()

--- a/inputdevices1/mouse.go
+++ b/inputdevices1/mouse.go
@@ -211,8 +211,6 @@ func (m *Mouse) enableNaturalScroll() {
 				v.Id, v.Name, err)
 		}
 	}
-	// Log event
-	LogMouseNaturalScroll(enabled)
 }
 
 func (m *Mouse) enableMidBtnEmu() {
@@ -318,6 +316,7 @@ func (m *Mouse) initMouseDConfig() error {
 			m.disableTouchPad()
 		case dconfigKeyNaturalScroll:
 			m.enableNaturalScroll()
+			LogMouseNaturalScroll(m.NaturalScroll.Get())
 		case dconfigKeyMiddleButtonEnabled:
 			m.enableMidBtnEmu()
 		case dconfigKeyAdaptiveAccelProfile:

--- a/inputdevices1/touchpad.go
+++ b/inputdevices1/touchpad.go
@@ -232,8 +232,19 @@ func (tpad *Touchpad) init() {
 }
 
 func (tpad *Touchpad) handleDeviceChanged() {
+	oldExist := tpad.Exist
 	tpad.updateDXTpads()
 	tpad.init()
+
+	if oldExist != tpad.Exist {
+		if tpad.Exist {
+			// Touchpad plugged in: report real value
+			LogTouchpadNaturalScroll(tpad.NaturalScroll.Get(), true)
+		} else {
+			// Touchpad unplugged: report empty value
+			LogTouchpadNaturalScroll(false, false)
+		}
+	}
 }
 
 func (tpad *Touchpad) updateDXTpads() {
@@ -321,8 +332,6 @@ func (tpad *Touchpad) enableNaturalScroll() {
 				v.Id, v.Name, err)
 		}
 	}
-	// Log event
-	LogTouchpadNaturalScroll(enabled)
 }
 
 func (tpad *Touchpad) setScrollDistance() {
@@ -578,6 +587,7 @@ func (tpad *Touchpad) initTouchpadDConfig() error {
 			tpad.disableWhileTyping()
 		case dconfigKeyTouchpadNaturalScroll:
 			tpad.enableNaturalScroll()
+			LogTouchpadNaturalScroll(tpad.NaturalScroll.Get(), true)
 		case dconfigKeyTouchpadEdgeScroll:
 			tpad.enableEdgeScroll()
 		case dconfigKeyTouchpadHorizScroll:


### PR DESCRIPTION
… reporting

Rename event fields and restructure logging triggers to ensure each event is reported exactly once from the correct source:

- Rename mouse_natural_scroll -> mouse_scroll_native_on
- Rename touchpad_natural_scroll -> touchpad_scroll_native_on
- Report mouse and touchpad separately on startup instead of combined
- Move logging from enableNaturalScroll() to dconfig change callbacks to avoid duplicate events during device hotplug/init
- Add touchpad hotplug detection: report real value on plug-in, empty value on unplug, no event otherwise
- Remove LogOnStartup and LogNaturalScroll helper functions

修改自然滚动事件埋点字段名及上报逻辑，确保事件准确上报：
- 重命名字段 mouse_natural_scroll -> mouse_scroll_native_on
- 重命名字段 touchpad_natural_scroll -> touchpad_scroll_native_on
- 开机时鼠标和触摸板分别独立上报，不再合并
- 将埋点从 enableNaturalScroll() 移至 dconfig 值变更回调， 避免设备热插拔和初始化时重复上报
- 新增触摸板热插拔检测：插入时上报真实值，拔出时上报空值， 其他情况不触发
- 移除 LogOnStartup 和 LogNaturalScroll 辅助函数

Test:
1. systemctl --user restart org.dde.session.Daemon1 -> 2 events: mouse_scroll_native_on ("true"/"false") + touchpad_scroll_native_on ("true"/"false")
2. Toggle touchpad natural scroll in control center -> 1 event: touchpad_scroll_native_on only
3. Toggle mouse natural scroll in control center -> 1 event: mouse_scroll_native_on only
4. Unbind touchpad via sysfs (simulates unplug) -> 1 event: touchpad_scroll_native_on ("")
5. Bind touchpad via sysfs (simulates plug-in) -> 1 event: touchpad_scroll_native_on ("true"/"false")

PMS: BUG-361165、BUG-361159、BUG-361147、BUG-361141

## Summary by Sourcery

Refine natural scroll telemetry to log mouse and touchpad states separately and accurately across startup, configuration changes, and touchpad hotplug events.

New Features:
- Report touchpad hotplug events by sending the current natural scroll value on plug-in and an empty value on unplug.

Bug Fixes:
- Prevent duplicate natural scroll events by moving logging from runtime enablement functions to configuration change callbacks.

Enhancements:
- Rename natural scroll logging fields for mouse and touchpad and switch to per-device reporting instead of a combined event.
- Simplify event logging by removing the delayed startup logger and combined natural scroll helper.