### PR TITLE
fix(eventlog): 修复 .desktop 文件名命令注入漏洞

### DIFF
--- a/session/eventlog/app_event.go
+++ b/session/eventlog/app_event.go
@@ -196,8 +196,7 @@ func (c *appEventCollector) monitor(entryObj dock.Entry) {
 				logger.Debugf("desktop file is link file, real path is %v", desktop)
 			}
 			// run dpkg to get package name
-			dpkg := []string{"dpkg", "-S", desktop}
-			cmd := exec.Command("/bin/bash", "-c", strings.Join(dpkg, " "))
+			cmd := exec.Command("dpkg", "-S", desktop)
 			logger.Debugf("dpkg command is %v", cmd)
 			// run command to get package
 			buf, err := cmd.Output()


### PR DESCRIPTION
## Summary

session/eventlog 模块中，`getPackageName` 使用 `exec.Command("/bin/bash", "-c", ...)` 执行 `dpkg -S` 查询归属包。当 .desktop 文件名包含 shell 元字符（如 \$(cmd)）时，会被 bash 展开执行。

## 修复

将 `exec.Command("/bin/bash", "-c", strings.Join(dpkg, " "))` 改为 `exec.Command("dpkg", "-S", desktop)`，直接传递参数给系统调用，不经过 shell 解释。

## 受影响版本

6.1.89 及 master 分支均存在此问题。

## 测试

- 创建名为 \$(id).desktop 的 .desktop 文件，验证修复前会执行命令，修复后 id 命令不会被展开
- 正常 .desktop 文件的包名查询功能不受影响

## 安全说明

dde-session-daemon 以用户权限运行（非 root），此漏洞不构成提权，但属于应在 code review 中消灭的代码模式。

## Summary by Sourcery

Bug Fixes:
- Prevent command injection in dpkg package lookup by invoking dpkg directly without passing through a shell when processing .desktop filenames.