### PR TITLE
fix: correct ddcci config structure

### DIFF
--- a/misc/dsg-configs/org.deepin.dde.daemon.appearance.json
+++ b/misc/dsg-configs/org.deepin.dde.daemon.appearance.json
@@ -5,8 +5,7 @@
         "irregularFontOverride": {
             "value": "{\"GB_SS_GB18030_Extended\":{\"AppendLang\":[\"zh-cn\",\"zh-sg\"]}}",
             "serial": 0,
-            "flags": [],
-            "global": true,
+            "flags": ["global"],
             "name": "IrregularFontOverride",
             "name[zh_CN]": "不规范字体参数override",
             "description": "不规范字体override",
@@ -19,7 +18,6 @@
             "flags": [
                 "global"
             ],
-            "global": true,
             "name": "scale without plymouth",
             "name[zh_CN]": "设置不包含plymouth的缩放",
             "description": "设置不包含plymouth的缩放",

--- a/misc/dsg-configs/org.deepin.dde.daemon.audio.json
+++ b/misc/dsg-configs/org.deepin.dde.daemon.audio.json
@@ -15,8 +15,7 @@
     "autoSwitchPort": {
       "value": true,
       "serial": 0,
-      "flags": [],
-      "global": true,
+      "flags": ["global"],
       "name": "AutoSwitchPort",
       "name[zh_CN]": "根据dde优先级管理自动切换端口",
       "description": "auto switch pulse port",
@@ -26,8 +25,7 @@
     "bluezModeFilterList": {
       "value": ["a2dp_source"],
       "serial": 0,
-      "flags": [],
-      "global": true,
+      "flags": ["global"],
       "name": "BluezModeFilterList",
       "name[zh_CN]": "需要过滤的蓝牙音频模式",
       "description": "bluetooth audio mode that requires filtering",
@@ -42,8 +40,7 @@
 	"unknown-output"
       ],
       "serial": 0,
-      "flags": [],
-      "global": true,
+      "flags": ["global"],
       "name": "PortFilterList",
       "name[zh_CN]": "需要过滤的端口",
       "description": "port filter list",
@@ -79,8 +76,7 @@
     "bluezModeDefault": {
       "value": "a2dp",
       "serial": 0,
-      "flags": [],
-      "global": true,
+      "flags": ["global"],
       "name": "BluezModeDefault",
       "name[zh_CN]": "蓝牙默认模式",
       "description": "bluetooth audio default mode",
@@ -90,8 +86,7 @@
     "monoEnabled":{
       "value": false,
       "serial": 0,
-      "flags": [],
-      "global": true,
+      "flags": ["global"],
       "name": "monoEnabled",
       "name[zh_CN]": "单声道开关",
       "description": "audio channel mono enabled set",
@@ -101,8 +96,7 @@
     "reduceNoiseEnabled":{
       "value": false,
       "serial": 0,
-      "flags": [],
-      "global": true,
+      "flags": ["global"],
       "name": "reduceNoiseEnabled",
       "name[zh_CN]": "噪音抑制开关",
       "description": "audio channel noise reduce enabled set",

--- a/misc/dsg-configs/org.deepin.dde.daemon.brightness.json
+++ b/misc/dsg-configs/org.deepin.dde.daemon.brightness.json
@@ -5,8 +5,7 @@
         "supportDdcci": {
             "value": false,
             "serial": 0,
-            "flags": [],
-            "global": true,
+            "flags": ["global"],
             "name": "SupportDdcci",
             "name[zh_CN]": "支持ddcci亮度调节",
             "description": "brightness ddcci support",
@@ -16,8 +15,7 @@
         "isBacklightHelperHold": {
             "value": false,
             "serial": 0,
-            "flags": [],
-            "global": true,
+            "flags": ["global"],
             "name": "IsBacklightHelperHold",
             "name[zh_CN]": "亮度调节是否驻留",
             "description": "config backlight-helper progress hold",

--- a/misc/dsg-configs/org.deepin.dde.daemon.dock.json
+++ b/misc/dsg-configs/org.deepin.dde.daemon.dock.json
@@ -5,8 +5,7 @@
     "hideRequestDockAndUndockByName": {
       "value": ["Deepin-Deepinid-Client"],
       "serial": 0,
-      "flags": [],
-      "global": true,
+      "flags": ["global"],
       "name": "HideRequestDockAndUndockByName",
       "name[zh_CN]": "通过名称隐藏驻留和移除驻留",
       "description": "hide request dock and undock by name",


### PR DESCRIPTION
1. Moved the "global" property into the "flags" array for both supportDdcci and isBacklightHelperHold settings
2. Removed the standalone "global": true key to comply with the correct DSG config schema
3. This ensures the configuration is properly parsed and applied globally as intended

Log: Fixed DDC/CI brightness configuration format to ensure proper global application

Influence:
1. Verify that DDC/CI brightness control is correctly recognized as a global setting in the system configuration
2. Test adjusting external monitor brightness to ensure DDC/CI support is enabled as expected
3. Check if the backlight helper process hold setting is correctly applied globally

fix: 更正ddcci配置结构

1. 将 supportDdcci 和 isBacklightHelperHold 设置项的 global 属性移至 flags 数组中
2. 移除了独立的 global: true 键，以符合正确的 DSG 配置架构规范
3. 这确保了配置能被正确解析，并按预期全局生效

Log: 修复DDC/CI亮度配置格式，确保其正确全局生效

Influence:
1. 验证 DDC/CI 亮度控制是否在系统配置中被正确识别为全局设置
2. 测试调节外接显示器亮度，确保 DDC/CI 支持按预期启用
3. 检查亮度调节驻留设置是否正确全局应用

PMS: BUG-363673
Change-Id: I8e0262761ba6ef16b15728877c644ef5b82c276b

## Summary by Sourcery

Bug Fixes:
- Fix misconfigured DDC/CI brightness options so supportDdcci and backlight helper hold behave as global settings as intended.