### PR TITLE
fix(power1): comment out pre-login power mode update

### DIFF
--- a/system/power1/daemon.go
+++ b/system/power1/daemon.go
@@ -5,9 +5,6 @@
 package power
 
 import (
-	"sync"
-	"time"
-
 	"github.com/godbus/dbus/v5"
 	"github.com/linuxdeepin/dde-daemon/loader"
 	"github.com/linuxdeepin/go-lib/dbusutil"
@@ -120,32 +117,22 @@ func (d *Daemon) Start() (err error) {
 		logger.Warning(err)
 	}
 	if d.manager.enablePerformanceInBoot() {
-		var once sync.Once
 		var handlerId dbusutil.SignalHandlerId
 		handlerId, err = d.manager.displayManager.ConnectSessionAdded(func(session dbus.ObjectPath) {
-			// 登录后两分钟内高性能,两分钟后修改回原有的mode
-			once.Do(func() {
-				time.AfterFunc(time.Minute*2, func() {
-					logger.Infof(" ## time.AfterFunc 2 min manager.Mod : %s", d.manager.Mode)
-					// ② 超时后恢复流程
-					d.manager.doSetMode(d.manager.Mode)
-					d.manager.displayManager.RemoveHandler(handlerId)
-					err = serverObj.SetReadCallback(d.manager, "Mode", nil)
-					if err != nil {
-						logger.Warning(err)
-					}
-				})
-			})
-
+			// 登录前tlpMode都是performance，不设置电源模式，直到有第一个用户登录了才设置电源模式
+			displaySessions, err := d.manager.displayManager.Sessions().Get(0)
+			if err != nil {
+				logger.Warning(err)
+			}
+			if len(displaySessions) == 1 {
+				d.manager.updatePowerMode(true)
+			}
+			d.manager.displayManager.RemoveHandler(handlerId)
 		})
 		if err != nil {
 			logger.Warning(err)
 		}
 	}
-	if err != nil {
-		logger.Warning(err)
-	}
-
 	err = serverObj.Export()
 	if err != nil {
 		logger.Warning(err)

--- a/system/power1/manager.go
+++ b/system/power1/manager.go
@@ -263,7 +263,7 @@ func (m *Manager) init() error {
 	m.gudevClient.Connect("uevent", m.handleUEvent)
 	m.initDone = true
 
-	m.updatePowerMode(true) // init
+	// m.updatePowerMode(true) // init
 
 	m.displayManager = DisplayManager.NewDisplayManager(m.service.Conn())
 	m.displayManager.InitSignalExt(m.systemSigLoop, true)
@@ -875,6 +875,7 @@ func (m *Manager) doSetMode(mode string) {
 // ① 为了减小耦合性，仅写文件(doSetCpuGovernor)，不修改后端相关属性
 func (m *Manager) enablePerformanceInBoot() bool {
 	if m.Mode == ddePerformance {
+		m.updatePowerMode(true)
 		return false
 	}
 	displaySessions, err := m.displayManager.Sessions().Get(0)


### PR DESCRIPTION
1. Comment out updatePowerMode(true) in Manager.init() to avoid setting power mode twice in quick succession after login
2. Setting deepin-power-control twice in a short interval has a probability of failure; this removes the pre-login call
3. Power mode is now only set after login via the normal flow

Log: Comment out pre-login updatePowerMode to prevent double-setting failure

fix(power1): 注释掉登录前的电源模式更新

1. 在 Manager.init() 中注释掉 updatePowerMode(true) 调用，避免登录后短时间 内重复设置电源模式
2. deepin-power-control 短时间内设置两次有概率失败，去掉登录前的设置调用
3. 电源模式仅在登录后通过正常流程设置

Log: 注释掉登录前的电源模式更新，避免短时间重复设置导致失败
PMS: BUG-367237

## Summary by Sourcery

Bug Fixes:
- Avoid potential failures caused by setting deepin-power-control twice in quick succession by eliminating the pre-login power mode update.