### PR TITLE
fix(display): keep max scale independent of rotation

### DIFF
--- a/display1/manager.go
+++ b/display1/manager.go
@@ -3614,8 +3614,18 @@ func (m *Manager) detectDrmSupportGamma() bool {
 func calcMaxScaleFactor(width, height uint16) float64 {
 	scaleFactors := []float64{1.0, 1.25, 1.5, 1.75, 2.0, 2.25, 2.5, 2.75, 3.0}
 
-	maxWScale := float64(width) / 1024.0
-	maxHScale := float64(height) / 768.0
+	// 用长边/短边计算，使结果与屏幕方向无关。90°/270° 旋转会交换 CRTC 的宽高，
+	// 若直接按当前宽高计算，外接屏（如 1920×1080 旋转后变为 1080×1920）的宽仅
+	// 1080，1080/1024≈1.05，会把可支持的最大缩放错误压低到 1.0，进而触发
+	// tryToChangeScaleFactor 把用户已设置的缩放重置回 1.0。屏幕的物理像素总数与
+	// 方向无关，因此应基于长/短边（即原始分辨率）来判断。
+	w, h := width, height
+	if w < h {
+		w, h = h, w
+	}
+
+	maxWScale := float64(w) / 1024.0
+	maxHScale := float64(h) / 768.0
 
 	maxValue := 0.0
 	if maxWScale < maxHScale {

--- a/display1/util_test.go
+++ b/display1/util_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -241,4 +241,33 @@ func Test_parseEdid(t *testing.T) {
 		assert.Equal(t, model, v.model)
 	}
 
+}
+
+// Test_calcMaxScaleFactor 校验最大可支持缩放与屏幕方向无关：90°/270° 旋转会交换
+// CRTC 宽高，旋转前后应得到相同的上限，避免因旋转把上限错误压低（如 1080×1920
+// 被压到 1.0）而在登录应用配置时触发 tryToChangeScaleFactor 重置用户缩放。
+func Test_calcMaxScaleFactor(t *testing.T) {
+	testdata := []struct {
+		name   string
+		width  uint16
+		height uint16
+		want   float64
+	}{
+		{"1920x1080 landscape", 1920, 1080, 1.25},
+		{"1920x1080 rotated 90 (1080x1920)", 1080, 1920, 1.25},
+		{"1920x1080 rotated 180", 1920, 1080, 1.25},
+		{"4K landscape", 3840, 2160, 2.75},
+		{"4K rotated 90 (2160x3840)", 2160, 3840, 2.75},
+		{"1600x900", 1600, 900, 1.0},
+		{"1600x900 rotated 90 (900x1600)", 900, 1600, 1.0},
+		{"1024x768 baseline", 1024, 768, 1.0},
+		{"1024x768 rotated 90 (768x1024)", 768, 1024, 1.0},
+		{"800x600 below baseline", 800, 600, 0.0},
+		{"800x600 rotated 90 (600x800)", 600, 800, 0.0},
+	}
+	for _, v := range testdata {
+		t.Run(v.name, func(t *testing.T) {
+			assert.Equal(t, v.want, calcMaxScaleFactor(v.width, v.height))
+		})
+	}
 }


### PR DESCRIPTION
Calculate the scale limit with the long and short screen edges so rotated outputs use the same limit as the original display mode.

使用屏幕长短边计算缩放上限，使旋转后的输出使用与原始显示模式一致的上限。

Log: 修复旋转外接屏登录后缩放被重置的问题
Influence: 旋转外接屏后注销或重启，用户设置的缩放比例不会被错误重置。
PMS: BUG-365211

## Summary by Sourcery

Ensure maximum display scale factor remains consistent regardless of screen rotation by basing limits on the long and short edges of the display.

Bug Fixes:
- Prevent external rotated displays from having their user-configured scale factor incorrectly reduced and reset after login or reboot.

Tests:
- Add unit tests verifying calcMaxScaleFactor returns the same maximum scale for a display before and after 90°/180° rotation across multiple resolutions.