### PR TITLE
fix(touchpad): correct DConfig key name for gesture enabled

### DIFF
--- a/inputdevices1/touchpad.go
+++ b/inputdevices1/touchpad.go
@@ -559,11 +559,11 @@ func enableGesture(enabled bool) {
 	if err != nil {
 		return
 	}
-	if value, _ := dconfig.GetValueBool("touchpadEnabled"); value == enabled {
+	if value, _ := dconfig.GetValueBool("touchPadEnabled"); value == enabled {
 		return
 	}
 
-	dconfig.SetValue("touchpadEnabled", enabled)
+	dconfig.SetValue("touchPadEnabled", enabled)
 }
 
 func (tpad *Touchpad) initTouchpadDConfig() error {


### PR DESCRIPTION
Use "touchPadEnabled" to match the key defined in org.deepin.dde.daemon.gesture schema, fixing touchpad gestures remaining active after disabling the touchpad.

修复触控板禁用后手势仍然可用的问题，DConfig key 名称大小写不匹配导致写入了错误的配置项。

Log: 修复禁用触控板后手势仍然可用的bug
PMS: 360815
Influence: 禁用触控板后，触控板手势正确停止响应

## Summary by Sourcery

Bug Fixes:
- Ensure disabling the touchpad correctly disables touchpad gestures by aligning the DConfig key name with the gesture daemon schema.