### PR TITLE
fix(display): adjust default manual color temperature

### DIFF
--- a/misc/dsg-configs/org.deepin.Display.json
+++ b/misc/dsg-configs/org.deepin.Display.json
@@ -14,7 +14,7 @@
       "visibility": "private"
     },
     "defaultTemperatureManual": {
-      "value": 3500,
+      "value": 6500,
       "serial": 0,
       "flags": [],
       "name": "default temperature manual",


### PR DESCRIPTION
The default value for manual color temperature mode was 3500K which caused unexpected warm tint when users first enable color temperature. Change to 6500K to match the standard display default and the none-mode behavior.

手动模式下默认色温值为3500K，修改为6500K，与标准显示器默认值保持一致。

Log: 修正手动色温默认值为6500K
PMS: 360915
Influence: 控制中心开启护眼模式，全天模式下，默认色温为50%

## Summary by Sourcery

Adjust the default manual color temperature configuration to align with the standard display default and non-adjusted mode behavior.

Bug Fixes:
- Correct the initial manual color temperature value to prevent an unexpectedly warm tint when enabling color temperature adjustment.

Enhancements:
- Update display configuration so manual color temperature defaults to a neutral 6500K matching typical display settings.