### PR TITLE
fix: adjust dpms-state file permissions

### DIFF
--- a/keybinding1/utils.go
+++ b/keybinding1/utils.go
@@ -331,7 +331,7 @@ func (m *Manager) systemTurnOffScreen() {
 		m.setWmBlackScreenActive(false)
 	}
 	undoPrepareSuspend()
-	fileutil.SafeWriteFile("/tmp/dpms-state", []byte("1"), 0600)
+	fileutil.SafeWriteFile("/tmp/dpms-state", []byte("1"), 0644)
 }
 
 func isDpmsOff() bool {

--- a/session/power1/power_save_plan.go
+++ b/session/power1/power_save_plan.go
@@ -1068,7 +1068,7 @@ func (ps *powerSavePlan) restoreDpmsStateFile() {
 	}
 
 	if string(v) == "1" {
-		err = fileutil.SafeWriteFile("/tmp/dpms-state", []byte("0"), 0600)
+		err = fileutil.SafeWriteFile("/tmp/dpms-state", []byte("0"), 0644)
 		if err != nil {
 			logger.Warning("write dpms state:", err)
 		}

--- a/session/power1/utils.go
+++ b/session/power1/utils.go
@@ -210,7 +210,7 @@ func (m *Manager) setDPMSModeOff() {
 	} else {
 		callSetScreenState(true)
 	}
-	fileutil.SafeWriteFile("/tmp/dpms-state", []byte("1"), 0600)
+	fileutil.SafeWriteFile("/tmp/dpms-state", []byte("1"), 0644)
 }
 
 const (


### PR DESCRIPTION
Change file permissions for `/tmp/dpms-state` from 0600 to 0644 in three locations
1. keybinding1/utils.go: systemTurnOffScreen function
2. session/power1/power_save_plan.go: restoreDpmsStateFile function
3. session/power1/utils.go: setDPMSModeOff function This change is necessary because dde-lock also reads/writes this file, and the restrictive 0600 permissions caused permission errors leading to lock screen failure

Influence:
1. Test lock screen functionality (dde-lock) to verify it can read/write dpms-state file without errors
2. Verify power management functions (DPMS mode and state restoration) work correctly after permission change
3. Test screen turn off/on sequences during power save operations
4. Check file permissions are correctly set to 0644 and verify proper read/write access
5. Test multiple users or processes accessing the dpms-state file simultaneously
6. Verify no other components are affected by the permission change on / tmp/dpms-state

修复: 调整 dpms-state 文件权限

在三个位置将 `/tmp/dpms-state` 文件的权限从 0600 改为 0644
1. keybinding1/utils.go: systemTurnOffScreen 函数
2. session/power1/power_save_plan.go: restoreDpmsStateFile 函数
3. session/power1/utils.go: setDPMSModeOff 函数 此更改是必要的，因为 dde-lock 也会读写此文件，而限制性的 0600 权限导致权
限错误，造成锁屏失败

Influence:
1. 测试锁屏功能 (dde-lock) 以确保其能够无错误地读写 dpms-state 文件
2. 验证权限更改后电源管理功能（DPMS 模式和状态恢复）正常工作
3. 测试省电计划期间的屏幕开关序列
4. 检查文件权限是否正确设置为 0644 并验证适当的读写访问权限
5. 测试多个用户或进程同时访问 dpms-state 文件
6. 验证权限更改不会影响其他依赖于 /tmp/dpms-state 的组件

PMS: BUG-364835