### PR TITLE
fix(audio): honor manual output selection

### DIFF
--- a/audio1/audio.go
+++ b/audio1/audio.go
@@ -190,6 +190,8 @@ type Audio struct {
 	noRestartPulseAudio bool
 	// 自动端口切换
 	enableAutoSwitchPort bool
+	pendingManualPortMu  sync.Mutex
+	pendingManualPort    *pendingManualPortSwitch
 
 	// 控制中心-声音-设备管理 是否显示
 	controlCenterDeviceManager dconfig.Bool
@@ -204,13 +206,19 @@ type Audio struct {
 	}
 }
 
+type pendingManualPortSwitch struct {
+	cardId    uint32
+	portName  string
+	direction int
+}
+
 func newAudio(service *dbusutil.Service) *Audio {
 	a := &Audio{
-		service:       service,
-		meters:        make(map[string]*Meter),
-		MaxUIVolume:   pulse.VolumeUIMax,
+		service:          service,
+		meters:           make(map[string]*Meter),
+		MaxUIVolume:      pulse.VolumeUIMax,
 		AudioServerState: AudioStateChanged,
-		cardFixGroup:  newCardFixGroup(),
+		cardFixGroup:     newCardFixGroup(),
 	}
 
 	var err error
@@ -1032,15 +1040,81 @@ func (a *Audio) setPort(cardId uint32, portName string, direction int, auto bool
 	}
 
 	if card.ActiveProfile.Name == profile {
+		if !auto {
+			return a.setManualPortDirectly(cardId, portName, direction)
+		}
 		return a.setPortDirectly(cardId, portName, direction)
 	} else {
 		// 暂不设置端口，先切换配置文件
-		// 等待事件完成后，再自动设置端口
+		// 等待事件完成后，自动切换通过 autoSwitchPort 继续；手动切换通过 pendingManualPort 继续
 		logger.Info("modify card profile:", card.core.Name, "from", card.ActiveProfile.Name, "to", profile)
+		if !auto {
+			a.setPendingManualPort(cardId, portName, direction)
+		}
 		card.core.SetProfile(profile)
 	}
 
 	return nil
+}
+
+func (a *Audio) setPendingManualPort(cardId uint32, portName string, direction int) {
+	logger.Debugf("setPendingManualPort: cardId=%d, portName=%s, direction=%d", cardId, portName, direction)
+
+	a.pendingManualPortMu.Lock()
+	defer a.pendingManualPortMu.Unlock()
+
+	a.pendingManualPort = &pendingManualPortSwitch{
+		cardId:    cardId,
+		portName:  portName,
+		direction: direction,
+	}
+}
+
+func (a *Audio) setManualPortDirectly(cardId uint32, portName string, direction int) error {
+	a.clearPendingManualPort(cardId, direction)
+	return a.setPortDirectly(cardId, portName, direction)
+}
+
+func (a *Audio) clearPendingManualPort(cardId uint32, direction int) {
+	logger.Debugf("clearPendingManualPort: cardId=%d, direction=%d", cardId, direction)
+
+	a.pendingManualPortMu.Lock()
+	defer a.pendingManualPortMu.Unlock()
+
+	if a.pendingManualPort != nil &&
+		a.pendingManualPort.cardId == cardId &&
+		a.pendingManualPort.direction == direction {
+		a.pendingManualPort = nil
+	}
+}
+
+func (a *Audio) completePendingManualPort(cardId uint32) (handled bool, applied bool) {
+	logger.Debugf("completePendingManualPort: cardId=%d", cardId)
+
+	a.pendingManualPortMu.Lock()
+	if a.pendingManualPort == nil || a.pendingManualPort.cardId != cardId {
+		a.pendingManualPortMu.Unlock()
+		return false, false
+	}
+	pending := *a.pendingManualPort
+	a.pendingManualPortMu.Unlock()
+
+	err := a.setPortDirectly(pending.cardId, pending.portName, pending.direction)
+	if err != nil {
+		logger.Warningf("failed to complete pending manual port: cardId=%d, portName=%s, direction=%d, err=%v",
+			pending.cardId, pending.portName, pending.direction, err)
+		return true, false
+	}
+
+	a.pendingManualPortMu.Lock()
+	if a.pendingManualPort != nil &&
+		a.pendingManualPort.cardId == pending.cardId &&
+		a.pendingManualPort.portName == pending.portName &&
+		a.pendingManualPort.direction == pending.direction {
+		a.pendingManualPort = nil
+	}
+	a.pendingManualPortMu.Unlock()
+	return true, true
 }
 
 // setPortDirectly 直接设置端口，无需切换配置文件

