### PR TITLE
fix: skip screen off if already in dpms off state

### DIFF
--- a/common/fileutil/fileutil.go
+++ b/common/fileutil/fileutil.go
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package fileutil
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// SafeReadFile 安全读取文件，拒绝符号链接
+func SafeReadFile(filename string) ([]byte, error) {
+	fi, err := os.Lstat(filename)
+	if err != nil {
+		return nil, err
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("file %q is a symlink, refusing to follow", filename)
+	}
+	if !fi.Mode().IsRegular() {
+		return nil, fmt.Errorf("file %q is not a regular file", filename)
+	}
+
+	f, err := os.OpenFile(filename, unix.O_RDONLY|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return io.ReadAll(f)
+}
+
+// SafeWriteFile 安全写入文件，拒绝符号链接
+func SafeWriteFile(filename string, content []byte, perm os.FileMode) error {
+	fi, err := os.Lstat(filename)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if err == nil {
+		// 文件已存在，必须是普通文件
+		if fi.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("file %q is a symlink, refusing to write", filename)
+		}
+		if !fi.Mode().IsRegular() {
+			return fmt.Errorf("file %q is not a regular file", filename)
+		}
+		f, err := os.OpenFile(filename, unix.O_WRONLY|unix.O_TRUNC|unix.O_NOFOLLOW, perm)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		_, err = f.Write(content)
+		return err
+	}
+	// 文件不存在，安全创建
+	f, err := os.OpenFile(filename, unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL, perm)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.Write(content)
+	return err
+}

