### PR TITLE
fix(audio): fix BluetoothAudioMode empty after bluez5 support

### DIFF
--- a/audio1/audio.go
+++ b/audio1/audio.go
@@ -1314,7 +1314,7 @@ func (a *Audio) refreshBluetoothOpts() {
 		return
 	}
 
-	if !isBluezAudio(card.Name) {
+	if !isBluezAudio(card.core.Name) {
 		return
 	}
 

--- a/audio1/card.go
+++ b/audio1/card.go
@@ -51,7 +51,7 @@ func getCardName(card *pulse.Card) (name string) {
 	propAlsaCardName := card.PropList["alsa.card_name"]
 	propDeviceApi := card.PropList["device.api"]
 	propDeviceDesc := card.PropList["device.description"]
-	if propDeviceApi == "bluez" && propDeviceDesc != "" {
+	if (propDeviceApi == "bluez5" || propDeviceApi == "bluez") && propDeviceDesc != "" {
 		name = propDeviceDesc
 	} else if propAlsaCardName != "" {
 		name = propAlsaCardName


### PR DESCRIPTION
1. Add bluez5 device API recognition in getCardName to support PipeWire/BlueZ5 bluetooth audio devices
2. Fix refreshBluetoothOpts using friendly card name instead of pulse raw name for isBluezAudio check, causing BluetoothAudioMode to remain empty after bluetooth profile switch

Log: fix BluetoothAudioMode empty caused by bluez5 card name change

fix(audio): 修复 bluez5 支持后 BluetoothAudioMode 为空的问题

1. getCardName 中增加 bluez5 设备 API 的识别，支持 PipeWire/BlueZ5 蓝牙音频设备
2. 修复 refreshBluetoothOpts 中 isBluezAudio 使用友好名称而非 pulse 原始名称判断， 导致蓝牙 profile 切换后 BluetoothAudioMode 属性未被赋值

Log: 修复 bluez5 声卡名称变更导致 BluetoothAudioMode 为空
PMS: BUG-364299

## Summary by Sourcery

Fix Bluetooth audio mode handling for BlueZ5/PipeWire devices by correctly identifying BlueZ5 cards and using the raw card name for BlueZ detection.

Bug Fixes:
- Recognize BlueZ5 device API when deriving card names so PipeWire/BlueZ5 Bluetooth audio devices are treated as Bluetooth cards.
- Ensure BluetoothAudioMode is updated after Bluetooth profile switches by checking BlueZ audio status using the underlying PulseAudio card name instead of the friendly name.