### PR TITLE
fix: avoid unnecessary feedback sound when unmuting sink

### DIFF
--- a/audio1/sink.go
+++ b/audio1/sink.go
@@ -120,7 +120,7 @@ func (s *Sink) SetVolume(value float64, isPlay bool) *dbus.Error {
 		s.setMute(true)
 	} else {
 		// SetMute中判断了音量是否为0，但是Volume是根据事件刷新的，此时还不是设置后的音量，因此会影响判断
-		if err := s.setMute(false); err == nil {
+		if err := s.setMuteWithoutFeedback(false); err == nil {
 			if GetConfigKeeper().Mute.MuteOutput {
 				GetConfigKeeper().SetMuteOutput(false)
 			}
@@ -265,6 +265,14 @@ func (s *Sink) SetMute(value bool) *dbus.Error {
 }
 
 func (s *Sink) setMute(value bool) error {
+	return s.setMuteInternal(value, true)
+}
+
+func (s *Sink) setMuteWithoutFeedback(value bool) error {
+	return s.setMuteInternal(value, false)
+}
+
+func (s *Sink) setMuteInternal(value bool, isPlayFeedback bool) error {
 	err := s.CheckPort()
 	if err != nil {
 		logger.Warning(err.Body...)
@@ -275,7 +283,7 @@ func (s *Sink) setMute(value bool) error {
 	}
 	s.audio.context().SetSinkMuteByIndex(s.index, value)
 
-	if !value {
+	if !value && isPlayFeedback {
 		s.playFeedback()
 	}
 	return nil


### PR DESCRIPTION
When setting volume, the system was calling setMute with feedback enabled, which could trigger a feedback sound incorrectly. This change introduces setMuteWithoutFeedback to suppress the feedback sound during volume updates, ensuring feedback is only played when the user explicitly toggles mute.

Log: Fixed unexpected feedback sound when adjusting volume while sink is muted

Influence:
1. Test volume adjustment while sink is muted - verify no feedback sound plays
2. Test toggling mute via UI - verify feedback sound plays correctly
3. Test volume adjustment when not muted - verify normal behavior
4. Verify mute state persistence after volume changes

fix: 修复取消静音时不必要的反馈音

调整音量时，系统调用了带反馈的 setMute，可能在静音状态下错误触发反馈音。
此更改引入 setMuteWithoutFeedback 以在音量更新时抑制反馈音，确保仅当用户
明确切换静音时才播放反馈音。

Log: 修复调整音量时静音状态下意外播放反馈音的问题

Influence:
1. 测试在静音状态下调整音量 - 验证无反馈音播放
2. 测试通过界面切换静音 - 验证反馈音正常播放
3. 测试非静音状态下调整音量 - 验证行为正常
4. 验证音量调整后静音状态正确保持

PMS: BUG-368461