--- a/keybinding1/utils.go
+++ b/keybinding1/utils.go
@@ -20,6 +20,7 @@ import (
 	dbus "github.com/godbus/dbus/v5"
 	"github.com/linuxdeepin/dde-daemon/keybinding1/constants"
 	"github.com/linuxdeepin/dde-daemon/keybinding1/util"
+	"github.com/linuxdeepin/dde-daemon/common/fileutil"
 	wm "github.com/linuxdeepin/go-dbus-factory/session/com.deepin.wm"
 
 	gio "github.com/linuxdeepin/go-gir/gio-2.0"
@@ -31,10 +32,10 @@ import (
 const (
 	suspendStateUnknown = iota + 1
 	suspendStateLidOpen
+	suspendStateLidClose
 	suspendStateFinish
 	suspendStateWakeup
 	suspendStatePrepare
-	suspendStateLidClose
 	suspendStateButtonClick
 )
 
@@ -287,6 +288,9 @@ func (m *Manager) systemShutdown() {
 }
 
 func (m *Manager) systemTurnOffScreen() {
+	if isDpmsOff() {
+		return
+	}
 	logger.Info("DPMS Off")
 	var err error
 	var useWayland bool
@@ -327,7 +331,16 @@ func (m *Manager) systemTurnOffScreen() {
 		m.setWmBlackScreenActive(false)
 	}
 	undoPrepareSuspend()
-	os.WriteFile("/tmp/dpms-state", []byte("1"), 0644)
+	fileutil.SafeWriteFile("/tmp/dpms-state", []byte("1"), 0600)
+}
+
+func isDpmsOff() bool {
+	content, err := fileutil.SafeReadFile("/tmp/dpms-state")
+	if err != nil {
+		logger.Debug("read dpms state error:", err)
+		return false
+	}
+	return bytes.Equal(bytes.TrimSpace(content), []byte("1"))
 }
 
 func (m *Manager) systemLogout() {

--- a/session/power1/power_save_plan.go
+++ b/session/power1/power_save_plan.go
@@ -13,6 +13,8 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+
+	"github.com/linuxdeepin/dde-daemon/common/fileutil"
 	"time"
 
 	"github.com/godbus/dbus/v5"
@@ -1059,15 +1061,15 @@ func (psp *powerSavePlan) startIdleTasksLocked() {
 }
 
 func (ps *powerSavePlan) restoreDpmsStateFile() {
-	v, err := os.ReadFile("/tmp/dpms-state")
+	v, err := fileutil.SafeReadFile("/tmp/dpms-state")
 	if err != nil {
 		return
 	}
 
 	if string(v) == "1" {
-		err = os.WriteFile("/tmp/dpms-state", []byte("0"), 0644)
+		err = fileutil.SafeWriteFile("/tmp/dpms-state", []byte("0"), 0600)
 		if err != nil {
-			logger.Warning("WriteFile /tmp/dpms-state:", err)
+			logger.Warning("write dpms state:", err)
 		}
 	}
 }

--- a/session/power1/utils.go
+++ b/session/power1/utils.go
@@ -6,13 +6,13 @@ package power
 
 import (
 	"math"
-	"os"
 	"os/exec"
 	"strings"
 	"time"
 
 	dbus "github.com/godbus/dbus/v5"
 	"github.com/linuxdeepin/dde-api/soundutils"
+	"github.com/linuxdeepin/dde-daemon/common/fileutil"
 	. "github.com/linuxdeepin/go-lib/gettext"
 	"github.com/linuxdeepin/go-lib/pulse"
 	"github.com/linuxdeepin/go-x11-client/ext/dpms"
@@ -210,7 +210,7 @@ func (m *Manager) setDPMSModeOff() {
 	} else {
 		callSetScreenState(true)
 	}
-	os.WriteFile("/tmp/dpms-state", []byte("1"), 0644)
+	fileutil.SafeWriteFile("/tmp/dpms-state", []byte("1"), 0600)
 }
 
 const (


### PR DESCRIPTION
1. Add a check at the beginning of the systemTurnOffScreen function to skip processing if the display is already in a DPMS off state
2. Introduce a new isDpmsOff helper function to read the state from / tmp/dpms-state and determine if the screen is already off
3. Adjust the ordering of suspend state constants for logical consistency, moving suspendStateLidClose before suspendStateFinish

Log: Optimized power button logic to avoid redundant screen-off commands

Influence:
1. Test pressing the power button when the screen is already off via DPMS; verify the screen state does not change and no redundant actions occur
2. Test pressing the power button when the screen is on; verify the screen turns off correctly
3. Test the behavior after waking the system from suspend (lid open); ensure the screen state is correctly reported and handled
4. Verify that the /tmp/dpms-state file is created and updated correctly on screen state changes
5. Test the interaction between the power button and other screen off mechanisms (like idle timeout) to ensure no conflicts

fix: 如果屏幕已处于DPMS关闭状态则跳过屏幕关闭处理

1. 在systemTurnOffScreen函数开头添加检查，如果显示器已处于DPMS off状态则 跳过处理
2. 新增isDpmsOff辅助函数，通过读取/tmp/dpms-state文件来判断屏幕是否已 关闭
3. 调整挂起状态常量的顺序以保持逻辑一致性，将suspendStateLidClose移到 suspendStateFinish之前

Log: 优化电源键逻辑，避免重复发送屏幕关闭命令

Influence:
1. 测试在屏幕已通过DPMS关闭时按下电源键，验证屏幕状态不会改变且没有多余 操作
2. 测试在屏幕开启时按下电源键，验证屏幕能正确关闭
3. 测试从挂起状态唤醒（开盖）后的行为，确保屏幕状态能正确报告和处理
4. 验证/tmp/dpms-state文件在屏幕状态变化时能被正确创建和更新
5. 测试电源键与其他屏幕关闭机制（如空闲超时）的交互，确保没有冲突

PMS: BUG-364835

## Summary by Sourcery

Skip redundant DPMS screen-off operations when the display is already off and align suspend state constants ordering

Bug Fixes:
- Prevent duplicate DPMS off commands by checking the stored DPMS state before turning off the screen

Enhancements:
- Reorder suspend state constants to reflect a more logical suspend lifecycle sequence