### PR TITLE
fix(display): migrate concat screen management to daemon

### DIFF
--- a/display1/exported_methods_auto.go
+++ b/display1/exported_methods_auto.go
@@ -125,6 +125,11 @@ func (v *Manager) GetExportedMethods() dbusutil.ExportedMethods {
 			InArgs: []string{"outputName"},
 		},
 		{
+			Name:   "SetConcatScreen",
+			Fn:     v.SetConcatScreen,
+			InArgs: []string{"enable"},
+		},
+		{
 			Name:    "SupportSetColorTemperature",
 			Fn:      v.SupportSetColorTemperature,
 			OutArgs: []string{"outArg0"},

--- a/display1/manager.go
+++ b/display1/manager.go
@@ -223,9 +223,10 @@ type Manager struct {
 	// dbusutil-gen: equal=objPathsEqual
 	Monitors []dbus.ObjectPath
 	// dbusutil-gen: equal=nil
-	CustomIdList []string
-	HasChanged   bool
-	DisplayMode  byte
+	CustomIdList        []string
+	HasChanged          bool
+	DisplayMode         byte
+	ConcatScreenEnabled bool
 	// dbusutil-gen: equal=nil
 	Brightness map[string]float64
 	// dbusutil-gen: equal=nil
@@ -1275,6 +1276,16 @@ func (m *Manager) applyConfig(setColorTemp bool, options applyOptions) (paths []
 		logger.Warning(err)
 	}
 
+	// 热插拔/配置重应用时自动退出跨屏拼接
+	m.PropsMu.RLock()
+	concatEnabled := m.ConcatScreenEnabled
+	m.PropsMu.RUnlock()
+	if concatEnabled {
+		if err := m.removeConcatScreen(); err != nil {
+			logger.Warning("applyConfig: failed to remove concat screen:", err)
+		}
+	}
+
 	return monitors.getPaths()
 }
 
@@ -2229,6 +2240,16 @@ func (m *Manager) switchMode(mode byte, name string) (err error) {
 		return nil
 	}
 
+	// 非扩展模式时自动清理拼接
+	m.PropsMu.RLock()
+	concatEnabled := m.ConcatScreenEnabled
+	m.PropsMu.RUnlock()
+	if mode != DisplayModeExtend && concatEnabled {
+		if err := m.removeConcatScreen(); err != nil {
+			logger.Warning("switchMode: failed to remove concat screen:", err)
+		}
+	}
+
 	monitorsId := monitors.getMonitorsId()
 	options := getSwitchModeOptions(mode, name)
 	err = m.switchModeAux(mode, oldMode, monitorsId, monitorMap, true, options)
@@ -2259,6 +2280,56 @@ func getSwitchModeOptions(mode byte, name string) applyOptions {
 func (m *Manager) setDisplayMode(mode byte) {
 	m.setPropDisplayMode(mode)
 	m.sysConfig.Config.DisplayMode = mode
+}
+
+func (m *Manager) applyConcatScreen() error {
+	if _useWayland {
+		return errors.New("concat screen not supported on wayland")
+	}
+
+	monitors := m.getConnectedMonitors()
+	if len(monitors) < 2 {
+		return errors.New("need at least 2 connected monitors for concat screen")
+	}
+
+	var outputNames []string
+	for _, mon := range monitors {
+		if mon.Enabled {
+			outputNames = append(outputNames, mon.Name)
+		}
+	}
+	if len(outputNames) < 2 {
+		return errors.New("need at least 2 enabled monitors for concat screen")
+	}
+
+	if err := m.mm.setConcatScreen(outputNames); err != nil {
+		return err
+	}
+
+	m.PropsMu.Lock()
+	m.ConcatScreenEnabled = true
+	m.PropsMu.Unlock()
+
+	_ = m.service.EmitPropertyChanged(m, "ConcatScreenEnabled", true)
+	return nil
+}
+
+func (m *Manager) removeConcatScreen() error {
+	if _useWayland {
+		return errors.New("concat screen not supported on wayland")
+	}
+
+	if err := m.mm.deleteConcatScreen(); err != nil {
+		logger.Warning("deleteConcatScreen failed:", err)
+		return err
+	}
+
+	m.PropsMu.Lock()
+	m.ConcatScreenEnabled = false
+	m.PropsMu.Unlock()
+
+	_ = m.service.EmitPropertyChanged(m, "ConcatScreenEnabled", false)
+	return nil
 }
 
 func (m *Manager) save() (err error) {
@@ -2392,6 +2463,16 @@ func (m *Manager) applyChanges() error {
 	} else {
 		m.futureConfig.setConfigs(monitorsId, configs)
 	}
+	// 分辨率/位置变更时自动退出跨屏拼接
+	m.PropsMu.RLock()
+	concatEnabled := m.ConcatScreenEnabled
+	m.PropsMu.RUnlock()
+	if concatEnabled {
+		if err := m.removeConcatScreen(); err != nil {
+			logger.Warning("applyChanges: failed to remove concat screen:", err)
+		}
+	}
+
 	return err
 }
 

--- a/display1/manager_ifc.go
+++ b/display1/manager_ifc.go
@@ -260,6 +260,29 @@ func (m *Manager) SetPrimary(outputName string) *dbus.Error {
 	return dbusutil.ToError(err)
 }
 
+func (m *Manager) SetConcatScreen(enable bool) *dbus.Error {
+	if _useWayland {
+		return dbusutil.ToError(errors.New("concat screen not supported on wayland"))
+	}
+
+	if enable {
+		m.PropsMu.RLock()
+		displayMode := m.DisplayMode
+		m.PropsMu.RUnlock()
+		if displayMode != DisplayModeExtend {
+			return dbusutil.ToError(errors.New("concat screen is only supported in extend mode"))
+		}
+		if err := m.applyConcatScreen(); err != nil {
+			return dbusutil.ToError(err)
+		}
+	} else {
+		if err := m.removeConcatScreen(); err != nil {
+			return dbusutil.ToError(err)
+		}
+	}
+	return nil
+}
+
 func (m *Manager) CanRotate() (bool, *dbus.Error) {
 	if os.Getenv("DEEPIN_DISPLAY_DISABLE_ROTATE") == "1" {
 		return false, nil

--- a/display1/xorg.go
+++ b/display1/xorg.go
@@ -21,6 +21,8 @@ import (
 	"github.com/linuxdeepin/go-x11-client/ext/xfixes"
 )
 
+const concatScreenName = "DDE-CONCAT-SCREEN"
+
 var _hasRandr1d2 bool // 是否 randr 版本大于等于 1.2
 
 var _useWayland bool
@@ -141,6 +143,8 @@ type monitorManager interface {
 	showCursor(show bool) error
 	HandleEvent(ev interface{})
 	HandleScreenChanged(e *randr.ScreenChangeNotifyEvent) (cfgTsChanged bool)
+	setConcatScreen(outputNames []string) error
+	deleteConcatScreen() error
 }
 
 type xMonitorManager struct {
@@ -1098,6 +1102,124 @@ func (mm *xMonitorManager) getScreenResourcesCurrent() (*randr.GetScreenResource
 	root := mm.xConn.GetDefaultScreen().Root
 	resources, err := randr.GetScreenResourcesCurrent(mm.xConn, root).Reply(mm.xConn)
 	return resources, err
+}
+
+func (mm *xMonitorManager) setConcatScreen(outputNames []string) error {
+	rootWindow := mm.xConn.GetDefaultScreen().Root
+
+	screenRes, err := mm.getScreenResources(mm.xConn)
+	if err != nil {
+		return fmt.Errorf("getScreenResources failed: %w", err)
+	}
+
+	// 单轮扫描所有 output，建立 name → output 映射，同时缓存 outputInfo 避免重复 X11 调用
+	type outputEntry struct {
+		id      randr.Output
+		outInfo *randr.GetOutputInfoReply
+	}
+	nameMap := make(map[string]outputEntry)
+	for _, output := range screenRes.Outputs {
+		outInfo, err := randr.GetOutputInfo(mm.xConn, output, screenRes.ConfigTimestamp).Reply(mm.xConn)
+		if err != nil || outInfo == nil {
+			continue
+		}
+
+		for _, name := range outputNames {
+			if outInfo.Name == name {
+				nameMap[name] = outputEntry{id: output, outInfo: outInfo}
+				break
+			}
+		}
+	}
+
+	var outputs []randr.Output
+	var outInfos []*randr.GetOutputInfoReply
+	for _, name := range outputNames {
+		if entry, ok := nameMap[name]; ok {
+			outputs = append(outputs, entry.id)
+			outInfos = append(outInfos, entry.outInfo)
+		}
+	}
+	if len(outputs) < 2 {
+		return errors.New("need at least 2 outputs for concat screen")
+	}
+
+	nameAtom, err := x.InternAtom(mm.xConn, true, concatScreenName).Reply(mm.xConn)
+	if err != nil {
+		return fmt.Errorf("InternAtom failed: %w", err)
+	}
+	if nameAtom.Atom == 0 {
+		nameAtom, err = x.InternAtom(mm.xConn, false, concatScreenName).Reply(mm.xConn)
+		if err != nil {
+			return fmt.Errorf("InternAtom create failed: %w", err)
+		}
+	}
+
+	var boundMinX, boundMinY int16 = math.MaxInt16, math.MaxInt16
+	var boundMaxX, boundMaxY int16
+	for _, outInfo := range outInfos {
+		if outInfo.Crtc == 0 {
+			continue
+		}
+		crtcInfo, err := randr.GetCrtcInfo(mm.xConn, outInfo.Crtc, screenRes.ConfigTimestamp).Reply(mm.xConn)
+		if err != nil || crtcInfo == nil {
+			continue
+		}
+		if crtcInfo.X < boundMinX {
+			boundMinX = crtcInfo.X
+		}
+		if crtcInfo.Y < boundMinY {
+			boundMinY = crtcInfo.Y
+		}
+		if right := crtcInfo.X + int16(crtcInfo.Width); right > boundMaxX {
+			boundMaxX = right
+		}
+		if bottom := crtcInfo.Y + int16(crtcInfo.Height); bottom > boundMaxY {
+			boundMaxY = bottom
+		}
+	}
+	if boundMinX > boundMaxX || boundMinY > boundMaxY {
+		return errors.New("no valid CRTC info for concat screen outputs")
+	}
+
+	monInfo := randr.MonitorInfo{
+		Name:      nameAtom.Atom,
+		Primary:   false,
+		Automatic: false,
+		NOutputs:  uint16(len(outputs)),
+		X:         boundMinX,
+		Y:         boundMinY,
+		Width:     uint16(boundMaxX - boundMinX),
+		Height:    uint16(boundMaxY - boundMinY),
+		Outputs:   outputs,
+	}
+
+	cookie := randr.SetMonitorChecked(mm.xConn, rootWindow, &monInfo)
+	if err := cookie.Check(mm.xConn); err != nil {
+		return fmt.Errorf("SetMonitor failed: %w", err)
+	}
+	logger.Debug("concat screen set with", len(outputs), "outputs")
+	return nil
+}
+
+func (mm *xMonitorManager) deleteConcatScreen() error {
+	rootWindow := mm.xConn.GetDefaultScreen().Root
+
+	nameAtom, err := x.InternAtom(mm.xConn, true, concatScreenName).Reply(mm.xConn)
+	if err != nil {
+		return fmt.Errorf("InternAtom failed: %w", err)
+	}
+	if nameAtom.Atom == 0 {
+		logger.Debug("concat screen not found, nothing to delete")
+		return nil
+	}
+
+	cookie := randr.DeleteMonitorChecked(mm.xConn, rootWindow, nameAtom.Atom)
+	if err := cookie.Check(mm.xConn); err != nil {
+		return fmt.Errorf("DeleteMonitor failed: %w", err)
+	}
+	logger.Debug("concat screen deleted")
+	return nil
 }
 
 func (mm *xMonitorManager) handleCrtcChanged(e *randr.CrtcChangeNotifyEvent) {


### PR DESCRIPTION
Add DBus method SetConcatScreen and manage RANDR Monitor via XCB/RANDR protocol directly. The daemon owns the concat screen lifecycle: auto cleanup on mode switch, hotplug, and layout changes.

新增 DBus 接口 SetConcatScreen，通过 XCB/RANDR 协议直接管理拼接。daemon 接管拼接生命周期：模式切换时自动清理，热插拔/布局变更时退出。

Log: 将跨屏拼接逻辑迁移至dde-daemon
PMS: BUG-363737
Influence: 1.开启跨屏拼接后，使用系统快捷键切换到其他多屏模式，能自动退出拼接；
	    2.控制中心切换多屏模式，开/关跨屏拼接，状态正确；
	    3.热插拔显示器、更改显示器坐标、自动退出拼接