### PR TITLE
fix: correct display mode in event log for single screen / 修复单屏时事件日志显…

### DIFF
--- a/display1/manager.go
+++ b/display1/manager.go
@@ -3565,6 +3565,10 @@ func (m *Manager) logDisplayScreenEvent() {
 
 	// 获取当前显示模式
 	displayMode := m.DisplayMode
+	// 如果只有一个屏幕，强制使用单屏模式
+	if screenCount == 1 {
+		displayMode = DisplayModeOnlyOne
+	}
 
 	// 获取主显示器名称
 	primaryMonitor := m.Primary


### PR DESCRIPTION
…示模式错误

When a user unplugs an external monitor and logs in again with only one screen, the event log incorrectly shows display_mode as "EXTEND" instead of the monitor name. This fix ensures the display mode in event logs reflects the actual screen state.

当用户拔掉外接显示器后重新登录只有一个屏幕时，事件日志错误地显示 display_mode 为 "EXTEND" 而不是显示器名称。 此修复确保事件日志中的显示模式反映实际的屏幕状态。

PMS: BUG-361115

## Summary by Sourcery

Bug Fixes:
- Correct display_mode logging so that when only one screen is connected it records single-screen mode instead of an extended display state.