### PR TITLE
fix: add dde-shell to touchscreen longpress blacklist

### DIFF
--- a/gesture1/utils.go
+++ b/gesture1/utils.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2018 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -77,7 +77,8 @@ func getCurrentActionWindowCmd() string {
 		logger.Warning("Failed to read cmdline:", err)
 		return ""
 	}
-	return string(data)
+	// /proc/<pid>/cmdline 用 null 字节分隔参数，替换为空格以便黑名单匹配
+	return strings.ReplaceAll(string(data), "\x00", " ")
 }
 
 func isSessionActive(sessionPath dbus.ObjectPath) bool {

--- a/misc/dsg-configs/org.deepin.dde.daemon.touchscreen.json
+++ b/misc/dsg-configs/org.deepin.dde.daemon.touchscreen.json
@@ -36,7 +36,7 @@
       "visibility": "public"
     },
     "longpressBlacklist": {
-      "value": ["/opt/google/chrome/chrome"],
+      "value": ["/opt/google/chrome/chrome","/usr/bin/dde-shell -C DDE"],
       "serial": 0,
       "flags": [],
       "name": "longpressBlacklist",


### PR DESCRIPTION
1. Fix cmdline parsing to replace null bytes with spaces for proper blacklist matching
2. Add "/usr/bin/dde-shell -C DDE" to longpressBlacklist configuration
3. The dde-shell implements its own touch screen long-press functionality, causing conflicts when both handle the gesture

Log: Filter dde-shell DDE plugin from touchscreen longpress handling

Influence:
1. Test touchscreen long-press functionality on DDE desktop environment
2. Verify long-press detection no longer triggers duplicate actions in dde-shell
3. Test cmdline parsing with processes containing multiple arguments
4. Verify other blacklisted applications still work correctly
5. Test long-press behavior on Chrome browser remains unchanged

fix: 将 dde-shell 添加到触控屏长按黑名单

1. 修复 cmdline 解析，将空字节替换为空格以便正确进行黑名单匹配
2. 在 longpressBlacklist 配置中添加 "/usr/bin/dde-shell -C DDE"
3. dde-shell 自己实现了触控屏长按功能，需要过滤以避免重复处理导致冲突

Log: 过滤 dde-shell DDE 插件的触控屏长按处理

Influence:
1. 测试 DDE 桌面环境下的触控屏长按功能
2. 验证长按检测不再在 dde-shell 中触发重复操作
3. 测试包含多个参数的进程 cmdline 解析
4. 验证其他被加入黑名单的应用程序仍然正常工作
5. 测试 Chrome 浏览器的长按行为保持不变

PMS: BUG-358827
Change-Id: I80b21641e55c2d5c6d89c53a8595d3559f79fa22