### PR TITLE
feat(account): make passwordEncryptionAlgorithm config writable

### DIFF
--- a/misc/dsg-configs/org.deepin.dde.daemon.account.json
+++ b/misc/dsg-configs/org.deepin.dde.daemon.account.json
@@ -29,7 +29,7 @@
       "name": "passwordEncryptionAlgorithm",
       "name[zh_CN]": "密码加密算法",
       "description": "Password encryption algorithm (sha512, sha256, yescrypt, sm3(default))",
-      "permissions": "readonly",
+      "permissions": "readwrite",
       "visibility": "private"
     }
   }


### PR DESCRIPTION
This commit changes the passwordEncryptionAlgorithm configuration permission from readonly to readwrite, allowing applications to modify the password encryption algorithm setting directly. Key changes include:
1. Updated permissions field from 'readonly' to 'readwrite' in account DSG config
2. Enabled write access for password encryption algorithm settings (sha512, sha256, yescrypt, sm3)

The change allows authorized applications to configure the password encryption algorithm, providing more flexible account management capabilities.

Log: 将密码加密算法配置项权限改为可读写
Influence:
1. 验证授权应用程序能否正常修改密码加密算法设置
2. 确认各加密算法（sha512/sha256/yescrypt/sm3）切换正常
3. 检查配置修改后用户创建/修改密码功能正常
4. 确认未授权应用无法修改该配置项

PMS: TASK-390539