### PR TITLE
fix: improve gfxmode signal file creation safety

### DIFF
--- a/grub2/grub2_ifc.go
+++ b/grub2/grub2_ifc.go
@@ -6,7 +6,6 @@ package grub2
 
 import (
 	"errors"
-	"os"
 	"strings"
 
 	"github.com/godbus/dbus/v5"
@@ -316,7 +315,7 @@ func (g *Grub2) PrepareGfxmodeDetect(sender dbus.Sender) *dbus.Error {
 
 	g.addModifyTask(getModifyTaskPrepareGfxmodeDetect(gfxmodesStr))
 
-	err = os.WriteFile(grub_common.GfxmodeDetectReadyPath, nil, 0644)
+	err = grub_common.CreateGfxmodeDetectReady()
 	if err != nil {
 		return dbusutil.ToError(err)
 	}

--- a/grub2/main.go
+++ b/grub2/main.go
@@ -81,7 +81,7 @@ func PrepareGfxmodeDetect() error {
 	gfxmodesStr := joinGfxmodesForDetect(gfxmodes)
 	getModifyFuncPrepareGfxmodeDetect(gfxmodesStr)(params)
 
-	err = os.WriteFile(grub_common.GfxmodeDetectReadyPath, nil, 0644)
+	err = grub_common.CreateGfxmodeDetectReady()
 	if err != nil {
 		return err
 	}

--- a/grub_common/common.go
+++ b/grub_common/common.go
@@ -28,7 +28,7 @@ var logger = log.NewLogger("grub_common")
 const (
 	GrubParamsFile            = "/etc/default/grub"
 	DDEGrubParamsFile         = "/etc/default/grub.d/11_dde.cfg"
-	GfxmodeDetectReadyPath    = "/tmp/deepin-gfxmode-detect-ready"
+	GfxmodeDetectReadyPath    = "/run/deepin-gfxmode-detect/ready"
 	DeepinGfxmodeDetect       = "DEEPIN_GFXMODE_DETECT"
 	DeepinGfxmodeAdjusted     = "DEEPIN_GFXMODE_ADJUSTED"
 	DeepinGfxmodeNotSupported = "DEEPIN_GFXMODE_NOT_SUPPORTED"
@@ -263,6 +263,21 @@ func (v Gfxmodes) Intersection(v1 Gfxmodes) (result Gfxmodes) {
 
 func (v Gfxmodes) SortDesc() {
 	sort.Sort(sort.Reverse(v))
+}
+
+// CreateGfxmodeDetectReady 创建 gfxmode 探测完成信号文件。
+//
+// MkdirAll 兜底 unit 外调用（如 postinst 的 `grub2 -prepare-gfxmode-detect`）——此时无
+// RuntimeDirectory 托管父目录；服务内调用时父目录已由 systemd 建好，MkdirAll 为 no-op。
+func CreateGfxmodeDetectReady() error {
+	dir := filepath.Dir(GfxmodeDetectReadyPath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to mkdir %s: %w", dir, err)
+	}
+	if err := os.WriteFile(GfxmodeDetectReadyPath, nil, 0644); err != nil {
+		return fmt.Errorf("failed to create %s: %w", GfxmodeDetectReadyPath, err)
+	}
+	return nil
 }
 
 func ShouldFinishGfxmodeDetect(params map[string]string) bool {

--- a/misc/systemd/services/system/deepin-grub2.service
+++ b/misc/systemd/services/system/deepin-grub2.service
@@ -16,7 +16,9 @@ InaccessiblePaths=-/etc/pam.d
 #InaccessiblePaths=-/usr/share/uadp/
 # 创建/etc/default/grub.d/11_dde.cfg
 ReadWritePaths=-/etc/default/grub.d
-# 创建/tmp/deepin-gfxmode-detect-ready // TODO分析该文件是否有被其他进程使用，该文件存放需要修改
+# /run/deepin-gfxmode-detect/ready，作为 gfxmode 探测完成信号文件
+RuntimeDirectory=deepin-gfxmode-detect
+RuntimeDirectoryPreserve=yes
 ReadWritePaths=-/tmp/
 # /var/cache/deepin/grub2.log
 ReadWritePaths=-/var/cache/deepin


### PR DESCRIPTION
1. Move gfxmode signal file from /tmp to /run (tmpfs, wiped each boot) to fix stale-file issue that could prevent detection completion
2. Introduce CreateGfxmodeDetectReady function to centralize mkdir + write logic with consistent error wrapping
3. Remove direct os.WriteFile calls in favor of the new function
4. Update systemd service with RuntimeDirectory to manage /run/deepin-gfxmode-detect and preserve across restarts

Log: Relocate gfxmode detection signal file to /run and unify creation entry for better lifecycle management
PMS: BUG-367565
Influence:
1. Test gfxmode detection process with normal device conditions
2. Verify signal file creation in /run directory after detection
3. Verify signal file preservation across service restart
4. Verify postinst grub2 -prepare-gfxmode-detect creates signal file without systemd RuntimeDirectory

refactor: 提升 gfxmode 信号文件创建安全性

1. 将 gfxmode 信号文件从 /tmp 迁移至 /run（tmpfs，每次开机清空）， 修正残留旧文件导致探测完成判断失效的问题
2. 引入 CreateGfxmodeDetectReady 函数，统一 mkdir + 写文件逻辑并 规范错误包装
3. 移除直接的 os.WriteFile 调用，统一使用新函数
4. 更新 systemd 服务，通过 RuntimeDirectory 托管 /run/deepin-gfxmode-detect 父目录并跨重启保留

Log: 将 gfxmode 探测完成信号文件迁移至 /run 并统一创建入口，改善生命周期管理
PMS: BUG-367565
Influence:
1. 测试正常设备条件下的 gfxmode 检测流程
2. 验证检测完成后 /run 目录中信号文件的创建与生命周期
3. 验证服务重启后信号文件按 RuntimeDirectoryPreserve 行为保留
4. 验证 postinst 的 grub2 -prepare-gfxmode-detect 在无 systemd 托管时能正常创建信号文件

(cherry picked from commit a50e3aa7828716d7081983fa4c2ff0e414c429cb)