### PR TITLE
feat: add polkit authorization for uadp manager methods

### DIFF
--- a/misc/polkit-rules/org.deepin.dde.uadp.rules
+++ b/misc/polkit-rules/org.deepin.dde.uadp.rules
@@ -1,0 +1,17 @@
+polkit.addRule(function(action, subject) {
+    if (action.id === "org.deepin.dde.uadp.doAction") {
+        // lightdm 活跃会话放行（greeter 免密码调用）
+        if (subject.user === "lightdm") {
+            if (subject.active) {
+                return polkit.Result.YES;
+            } else {
+                return polkit.Result.NO;
+            }
+        }
+
+        // deepin-daemon 用户及组放行
+        if (subject.user === "deepin-daemon" || subject.isInGroup("deepin-daemon")) {
+            return polkit.Result.YES;
+        }
+    }
+});

--- a/system/uadp1/manager.go
+++ b/system/uadp1/manager.go
@@ -1,11 +1,14 @@
-// SPDX-FileCopyrightText: 2018 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 package uadp
 
 import (
-	"github.com/godbus/dbus/v5"
+	"errors"
+
+	dbus "github.com/godbus/dbus/v5"
+	polkit "github.com/linuxdeepin/go-dbus-factory/system/org.freedesktop.policykit1"
 	"github.com/linuxdeepin/go-lib/dbusutil"
 	"github.com/linuxdeepin/go-lib/procfs"
 )
@@ -15,6 +18,28 @@ import (
 // RSA-2048
 const uadpEncryptMaxSize = 256 - 11
 const uadpDecryptMaxSize = 256
+
+const uadpActionId = "org.deepin.dde.uadp.doAction"
+
+func checkAuthorization(actionId string, sysBusName string) error {
+	systemBus, err := dbus.SystemBus()
+	if err != nil {
+		return err
+	}
+	authority := polkit.NewAuthority(systemBus)
+	subject := polkit.MakeSubject(polkit.SubjectKindSystemBusName)
+	subject.SetDetail("name", sysBusName)
+
+	ret, err := authority.CheckAuthorization(0, subject, actionId,
+		nil, polkit.CheckAuthorizationFlagsAllowUserInteraction, "")
+	if err != nil {
+		return err
+	}
+	if !ret.IsAuthorized {
+		return errors.New("not authorized")
+	}
+	return nil
+}
 
 type Manager struct {
 	service *dbusutil.Service
@@ -60,6 +85,12 @@ func (m *Manager) Available() (bool, *dbus.Error) {
 }
 
 func (m *Manager) ListName(sender dbus.Sender) ([]string, *dbus.Error) {
+	err := checkAuthorization(uadpActionId, string(sender))
+	if err != nil {
+		logger.Warning(err)
+		return []string{}, dbusutil.ToError(err)
+	}
+
 	exec, err := m.getExecPath(sender)
 	if err != nil {
 		logger.Warning(err)
@@ -70,6 +101,12 @@ func (m *Manager) ListName(sender dbus.Sender) ([]string, *dbus.Error) {
 }
 
 func (m *Manager) Set(sender dbus.Sender, name string, data []byte) *dbus.Error {
+	err := checkAuthorization(uadpActionId, string(sender))
+	if err != nil {
+		logger.Warning(err)
+		return dbusutil.ToError(err)
+	}
+
 	exec, err := m.getExecPath(sender)
 	if err != nil {
 		logger.Warning(err)
@@ -102,6 +139,12 @@ func (m *Manager) Set(sender dbus.Sender, name string, data []byte) *dbus.Error 
 }
 
 func (m *Manager) Get(sender dbus.Sender, name string) ([]byte, *dbus.Error) {
+	err := checkAuthorization(uadpActionId, string(sender))
+	if err != nil {
+		logger.Warning(err)
+		return []byte{}, dbusutil.ToError(err)
+	}
+
 	exec, err := m.getExecPath(sender)
 	if err != nil {
 		logger.Warning(err)
@@ -123,6 +166,12 @@ func (m *Manager) Get(sender dbus.Sender, name string) ([]byte, *dbus.Error) {
 }
 
 func (m *Manager) Delete(sender dbus.Sender, name string) *dbus.Error {
+	err := checkAuthorization(uadpActionId, string(sender))
+	if err != nil {
+		logger.Warning(err)
+		return dbusutil.ToError(err)
+	}
+
 	exec, err := m.getExecPath(sender)
 	if err != nil {
 		logger.Warning(err)
@@ -140,6 +189,12 @@ func (m *Manager) Delete(sender dbus.Sender, name string) *dbus.Error {
 }
 
 func (m *Manager) Release(sender dbus.Sender) *dbus.Error {
+	err := checkAuthorization(uadpActionId, string(sender))
+	if err != nil {
+		logger.Warning(err)
+		return dbusutil.ToError(err)
+	}
+
 	exec, err := m.getExecPath(sender)
 	if err != nil {
 		logger.Warning(err)


### PR DESCRIPTION
1. Add polkit rules file allowing lightdm active sessions to call the uadp action without password
2. Implement checkAuthorization function using polkit authority to verify caller authorization
3. Add authorization checks to all sensitive uadp methods: ListName, Set, Get, Delete, Release
4. Return empty results with authorization error when caller is not authorized

Log: Added polkit authorization protection for uadp manager operations

Influence:
1. Test all uadp methods (ListName, Set, Get, Delete, Release) with unauthorized caller
2. Verify lightdm active sessions can call methods without password prompt
3. Test lightdm inactive sessions are denied access
4. Verify polkit rules file is installed correctly
5. Test normal user calls with proper authorization prompt
6. Verify error handling when authorization is denied

feat: 为 uadp 管理器方法添加 polkit 授权

1. 添加 polkit 规则文件，允许 lightdm 活跃会话无需密码调用 uadp 操作
2. 实现 checkAuthorization 函数，使用 polkit 权限验证调用者授权
3. 为所有敏感 uadp 方法添加授权检查：ListName、Set、Get、Delete、Release
4. 当调用者未授权时返回空结果和授权错误

Log: 为 uadp 管理操作添加 polkit 授权保护

Influence:
1. 使用未授权调用者测试所有 uadp 方法（ListName、Set、Get、Delete、 Release）
2. 验证 lightdm 活跃会话可无需密码调用方法
3. 测试 lightdm 非活跃会话被拒绝访问
4. 验证 polkit 规则文件正确安装
5. 测试普通用户调用时弹出授权提示
6. 验证授权被拒绝时的错误处理

PMS: BUG-367555 BUG-367575
Change-Id: I5a77779ab915aaae8fca23c25fda3173752aa5e4 (cherry picked from commit fdfc10109a25f8fdde933a2f0b40d57dbb611867)