### PR TITLE
fix: resolve Bluetooth connection notification issue

### DIFF
--- a/bluetooth1/utils_notify.go
+++ b/bluetooth1/utils_notify.go
@@ -143,14 +143,9 @@ func notifyPassiveConnect(dev *DeviceInfo, pinCode string) error {
 	cmd := notifyDdeDialogPath + "," + pinCode + "," + string(dev.Path) + "," + timestamp
 	hints := map[string]dbus.Variant{"x-deepin-action-pair": dbus.MakeVariant(cmd)}
 
-	// to make sure last notification has been closed
-	err := globalNotifications.CloseNotification(0, nid)
-	if err != nil {
-		logger.Warningf("close last notification failed,err:%v", err)
-	}
-
 	// notify connect request to dde-control-center
 	// set notify time out as -1, default time out is 5 seconds
+	var err error
 	nid, err = globalNotifications.Notify(0, Tr("dde-control-center"), nid, notifyIconBluetoothConnected,
 		summary, body, as, hints, 30*1000)
 	if err != nil {


### PR DESCRIPTION
The code in bluetooth1/utils_notify.go was modified to remove the call to close the previous notification before sending a new one. This change addresses potential errors that could occur when the notification system fails to close properly, which might have been causing Bluetooth connection attempts to fail. By simplifying the notification logic, we ensure more reliable user feedback during connection processes.

Log: Fixed notification handling to improve Bluetooth connection reliability

Influence:
1. Test Bluetooth connection attempts and verify that notifications appear correctly for pairing requests
2. Ensure that notifications do not show errors or fail to display during connection
3. Verify that the connection process completes successfully without being hindered by notification issues
4. Test with multiple rapid connection attempts to check for notification race conditions

修复: 解决蓝牙连接通知问题

蓝牙1/utils_notify.go 文件中的代码被修改，移除了在发送新通知前关闭先前通
知的调用。此更改解决了通知系统可能无法正常关闭时产生的错误，这可能导致蓝
牙连接尝试失败。通过简化通知逻辑，确保在连接过程中提供更可靠的用户反馈。

Log: 修复通知处理以提高蓝牙连接可靠性

Influence:
1. 测试蓝牙连接尝试，验证配对请求的通知是否正确显示
2. 确保通知在连接过程中不会显示错误或无法显示
3. 验证连接过程成功完成，不受通知问题影响
4. 使用多次快速连接尝试测试通知竞争条件

PMS: BUG-362449
Change-Id: Ib0996b0f840d7a6e3d17cee2ada285b4ed7b02f7