### PR TITLE
fix: add iio-sensor-proxy to short idle service config

### DIFF
--- a/misc/dsg-configs/org.deepin.dde.daemon.power.json
+++ b/misc/dsg-configs/org.deepin.dde.daemon.power.json
@@ -826,7 +826,8 @@
                 "serial-getty@ttyAMA0.service",
                 "winbind.service",
                 "tpm2-abrmd.service",
-                "fprintd.service"
+                "fprintd.service",
+                "iio-sensor-proxy.service"
             ],
             "serial": 0,
             "flags": [


### PR DESCRIPTION
Added service configuration to ensure the system successfully enters "short-idle" mode after remaining idle for 5 minutes.

Influence:
1. Test system entering and exiting short idle state
2. Verify iio-sensor-proxy service remains active during idle
3. Check sensor data availability during idle periods

fix: 在短空闲服务配置中添加 iio-sensor-proxy

新增服务配置,保证系统在静置5分钟后可以正常进入shortidle模式

Influence:
1. 测试系统进入和退出短空闲状态
2. 验证 iio-sensor-proxy 服务在空闲期间保持活跃
3. 检查空闲期间传感器数据可用性

PMS: BUG-370415
Change-Id: Idc13850f8708e18036b4183d55f9de5463eb7543

## Summary by Sourcery

Update power daemon configuration for short-idle behavior.

Enhancements:
- Adjust power management configuration to ensure the system can enter short-idle mode after 5 minutes of inactivity.
- Keep the iio-sensor-proxy service active during short-idle periods to maintain sensor data availability.