### PR TITLE
feat: add services and desktop entry to whitelist

### DIFF
--- a/misc/dsg-configs/org.deepin.dde.daemon.power.json
+++ b/misc/dsg-configs/org.deepin.dde.daemon.power.json
@@ -737,7 +737,8 @@
                 "deepin-offline-update-tool.desktop",
                 "com.uos.drive.desktop",
                 "com.sogou.ime.ng.fcitx5.uos.configurer.desktop",
-                "xdg-desktop-portal-gtk.desktop"
+                "xdg-desktop-portal-gtk.desktop",
+                "uos-activator.desktop"
             ],
             "serial": 0,
             "flags": [
@@ -822,7 +823,10 @@
                 "ssh.service",
                 "udcp-guard.service",
                 "com.home.appstore.daemon.service",
-                "serial-getty@ttyAMA0.service"
+                "serial-getty@ttyAMA0.service",
+                "winbind.service",
+                "tpm2-abrmd.service",
+                "fprintd.service"
             ],
             "serial": 0,
             "flags": [


### PR DESCRIPTION
Add "uos-activator.desktop" to desktop entry whitelist and "winbind.service", "tpm2-abrmd.service", "fprintd.service" to service whitelist in the power daemon configuration.

Log: Power daemon whitelist updated with new services

Influence:
1. Verify that the power daemon recognizes and respects the whitelisted desktop entry
2. Test that new services do not interfere with power management functionality
3. Confirm no regressions in whitelist behavior for previously existing entries

feat: 将服务和桌面条目加入白名单

在电源守护进程配置的白名单中添加 "uos-activator.desktop" 桌面条目以及
"winbind.service"、"tpm2-abrmd.service" 和 "fprintd.service" 服务。

Log: 电源守护进程白名单更新，新增服务

Influence:
1. 验证电源守护进程能正确识别白名单中的桌面条目
2. 测试新增的服务不影响电源管理功能
3. 确认已有的白名单条目行为无回归

PMS: BUG-367187
Change-Id: I2237a50a12af872f6896ce232f35d24f7a65aa4f

## Summary by Sourcery

Update power daemon configuration whitelists to include additional services and a desktop entry.

New Features:
- Allow the power daemon to recognize the uos-activator desktop entry via whitelist configuration.
- Permit winbind, tpm2-abrmd, and fprintd services to run without being blocked by power daemon policies.