### PR TITLE
chore: update changelog to 6.1.96

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+dde-daemon (6.1.96) unstable; urgency=medium
+
+  * fix(audio): honor manual output selection
+  * fix: optimize power key screen off logic and secure file operations
+  * fix: fix TOCTOU race in wallpaper save function
+  * chore: remove unused network connection sync interfaces
+
+ -- zhangkun <zhangkun2@uniontech.com>  Wed, 17 Jun 2026 16:28:16 +0800
+
 dde-daemon (6.1.95) unstable; urgency=medium
 
   * fix(display): migrate concat screen management to daemon


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 6.1.96

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 6.1.96
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump Debian changelog entry to version 6.1.96 targeting master.