### PR TITLE
chore: update changelog to 6.1.98

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-daemon (6.1.98) unstable; urgency=medium
+
+  * fix: adjust dpms-state file permissions
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 18 Jun 2026 13:29:03 +0800
+
 dde-daemon (6.1.97) unstable; urgency=medium
 
   * feat: optimize system application recognition and add power save


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 6.1.98

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 6.1.98
- 目标分支: master

## Summary by Sourcery

Chores:
- Refresh debian/changelog entries to reflect version 6.1.98 targeting master.