### PR TITLE
Revert "fix(display): adjust default manual color temperature"

### DIFF
--- a/misc/dsg-configs/org.deepin.Display.json
+++ b/misc/dsg-configs/org.deepin.Display.json
@@ -14,7 +14,7 @@
       "visibility": "private"
     },
     "defaultTemperatureManual": {
-      "value": 6500,
+      "value": 3500,
       "serial": 0,
       "flags": [],
       "name": "default temperature manual",


### PR DESCRIPTION
This reverts commit 8184e7d43a5979bcdc2545e49cbdf3dd3eb074fe.

## Summary by Sourcery

Bug Fixes:
- Restore the prior default manual color temperature behavior in the display configuration to undo an unintended change.