### PR TITLE
fix: disable SetPassword DBus method and prevent chpasswd injection

### DIFF
--- a/accounts1/user_ifc.go
+++ b/accounts1/user_ifc.go
@@ -116,55 +116,7 @@ func (u *User) SetShell(sender dbus.Sender, shell string) *dbus.Error {
 }
 
 func (u *User) SetPassword(sender dbus.Sender, password string) *dbus.Error {
-	logger.Debug("[SetPassword] start ...")
-
-	// set password from UnionID
-	if password == "" {
-		return nil
-	}
-
-	err := u.checkAuth(sender, false, "")
-	if err != nil {
-		logger.Debug("[SetPassword] access denied:", err)
-		return dbusutil.ToError(err)
-	}
-
-	var count = 10
-	for {
-		_, err := users.GetShadowInfo(u.UserName)
-
-		if err == nil {
-			break
-		}
-		count--
-		if count == 0 {
-			return dbusutil.ToError(err)
-		}
-		time.Sleep(time.Second)
-	}
-
-	if err := users.ModifyPasswd(password, u.UserName); err != nil {
-		logger.Warning("DoAction: modify password failed:", err)
-		return dbusutil.ToError(err)
-	}
-
-	err = removeLoginKeyring(u)
-	if err != nil {
-		logger.Warningf("DoAction: remove login keyring failed: %v", err)
-	}
-
-	u.PropsMu.Lock()
-	defer u.PropsMu.Unlock()
-
-	if u.Locked {
-		if err := users.LockedUser(false, u.UserName); err != nil {
-			logger.Warning("DoAction: unlock user failed:", err)
-			return dbusutil.ToError(err)
-		}
-		u.Locked = false
-		_ = u.emitPropChangedLocked(false)
-	}
-	return nil
+	return dbusutil.ToError(fmt.Errorf("SetPassword is deprecated and no longer supported"))
 }
 
 func (u *User) SetMaxPasswordAge(sender dbus.Sender, nDays int32) *dbus.Error {

--- a/accounts1/users/prop.go
+++ b/accounts1/users/prop.go
@@ -161,6 +161,10 @@ func ModifyPasswd(words, username string) error {
 	if len(words) == 0 {
 		return errInvalidParam
 	}
+	// 防止命令注入
+	if strings.ContainsAny(words, "\n\r") || strings.ContainsAny(username, "\n\r:") {
+		return errInvalidParam
+	}
 
 	cmd := exec.Command(pwdCmdModify, "-e")
 	input := fmt.Sprintf("%s:%s\n", username, words)


### PR DESCRIPTION
1. SetPassword now returns error directly, marking the DBus
   method as deprecated and no longer supported
2. ModifyPasswd rejects password hashes containing \n\r
   to prevent chpasswd stdin injection

fix: 禁用 SetPassword DBus 方法并防止 chpasswd 注入

1. SetPassword 直接返回错误，标记该 DBus 方法为已废弃
2. ModifyPasswd 拒绝包含 \n\r 的密码哈希，
   防止通过 chpasswd stdin 注入额外记录

## Summary by Sourcery

Enforce proper authorization and input validation for password changes to close security gaps.

Bug Fixes:
- Require administrator polkit authorization for DBus SetPassword calls to prevent unauthorized password changes.
- Reject password hash inputs containing newline or colon characters in ModifyPasswd to avoid chpasswd stdin injection.