### PR TITLE
fix: prevent duplicate power-off countdown notifications

### DIFF
--- a/session/power1/manager.go
+++ b/session/power1/manager.go
@@ -1370,7 +1370,8 @@ func (m *Manager) shutdownCountdownNotify(count int, playSound bool) {
 		"urgency":                     dbus.MakeVariant(2), //取消关闭按钮
 		"x-deepin-ShowInNotifyCenter": dbus.MakeVariant(false),
 		"x-deepin-ClickToDisappear":   dbus.MakeVariant(false),
-		"x-deepin-DisappearAfterLock": dbus.MakeVariant(false)}
+		"x-deepin-DisappearAfterLock": dbus.MakeVariant(false),
+		"x-deepin-SilentReplace":      dbus.MakeVariant(true)}
 	m.notifyIdMu.Lock()
 	nid := m.notifyId
 	m.notifyIdMu.Unlock()


### PR DESCRIPTION
Add silent replacement hint to power-off countdown notifications to avoid stacking duplicate alerts when the system triggers multiple shutdown countdown sequences in quick succession.

Log: Fixed duplicate power-off countdown notifications by adding silent replacement hint

Influence:
1. Trigger power-off countdown and verify no duplicate notification appears
2. Test rapid consecutive shutdown commands and verify only one notification is shown
3. Verify notification replacement works silently without visual stacking
4. Test notification behavior across system resume from suspend/lock
5. Verify other non-power-off notifications remain unaffected

fix: 防止电源关闭倒计时重复通知

在电源关闭倒计时通知中添加静默替换提示，避免系统在短时间内触发多次关闭倒
计时序列时出现重复通知堆积的问题。

Log: 修复电源关闭倒计时重复通知问题，添加静默替换提示

Influence:
1. 触发电源关闭倒计时，验证不会显示重复通知
2. 测试快速连续执行关机命令，验证只显示一条通知
3. 验证通知静默替换功能正常工作，无视觉堆积
4. 测试系统从挂起/锁定状态恢复后的通知行为
5. 验证其他非电源关闭倒计时通知不受影响

PMS: BUG-367205

## Summary by Sourcery

Bug Fixes:
- Prevent duplicate power-off countdown notifications by enabling silent replacement of existing countdown alerts.