### PR TITLE
feat(thp): disable transparent huge pages for DDE daemon services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,9 @@ print_gopath: prepare
 	GOPATH="${CURDIR}/${GOPATH_DIR}:${GOPATH}"
 
 install: build install-dde-data install-icons
+	mkdir -pv ${DESTDIR}${PREFIX}/libexec
+	install -Dm755 misc/thp/dde-thp-disable ${DESTDIR}${PREFIX}/libexec/dde-thp-disable
+
 	mkdir -pv ${DESTDIR}${PREFIX}/lib/deepin-daemon
 	cp -f out/bin/* ${DESTDIR}${PREFIX}/lib/deepin-daemon/
 

--- a/debian/dde-daemon.install
+++ b/debian/dde-daemon.install
@@ -1,1 +1,2 @@
 debian/reconfigure-dde-daemon /etc/kernel/postinst.d/
+misc/thp/dde-thp-disable usr/libexec/

--- a/misc/systemd/services/system/dde-lock-service.service
+++ b/misc/systemd/services/system/dde-lock-service.service
@@ -7,6 +7,7 @@ Type=dbus
 User=lightdm
 Group=lightdm
 BusName=org.deepin.dde.LockService1
+ExecStartPre=-/usr/libexec/dde-thp-disable
 ExecStart=/usr/lib/deepin-daemon/dde-lockservice
 # 通过设置/var/lib/lightdm/目录的lightdm组权限，lockservice可以安全地以lightdm用户运行
 StandardOutput=journal

--- a/misc/systemd/services/system/dde-system-daemon.service
+++ b/misc/systemd/services/system/dde-system-daemon.service
@@ -9,6 +9,7 @@ Wants=nss-user-lookup.target fprintd.service
 
 [Service]
 User=root
+ExecStartPre=-/usr/libexec/dde-thp-disable
 ExecStart=/usr/lib/deepin-daemon/dde-system-daemon
 StandardOutput=null
 StandardError=journal

--- a/misc/systemd/services/user/org.dde.session.Daemon1.service
+++ b/misc/systemd/services/user/org.dde.session.Daemon1.service
@@ -13,6 +13,7 @@ After=treeland-xwayland.service
 [Service]
 Type=dbus
 BusName=org.deepin.dde.Daemon1
+ExecStartPre=-/usr/libexec/dde-thp-disable
 ExecStart=/usr/lib/deepin-daemon/dde-session-daemon
 Slice=app.slice
 Restart=on-failure

--- a/misc/thp/dde-thp-disable
+++ b/misc/thp/dde-thp-disable
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+CG=$(awk -F: '$1=="0"{print $3}' /proc/self/cgroup | head -n1)
+
+[ -n "${CG:-}" ] || exit 0
+
+FILE="/sys/fs/cgroup${CG}/memory.thp_mode"
+
+if [ -e "$FILE" ]; then
+    if ! echo disable > "$FILE" 2>/dev/null; then
+        logger -t thp-disable "failed to write disable to $FILE"
+    fi
+fi
+
+exit 0


### PR DESCRIPTION
1. Add dde-thp-disable script to disable THP at cgroup level before service startup
2. Integrate as ExecStartPre in dde-lock, dde-system-daemon, and dde-session-daemon services
3. Update Makefile and Debian packaging to install the script to /usr/libexec/

Log: Disable THP for DDE daemon processes to optimize memory behavior

feat(thp): 禁用 DDE 守护进程的透明大页

1. 新增 dde-thp-disable 脚本，在服务启动前通过 cgroup 禁用 THP
2. 将脚本作为 ExecStartPre 集成到 dde-lock、dde-system-daemon 和 dde-session-daemon 服务中
3. 更新 Makefile 和 Debian 打包规则，将脚本安装到 /usr/libexec/

Log: 为 DDE 守护进程禁用透明大页以优化内存行为
PMS: TASK-390043

## Summary by Sourcery

Disable transparent huge pages for core DDE daemon services via a new helper script and service unit integration.

New Features:
- Introduce dde-thp-disable helper script to disable transparent huge pages at the cgroup level before daemon startup.

Enhancements:
- Wire dde-thp-disable as an ExecStartPre step in dde-lock, dde-system-daemon, and dde-session-daemon systemd units to control THP behavior for these processes.
- Install the dde-thp-disable script into /usr/libexec via Makefile and Debian packaging updates.