### PR TITLE
fix(display): add switch for auto change scale factor

### DIFF
--- a/display1/manager.go
+++ b/display1/manager.go
@@ -88,6 +88,7 @@ const (
 	DSettingsKeyColorTemperatureManual   = "colorTemperatureManual"
 	DSettingsKeyRotateScreenTimeDelay    = "rotateScreenTimeDelay"
 	DSettingsKeyCustomDisplayMode        = "customDisplayMode"
+	DSettingsAutoChangeScaleEnabled      = "autoChangeScaleEnabled"
 
 	// 亮度曲线配置
 	DSettingsKeyBacklightCurveType     = "backlight-curve-type"
@@ -296,6 +297,8 @@ type Manager struct {
 	backlightCurveType string
 	backlightMinValue  int32
 	backlightMidValue  int32
+
+	dsAutoChangeScaleEnabled bool
 
 	powerSaving            bool
 	systemAdjustingTimer   *time.Timer
@@ -548,6 +551,8 @@ func (m *Manager) initDConfig(sysBus *dbus.Conn) {
 			m.getBacklightCurveType()
 		case DSettingsKeyMaxBrightnessUnlimited:
 			m.getMaxBrightnessUnlimited()
+		case DSettingsAutoChangeScaleEnabled:
+			m.getAutoChangeScaleEnabled()
 		case DSettingsKeyTransitionEnabled,
 			DSettingsKeyTransitionDuration,
 			DSettingsKeyTransitionStepPercent,
@@ -606,6 +611,7 @@ func (m *Manager) loadInitialConfigValues() {
 	m.getCustomBrightnessCurves()
 	m.getDefaultBrightnessCurve()
 	m.getMaxBrightnessUnlimited()
+	m.getAutoChangeScaleEnabled()
 	// 初始化FLM曲线
 	brightness.InitFlmCurves(m.backlightMinValue, m.backlightMidValue)
 }
@@ -826,6 +832,21 @@ func (m *Manager) getMaxBrightnessUnlimited() {
 		return
 	}
 	brightness.SetMaxBrightnessUnlimited(enabled)
+}
+
+func (m *Manager) getAutoChangeScaleEnabled() {
+	v, err := m.displayConfigMgr.Value(0, DSettingsAutoChangeScaleEnabled)
+	if err != nil {
+		logger.Warning(err)
+		return
+	}
+	enabled, ok := v.Value().(bool)
+	if !ok {
+		logger.Warning("autoChangeScaleEnabled configuration is not a bool")
+		return
+	}
+	m.dsAutoChangeScaleEnabled = enabled
+	logger.Info("auto change scale enabled:", m.dsAutoChangeScaleEnabled)
 }
 
 // 初始化系统级 display 服务的信号处理
@@ -3617,7 +3638,7 @@ func calcMaxScaleFactor(width, height uint16) float64 {
 
 func (m *Manager) tryToChangeScaleFactor(monitorWidth, monitorHeight uint16) {
 	// x 下拔掉显示器会触发更新操作，高宽均为0
-	if monitorWidth == 0 || monitorHeight == 0 {
+	if monitorWidth == 0 || monitorHeight == 0 || !m.dsAutoChangeScaleEnabled {
 		return
 	}
 

--- a/misc/dsg-configs/org.deepin.Display.json
+++ b/misc/dsg-configs/org.deepin.Display.json
@@ -178,6 +178,16 @@
       "permissions": "readwrite",
       "visibility": "public"
     },
+    "autoChangeScaleEnabled": {
+      "value": true,
+      "serial": 0,
+      "flags": ["global"],
+      "name": "autoChangeScaleEnabled",
+      "description": "auto change scale enabled",
+      "description[zh_CN]": "是否启用自动缩放",
+      "permissions": "readwrite",
+      "visibility": "private"
+    },
     "transition-enabled": {
       "value": false,
       "serial": 0,


### PR DESCRIPTION
1. Add DConfig key 'autoChangeScaleEnabled' to control auto scaling
2. Add getAutoChangeScaleEnabled() to read and apply the config value
3. Gate tryToChangeScaleFactor() with the new enabled flag
4. Update org.deepin.Display.json schema with the new config entry

Log: Add a DConfig switch to enable/disable automatic scale factor change on monitor plug

fix(display): 新增自动缩放开关联动配置项

1. 新增 DConfig 配置项 'autoChangeScaleEnabled' 控制是否启用自动缩放
2. 新增 getAutoChangeScaleEnabled() 方法读取配置值并应用
3. tryToChangeScaleFactor() 增加开关判断，关闭时跳过自动缩放
4. 更新 org.deepin.Display.json 配置 schema

Log: 新增 DConfig 开关，支持禁用显示器热插拔时的自动缩放功能
PMS: TASK-391423