### PR TITLE
fix(inputdevices): refresh touchpad devices after mouse removal

### DIFF
--- a/inputdevices1/touchpad.go
+++ b/inputdevices1/touchpad.go
@@ -281,14 +281,33 @@ func (tpad *Touchpad) updateDXTpads() {
 
 // 受鼠标禁用触控板影响，临时关闭触控板
 func (tpad *Touchpad) setDisableTemporary(disable bool) {
+	oldDisableTemporary := tpad.disableTemporary
+	tpad.disableTemporary = disable
+	enabled := !disable && tpad.TPadEnable
+	recovered := oldDisableTemporary && !disable && enabled
+
 	if len(tpad.devInfos) > 0 {
 		for _, v := range tpad.devInfos {
-			err := v.Enable(!disable && tpad.TPadEnable)
+			err := v.Enable(enabled)
 			if err != nil {
 				logger.Warningf("Enable '%v - %v' failed: %v",
 					v.Id, v.Name, err)
 			}
 		}
+	}
+
+	if recovered {
+		tpad.refreshSystemTouchpadDevices()
+	}
+}
+
+func (tpad *Touchpad) refreshSystemTouchpadDevices() {
+	if tpad.sysTouchPad == nil {
+		logger.Warning("skip system touchpad refresh because system touchpad proxy is nil")
+		return
+	}
+	if err := tpad.sysTouchPad.SetTouchpadEnable(0, true); err != nil {
+		logger.Warning("request system touchpad refresh failed:", err)
 	}
 }
 

--- a/system/inputdevices1/touchpad.go
+++ b/system/inputdevices1/touchpad.go
@@ -86,7 +86,11 @@ func (t *Touchpad) SetTouchpadEnable(enabled bool) *dbus.Error {
 
 func (t *Touchpad) setTouchpadEnable(enabled bool) error {
 	logger.Debugf("setTouchpadEnable: %v", enabled)
-	if !t.setPropEnable(enabled) {
+	changed := t.setPropEnable(enabled)
+	if !changed && enabled {
+		return t.refreshTouchpadDevices()
+	}
+	if !changed {
 		return nil
 	}
 
@@ -103,6 +107,17 @@ func (t *Touchpad) setTouchpadEnable(enabled bool) error {
 		return err
 	}
 
+	return nil
+}
+
+func (t *Touchpad) refreshTouchpadDevices() error {
+	if err := reloadUdevRules(); err != nil {
+		logger.Warning("failed to reload udev rules:", err)
+	}
+	if err := t.triggerTouchpadDevices(); err != nil {
+		logger.Warning("failed to trigger touchpad devices:", err)
+		return err
+	}
 	return nil
 }
 
@@ -132,17 +147,7 @@ func (t *Touchpad) setTouchpadEnableViaUdev(enabled bool) error {
 		logger.Info("created udev rule file:", udevRuleFile)
 	}
 
-	// 重新加载 udev 规则
-	if err := reloadUdevRules(); err != nil {
-		logger.Warning("failed to reload udev rules:", err)
-	}
-
-	// 只触发触控板设备，减少不必要的事件
-	if err := t.triggerTouchpadDevices(); err != nil {
-		logger.Warning("failed to trigger touchpad devices:", err)
-	}
-
-	return nil
+	return t.refreshTouchpadDevices()
 }
 
 // reloadUdevRules 重新加载 udev 规则


### PR DESCRIPTION
Refresh touchpad input devices after temporary disable recovery.

鼠标移除后从临时禁用恢复触摸板时，刷新触摸板输入设备。

Log: 修复拔出鼠标后WPS无法双指滚动的问题
Influence: 插入鼠标时禁用触摸板功能恢复触摸板后，WPS可正常双指滚动。
PMS: BUG-360263