### PR TITLE
fix: add ConcatScreenName property for multi-screen display

### DIFF
--- a/display1/manager.go
+++ b/display1/manager.go
@@ -228,6 +228,7 @@ type Manager struct {
 	HasChanged          bool
 	DisplayMode         byte
 	ConcatScreenEnabled bool
+	ConcatScreenName    string
 	// dbusutil-gen: equal=nil
 	Brightness          map[string]float64
 	CanSetBrightnessMap map[string]bool
@@ -2368,10 +2369,8 @@ func (m *Manager) applyConcatScreen() error {
 	}
 
 	m.PropsMu.Lock()
-	m.ConcatScreenEnabled = true
+	m.setConcatScreenEnabled(true, concatScreenName)
 	m.PropsMu.Unlock()
-
-	_ = m.service.EmitPropertyChanged(m, "ConcatScreenEnabled", true)
 	return nil
 }
 
@@ -2386,11 +2385,20 @@ func (m *Manager) removeConcatScreen() error {
 	}
 
 	m.PropsMu.Lock()
-	m.ConcatScreenEnabled = false
+	m.setConcatScreenEnabled(false, "")
 	m.PropsMu.Unlock()
-
-	_ = m.service.EmitPropertyChanged(m, "ConcatScreenEnabled", false)
 	return nil
+}
+
+func (m *Manager) setConcatScreenEnabled(enabled bool, name string) (changed bool) {
+	if m.ConcatScreenEnabled != enabled {
+		m.ConcatScreenEnabled = enabled
+		m.ConcatScreenName = name
+		_ = m.service.EmitPropertyChanged(m, "ConcatScreenEnabled", enabled)
+		_ = m.service.EmitPropertyChanged(m, "ConcatScreenName", name)
+		return true
+	}
+	return false
 }
 
 func (m *Manager) save() (err error) {


### PR DESCRIPTION
1. Added new `ConcatScreenName` field to Manager struct to store the name of the current concatenated screen
2. Refactored `applyConcatScreen` and `removeConcatScreen` to use new `setConcatScreenEnabled` helper
3. Created `setConcatScreenEnabled` method that sets both `ConcatScreenEnabled` and `ConcatScreenName`, emits property changes only when state actually changes
4. Removed direct property emission in favor of centralized change detection

Log: Added ConcatScreenName property to display manager for multi-screen identification

Influence:
1. Verify that ConcatScreenEnabled property emits changes correctly when enabling/disabling concatenated screen mode
2. Test that ConcatScreenName property is updated and emitted with the correct screen name
3. Ensure no redundant property emissions occur when state hasn't changed
4. Test backward compatibility with existing display management workflows
5. Verify that removing concatenated screen correctly clears the ConcatScreenName

feat: 添加多屏显示的 ConcatScreenName 属性

1. 在 Manager 结构体中新增 ConcatScreenName 字段，用于存储当前合并屏幕的 名称
2. 重构 applyConcatScreen 和 removeConcatScreen 方法，改用新的 setConcatScreenEnabled 辅助函数
3. 创建 setConcatScreenEnabled 方法，同时设置 ConcatScreenEnabled 和 ConcatScreenName 属性，仅在状态实际变化时发送属性变更信号
4. 移除直接的属性发送逻辑，改用集中式变更检测

Log: 为显示管理器新增 ConcatScreenName 属性，用于多屏识别

Influence:
1. 验证启用/禁用合并屏幕模式时 ConcatScreenEnabled 属性是否正确发送变更 信号
2. 测试 ConcatScreenName 属性是否随正确屏幕名称更新并发送信号
3. 确保状态未变化时不会产生冗余属性发送
4. 测试与现有显示管理功能的向后兼容性
5. 验证移除合并屏幕后是否正确清空 ConcatScreenName

PMS: BUG-362687