### PR TITLE
fix: solve audio silent issue after upgrade

### DIFF
--- a/audio1/audio.go
+++ b/audio1/audio.go
@@ -178,7 +178,8 @@ type Audio struct {
 	mu            sync.Mutex
 	quit          chan struct{}
 
-	cards CardList
+	cards        CardList
+	cardFixGroup *CardFixGroup
 
 	isSaving    bool
 	saverLocker sync.Mutex
@@ -205,10 +206,11 @@ type Audio struct {
 
 func newAudio(service *dbusutil.Service) *Audio {
 	a := &Audio{
-		service:          service,
-		meters:           make(map[string]*Meter),
-		MaxUIVolume:      pulse.VolumeUIMax,
+		service:       service,
+		meters:        make(map[string]*Meter),
+		MaxUIVolume:   pulse.VolumeUIMax,
 		AudioServerState: AudioStateChanged,
+		cardFixGroup:  newCardFixGroup(),
 	}
 
 	var err error
@@ -991,13 +993,39 @@ func (a *Audio) setPort(cardId uint32, portName string, direction int, auto bool
 		logger.Warning(err)
 		return err
 	}
+
+	// 提前校验：sink 方向的端口必须有可用的 profiles
+	if direction == pulse.DirectionSink && port.Profiles == nil {
+		logger.Warningf("setPort: card %d port %s has nil profiles", cardId, portName)
+		return fmt.Errorf("card %d port %s has nil profiles", cardId, portName)
+	}
+
 	// 获取声卡配置中的profile
 	var profile string
 	if direction == pulse.DirectionSink {
 		profile = GetConfigKeeper().GetMode(card, portName)
 		if profile == "" {
 			profile = port.Profiles.SelectProfile()
+			if profile == "" {
+				logger.Warningf("setPort: no available profile for card %d port %s", cardId, portName)
+				return fmt.Errorf("no available profile for card %d port %s", cardId, portName)
+			}
 			GetConfigKeeper().SetMode(card, portName, profile)
+		} else {
+			// 情况一：兼容pipewire升级导致的声卡的配置文件的发生变化，导致配置找不到
+			// 情况二：另一种情况是pipewire初始化时，音频端口不是同时上报上来的，导致配置文件找不到，暂时先切换到已存在的profile
+			// 由于情况二的场景存在，不能在这里修改profile
+			if !card.Profiles.Exists(profile) {
+				oldProfile := profile
+				profile = port.Profiles.SelectProfile()
+				if profile == "" {
+					logger.Warningf("setPort: no available fallback profile for card %d port %s", cardId, portName)
+					return fmt.Errorf("no available fallback profile for card %d port %s", cardId, portName)
+				}
+				a.cardFixGroup.addFix(cardId, 30*time.Second, func() {
+					card.fixProfile(a, portName, oldProfile)
+				})
+			}
 		}
 	} else {
 		profile = card.ActiveProfile.Name

--- a/audio1/audio_events.go
+++ b/audio1/audio_events.go
@@ -335,6 +335,7 @@ func (a *Audio) handleCardRemoved(idx uint32) {
 		return
 	}
 	logger.Infof("card <%s:%d> removed", oldCard.core.Name, idx)
+	a.cardFixGroup.deleteFix(idx)
 	a.cards, _ = a.cards.delete(idx)
 	cards := a.cards.string()
 	a.setPropCards(cards)

--- a/audio1/card.go
+++ b/audio1/card.go
@@ -9,6 +9,8 @@ import (
 	"math"
 	"sort"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/linuxdeepin/go-lib/pulse"
 	"github.com/linuxdeepin/go-lib/strv"
@@ -424,4 +426,109 @@ func (card *Card) doDiff(oldCard *Card, autoPause bool) ChangeType {
 		logger.Infof("card <%s> changed:%v", card.Name, changed)
 	}
 	return changed
+}
+
+// CardFixGroup 管理需要延迟修复的声卡
+type CardFixGroup struct {
+	mu    sync.Mutex
+	fixes map[uint32]*CardFix
+}
+
+func newCardFixGroup() *CardFixGroup {
+	return &CardFixGroup{
+		fixes: make(map[uint32]*CardFix),
+	}
+}
+
+// addFix 添加一个待修复的声卡，延迟delay后执行fixFn（sync.Once保证只执行一次）
+func (cfg *CardFixGroup) addFix(cardId uint32, delay time.Duration, fixFn func()) {
+	if fixFn == nil {
+		logger.Warning("addFix: fixFn is nil, skip")
+		return
+	}
+
+	cfg.mu.Lock()
+	defer cfg.mu.Unlock()
+
+	// 已存在则跳过
+	if _, exists := cfg.fixes[cardId]; exists {
+		return
+	}
+
+	fix := &CardFix{
+		cardId: cardId,
+		fixFn:  fixFn,
+	}
+	fix.timer = time.AfterFunc(delay, func() {
+		fix.once.Do(func() {
+			fix.fixFn()
+		})
+	})
+	cfg.fixes[cardId] = fix
+}
+
+// deleteFix 删除并停止指定声卡的修复定时器
+func (cfg *CardFixGroup) deleteFix(cardId uint32) {
+	cfg.mu.Lock()
+	defer cfg.mu.Unlock()
+
+	if fix, exists := cfg.fixes[cardId]; exists {
+		if fix.timer != nil {
+			fix.timer.Stop()
+		}
+		delete(cfg.fixes, cardId)
+	}
+}
+
+// fixProfile 修复声卡配置中的profile：配置中保存的profile一直不在card的profile列表中，则更新配置
+func (c *Card) fixProfile(a *Audio, portName string, oldProfile string) {
+	if a == nil {
+		logger.Warning("fixProfile: audio is nil")
+		return
+	}
+
+	// 加锁保护 a.cards 的并发访问，避免与 handleCardRemoved 产生数据竞争
+	a.mu.Lock()
+	currentCard, err := a.cards.get(c.Id)
+	a.mu.Unlock()
+
+	if err != nil {
+		logger.Warningf("fixProfile: card %d not found", c.Id)
+		return
+	}
+
+	if currentCard == nil {
+		logger.Warningf("fixProfile: card %d is nil", c.Id)
+		return
+	}
+
+	// 配置已经被其他流程更新，无需修复
+	currentMode := GetConfigKeeper().GetMode(currentCard, portName)
+	if currentMode != oldProfile {
+		logger.Debugf("fixProfile: config already changed to %s, skip", currentMode)
+		return
+	}
+
+	// 配置中保存的profile又出现了，说明是临时性变化，跳过修复
+	if currentCard.Profiles.Exists(oldProfile) {
+		logger.Debugf("fixProfile: old profile %s exists again, skip", oldProfile)
+		return
+	}
+
+	if currentCard.ActiveProfile == nil {
+		logger.Warningf("fixProfile: card %d ActiveProfile is nil", c.Id)
+		return
+	}
+
+	logger.Infof("fixProfile: update config profile from %s to %s for port %s",
+		oldProfile, currentCard.ActiveProfile.Name, portName)
+	GetConfigKeeper().SetMode(currentCard, portName, currentCard.ActiveProfile.Name)
+}
+
+// CardFix 单个声卡的修复项，fixFn由调用方提供具体修复逻辑
+type CardFix struct {
+	cardId uint32
+	fixFn  func()
+	timer  *time.Timer
+	once   sync.Once
 }

--- a/audio1/profile.go
+++ b/audio1/profile.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2018 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -32,6 +32,18 @@ func newProfile(info pulse.ProfileInfo2) *Profile {
 }
 
 type ProfileList []*Profile
+
+func (l ProfileList) Exists(name string) bool {
+	if l == nil {
+		return false
+	}
+	for _, p := range l {
+		if p != nil && p.Name == name {
+			return true
+		}
+	}
+	return false
+}
 
 func newProfileList(src []pulse.ProfileInfo2) ProfileList {
 	var result ProfileList


### PR DESCRIPTION
Added a method to check profile existence in ProfileList and modified audio setup to handle missing profiles by selecting an existing one when the stored profile is not found. This addresses compatibility issues after pipewire upgrades where configuration files change or audio ports are not reported simultaneously during initialization, preventing audio from being silent.

Log: Fixed audio issue where sound was lost after system upgrade, ensuring proper profile selection.

Influence:
1. Test audio playback after a system upgrade to ensure no sound loss.
2. Verify that audio profiles are correctly selected when stored profiles are missing.
3. Check audio initialization scenarios where ports might not be reported simultaneously.
4. Test compatibility with different pipewire versions or upgrade paths.

fix: 解决升级后音频无声的问题

添加了一个方法来检查 ProfileList 中是否存在配置文件，并在音频设置中，
当存储的配置文件未找到时，选择一个已存在的配置文件而非失败。这解决了
pipewire 升级后配置文件变化或音频端口在初始化时未同时上报导致的兼容性问
题，从而防止音频无声。

Log: 修复了系统升级后音频丢失的问题，确保正确的配置文件选择。

Influence:
1. 测试系统升级后的音频播放，确保无声音丢失。
2. 验证当存储的配置文件缺失时，音频配置文件是否被正确选择。
3. 检查音频初始化场景，其中端口可能未同时上报。
4. 测试与不同 pipewire 版本或升级路径的兼容性。

PMS: BUG-358827
Change-Id: Iee93871193e5ca05edbde091d362c71a0c12a801

## Summary by Sourcery

Ensure audio continues working after configuration changes by validating stored audio profiles and falling back to an available profile when necessary.

Bug Fixes:
- Prevent audio from becoming silent after upgrades by selecting an existing audio profile when the stored profile no longer exists.

Enhancements:
- Add a helper on ProfileList to check for the existence of a given audio profile.
- Update the audio module copyright header years.