### PR TITLE
refactor: rename display transition config

### DIFF
--- a/misc/dsg-configs/org.deepin.Display.json
+++ b/misc/dsg-configs/org.deepin.Display.json
@@ -207,7 +207,7 @@
       "permissions": "readwrite",
       "visibility": "private"
     },
-    "transition-step-interval": {
+    "transition-min-step-interval": {
       "value": 100,
       "serial": 0,
       "flags": [],


### PR DESCRIPTION
1. Rename the display configuration key from "transition-step-interval" to "transition-min-step-interval" in org.deepin.Display.json
2. Keep the existing default value, permissions, and visibility unchanged
3. Clarify that this setting represents the minimum interval between transition steps, improving naming accuracy and reducing ambiguity for future configuration usage and maintenance

Influence:
1. Verify that any component reading this display configuration can resolve the renamed key correctly
2. Test display transition behavior to confirm the configured interval still takes effect as expected
3. Check backward compatibility or migration handling if any existing environment still depends on the old key name
4. Validate that configuration loading does not report missing-key or invalid-schema errors

refactor: 重命名显示过渡配置项

1. 将 org.deepin.Display.json 中的显示配置键从 "transition-step- interval" 重命名为 "transition-min-step-interval"
2. 保持原有默认值、权限和可见性不变
3. 通过更准确的命名明确该配置表示过渡步骤之间的最小时间间隔，减少歧义， 便于后续配置使用与维护

Influence:
1. 验证所有读取该显示配置的组件都能正确识别重命名后的键
2. 测试显示过渡行为，确认该时间间隔配置仍能按预期生效
3. 检查向后兼容或迁移处理，确认现有环境若依赖旧键名时不会出现异常
4. 验证配置加载过程不会出现缺失键或模式不匹配等错误

PMS: BUG-358023
Change-Id: I5082b93e00aca72a30cec387ffefcab0d2968fd3

## Summary by Sourcery

Enhancements:
- Rename the display transition timing key in org.deepin.Display.json to better reflect that it represents the minimum interval between transition steps without altering defaults or permissions.