### PR TITLE
chore: update changelog to 6.1.99

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+dde-daemon (6.1.99) unstable; urgency=medium
+
+  * feat: add services and desktop entry to whitelist
+  * fix(display): add switch for auto change scale factor
+  * fix(keybinding): remove redundant app reload after cmd exec
+  * chore: Sync by
+    https://github.com/linuxdeepin/.github/commit/88706fa723e3771211cb07
+    81d3d97fd4a6cd2a68
+
+ -- zhangkun <zhangkun2@uniontech.com>  Wed, 24 Jun 2026 15:35:29 +0800
+
 dde-daemon (6.1.98) unstable; urgency=medium
 
   * fix: adjust dpms-state file permissions


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 6.1.99

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 6.1.99
- 目标分支: master

## Summary by Sourcery

Chores:
- Revise debian/changelog entries to reflect version 6.1.99 targeting master.