### PR TITLE
fix(audio): retry full port auto-switch on source events

### DIFF
--- a/audio1/audio_events.go
+++ b/audio1/audio_events.go
@@ -528,7 +528,7 @@ func (a *Audio) handleSourceAdded(idx uint32) {
 	} else if a.checkCardIsReady(source.Card) {
 		// 只有新增source或端口列表/活跃端口变化时才触发自动切换
 		if isNewSource || portChanged {
-			a.autoSwitchInputPort()
+			a.autoSwitchPort()
 		}
 	}
 
@@ -556,7 +556,7 @@ func (a *Audio) handleSourceRemoved(idx uint32) {
 		a.defaultSource = nil
 	}
 	if isPhy && a.checkCardIsReady(cardId) {
-		a.autoSwitchInputPort()
+		a.autoSwitchPort()
 	}
 }
 
@@ -577,7 +577,7 @@ func (a *Audio) handleSourceChanged(idx uint32) {
 	// cardchange事件也会触发，但是处理不了，因为这时source可能还没更新，无可用端口
 	// 只有当端口列表或活跃端口发生变化时，才触发自动切换
 	if portChanged && isPhysicalDevice(source.Name) && a.checkCardIsReady(source.Card) {
-		a.autoSwitchInputPort()
+		a.autoSwitchPort()
 	}
 }
 


### PR DESCRIPTION
Use autoSwitchPort in source event handlers when the card becomes ready.

在 source 事件处理里改为调用 autoSwitchPort，以便声卡就绪后同时重试输入输出切换。

Log: 修复具备输入和输出能力的声卡设备重插后输出恢复失败
PMS: 361483
Influence: 1. 修复具备输入和输出能力的声卡设备在 source 事件晚到时默认输出设备无法恢复的问题; 2. 修复多次选择指定输出设备并插拔后，输出设备列表显示空白问题。