### PR TITLE
fix: disable gesture module on Treeland

### DIFF
--- a/bin/dde-session-daemon/main.go
+++ b/bin/dde-session-daemon/main.go
@@ -40,7 +40,7 @@ var logger = log.NewLogger("daemon/dde-session-daemon")
 var hasDDECookie bool
 var hasTreeLand bool
 
-var treeLandNotAllowModules = []string{"x-event-monitor", "keybinding", "screensaver", "display", "xsettings", "power"}
+var treeLandNotAllowModules = []string{"x-event-monitor", "keybinding", "gesture", "screensaver", "display", "xsettings", "power"}
 
 func isInShutdown() bool {
 	bus, err := dbus.SystemBus()


### PR DESCRIPTION
Add gesture to the Treeland module denylist so dde-session-daemon does not load the legacy gesture module under Treeland.

将 gesture 加入 Treeland 模块禁用列表,避免 dde-session-daemon 在 Treeland 环境加载旧的 gesture 模块。

Log: disable gesture module on Treeland
Pms: TASK-390447
Change-Id: I68f5a29ef9b3543523d1b15baa678b6ec432032f

## Summary by Sourcery

Bug Fixes:
- Add the gesture module to the Treeland module denylist so it is not loaded under Treeland.