### PR TITLE
fix(keybinding): remove redundant app reload after cmd exec

### DIFF
--- a/keybinding1/manager.go
+++ b/keybinding1/manager.go
@@ -1348,10 +1348,6 @@ func (m *Manager) execCmd(cmd string, viaStartdde bool) error {
 	}
 
 	appManager := newAppmanager.NewManager(m.sessionSigLoop.Conn())
-	err = appManager.ReloadApplications(0)
-	if err != nil {
-		logger.Warning("reload applications error: ", err)
-	}
 	desktopFileName, err = appManager.AddUserApplication(0, desktopInfoMap, desktopFileName)
 	if err != nil {
 		logger.Warning("adding user application error: ", err)


### PR DESCRIPTION
1. Remove unnecessary ReloadApplications call in execCmd
2. Avoid redundant application reload on every command execution
3. Clean up dead code and potential performance overhead

Log: Remove redundant application reload after command execution

fix(keybinding): 移除命令执行后重复的应用重载

1. 移除 execCmd 中不必要的 ReloadApplications 调用
2. 避免每次命令执行时重复重载应用
3. 清理无效代码，减少不必要的性能开销

Log: 移除命令执行后重复的应用重载
PMS: BUG-364107

## Summary by Sourcery

Remove redundant application reload after executing commands in the keybinding manager to reduce unnecessary work and potential performance overhead.

Bug Fixes:
- Avoid reloading applications on every command execution when adding user applications through the keybinding manager.

Enhancements:
- Simplify command execution flow in the keybinding manager by removing dead or unnecessary code paths related to application reloads.