### PR TITLE
fix(dde-power): temporarily remove D-Bus service to prevent incorrect…

### DIFF
--- a/bin/dde-session-daemon/main.go
+++ b/bin/dde-session-daemon/main.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2018 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -40,7 +40,7 @@ var logger = log.NewLogger("daemon/dde-session-daemon")
 var hasDDECookie bool
 var hasTreeLand bool
 
-var treeLandNotAllowModules = []string{"x-event-monitor", "keybinding", "screensaver", "display", "xsettings"}
+var treeLandNotAllowModules = []string{"x-event-monitor", "keybinding", "screensaver", "display", "xsettings", "power"}
 
 func isInShutdown() bool {
 	bus, err := dbus.SystemBus()

--- a/misc/services/org.deepin.dde.Power1.service
+++ b/misc/services/org.deepin.dde.Power1.service
@@ -1,4 +1,0 @@
-[D-BUS Service]
-Name=org.deepin.dde.Power1
-Exec=/usr/lib/deepin-daemon/dde-session-daemon
-SystemdService=org.dde.session.Daemon1.service


### PR DESCRIPTION
… activation on Treeland

1. Removed org.deepin.dde.Power1.service activation file to prevent the power module from being incorrectly activated
2. On Treeland, the session power module now runs within dde-services, making the standalone activation file redundant
3. This is a temporary measure; X11 power flows will be migrated to dde-services for unified management later

Log: Temporarily remove D-Bus activation file to prevent duplicate power daemon on Treeland

fix(dde-power): 临时移除 D-Bus 激活文件，防止 Treeland 环境下的错误激活

1. 移除 org.deepin.dde.Power1.service 激活文件，防止电源模块被错误激活
2. Treeland 环境下 session 电源模块已在 dde-services 中运行，独立激活文件不再需要
3. 此为临时方案，后续将统一迁移 X11 流程到 dde-services 中管理

Log: 临时移除 D-Bus 激活文件，防止 Treeland 下电源守护进程重复启动
PMS: BUG-346597
PMS: BUG-346589
PMS: BUG-346575