--- a/audio1/audio_events.go
+++ b/audio1/audio_events.go
@@ -274,6 +274,18 @@ func (a *Audio) autoSwitchPort() {
 	a.autoSwitchInputPort()
 }
 
+func (a *Audio) switchPortAfterCardReady(cardId uint32) {
+	handledPending, applied := a.completePendingManualPort(cardId)
+	if !handledPending {
+		a.autoSwitchPort()
+		return
+	}
+	if !applied {
+		logger.Warningf("pending manual switch for cardId=%d was not applied, skip auto switch", cardId)
+		return
+	}
+}
+
 func (a *Audio) handleCardEvent(eventType int, idx uint32) {
 	var shouldAutoSwitch = false
 	switch eventType {
@@ -298,7 +310,7 @@ func (a *Audio) handleCardEvent(eventType int, idx uint32) {
 		GetPriorityManager().refreshPorts(a.cards)
 		GetPriorityManager().Save()
 		if a.checkCardIsReady(idx) {
-			a.autoSwitchPort()
+			a.switchPortAfterCardReady(idx)
 		}
 	}
 }
@@ -425,7 +437,7 @@ func (a *Audio) handleSinkAdded(idx uint32) {
 	} else if a.checkCardIsReady(sink.Card) {
 		// 只有新增sink或端口列表/活跃端口变化时才触发自动切换
 		if isNewSink || portChanged {
-			a.autoSwitchPort()
+			a.switchPortAfterCardReady(sink.Card)
 		}
 	}
 }
@@ -453,7 +465,7 @@ func (a *Audio) handleSinkRemoved(idx uint32) {
 		return
 	}
 	if isPhy && a.checkCardIsReady(cardId) {
-		a.autoSwitchPort()
+		a.switchPortAfterCardReady(cardId)
 	}
 }
 
@@ -473,7 +485,7 @@ func (a *Audio) handleSinkChanged(idx uint32) {
 	// cardchange事件也会触发，但是处理不了，因为这时sink可能还没更新，无可用端口
 	// 只有当端口列表或活跃端口发生变化时，才触发自动切换
 	if portChanged && isPhysicalDevice(sink.Name) && a.checkCardIsReady(sink.Card) {
-		a.autoSwitchPort()
+		a.switchPortAfterCardReady(sink.Card)
 	}
 
 	if a.defaultSink != nil && a.defaultSink.index == idx && isBluezAudio(sink.Name) {
@@ -529,7 +541,7 @@ func (a *Audio) handleSourceAdded(idx uint32) {
 	} else if a.checkCardIsReady(source.Card) {
 		// 只有新增source或端口列表/活跃端口变化时才触发自动切换
 		if isNewSource || portChanged {
-			a.autoSwitchPort()
+			a.switchPortAfterCardReady(source.Card)
 		}
 	}
 
@@ -557,7 +569,7 @@ func (a *Audio) handleSourceRemoved(idx uint32) {
 		a.defaultSource = nil
 	}
 	if isPhy && a.checkCardIsReady(cardId) {
-		a.autoSwitchPort()
+		a.switchPortAfterCardReady(cardId)
 	}
 }
 
@@ -578,7 +590,7 @@ func (a *Audio) handleSourceChanged(idx uint32) {
 	// cardchange事件也会触发，但是处理不了，因为这时source可能还没更新，无可用端口
 	// 只有当端口列表或活跃端口发生变化时，才触发自动切换
 	if portChanged && isPhysicalDevice(source.Name) && a.checkCardIsReady(source.Card) {
-		a.autoSwitchPort()
+		a.switchPortAfterCardReady(source.Card)
 	}
 }
 


### PR DESCRIPTION
1. Track pending manual port switches when a profile change is required.
2. Complete manual output device selection after the card becomes ready.
3. Avoid losing manual port selection when automatic port switching is disabled.

Log: Fix manual output device selection not taking effect when automatic port switching is disabled.

fix(audio): 修复手动输出设备选择失效

1. 在需要切换配置文件时记录待处理的手动端口切换。
2. 在声卡就绪后继续完成手动输出设备选择。
3. 避免关闭自动端口切换后丢失手动端口选择。

Log: 修复关闭自动端口切换后设置输出设备不生效的问题。

## Summary by Sourcery

Ensure manual audio output selection is correctly applied even when profile changes are required and automatic port switching is disabled.

Bug Fixes:
- Preserve and apply pending manual port switches across profile changes so user-selected outputs take effect once the card is ready.
- Prevent loss of manual port selections when automatic port switching is turned off by prioritizing completion of pending manual switches before auto switching.