### PR TITLE
fix: revert SetPassword disable, restore with admin auth

### DIFF
--- a/accounts1/user_ifc.go
+++ b/accounts1/user_ifc.go
@@ -116,7 +116,55 @@ func (u *User) SetShell(sender dbus.Sender, shell string) *dbus.Error {
 }
 
 func (u *User) SetPassword(sender dbus.Sender, password string) *dbus.Error {
-	return dbusutil.ToError(fmt.Errorf("SetPassword is deprecated and no longer supported"))
+	logger.Debug("[SetPassword] start ...")
+
+	// set password from UnionID
+	if password == "" {
+		return nil
+	}
+
+	err := u.checkAuth(sender, false, polkitActionUserAdministration)
+	if err != nil {
+		logger.Debug("[SetPassword] access denied:", err)
+		return dbusutil.ToError(err)
+	}
+
+	var count = 10
+	for {
+		_, err := users.GetShadowInfo(u.UserName)
+
+		if err == nil {
+			break
+		}
+		count--
+		if count == 0 {
+			return dbusutil.ToError(err)
+		}
+		time.Sleep(time.Second)
+	}
+
+	if err := users.ModifyPasswd(password, u.UserName); err != nil {
+		logger.Warning("DoAction: modify password failed:", err)
+		return dbusutil.ToError(err)
+	}
+
+	err = removeLoginKeyring(u)
+	if err != nil {
+		logger.Warningf("DoAction: remove login keyring failed: %v", err)
+	}
+
+	u.PropsMu.Lock()
+	defer u.PropsMu.Unlock()
+
+	if u.Locked {
+		if err := users.LockedUser(false, u.UserName); err != nil {
+			logger.Warning("DoAction: unlock user failed:", err)
+			return dbusutil.ToError(err)
+		}
+		u.Locked = false
+		_ = u.emitPropChangedLocked(false)
+	}
+	return nil
 }
 
 func (u *User) SetMaxPasswordAge(sender dbus.Sender, nDays int32) *dbus.Error {


### PR DESCRIPTION
1. Restore SetPassword DBus method implementation, as it is used by dde-control-center when creating new users
2. Require polkitActionUserAdministration authentication to prevent unauthorized password changes
3. Keep the chpasswd injection guard in ModifyPasswd

Log: SetPassword DBus method is restored for new user creation

Influence:
1. creating a new user via control center should set password successfully
2. non-admin user calling SetPassword should still be denied

PMS: TASK-390039

fix: 恢复 SetPassword 接口，保留管理员鉴权

1. 恢复 SetPassword DBus 方法实现，因为控制中心创建新用户 时需要调用该接口
2. 要求 polkitActionUserAdministration 鉴权，防止未授权 修改密码
3. 保留 ModifyPasswd 中的 chpasswd 注入防护

Log: SetPassword DBus 方法已恢复，用于新用户创建场景

Influence:
1. 通过控制中心创建新用户时应能成功设置密码
2. 非管理员用户调用 SetPassword 仍应被拒绝