### PR TITLE
feat: add private permission support for dconfig

### DIFF
--- a/misc/dsg-configs/org.deepin.Display.json
+++ b/misc/dsg-configs/org.deepin.Display.json
@@ -15,14 +15,14 @@
     },
     "defaultTemperatureManual": {
       "value": 3500,
-      "serial": 0,
+      "serial": 1,
       "flags": [],
       "name": "default temperature manual",
       "name[zh_CN]": "手动模式下的色温默认值",
       "description": "default temperature by manual",
       "description[zh_CN]": "手动模式下的默认色温值",
       "permissions": "readwrite",
-      "visibility": "private"
+      "visibility": "public"
     },
     "customModeTime": {
       "value": "22:00-7:00",

--- a/misc/dsg-configs/org.deepin.dde.daemon.account.json
+++ b/misc/dsg-configs/org.deepin.dde.daemon.account.json
@@ -14,13 +14,13 @@
     },
     "isAllowLocalUnlockTerminal": {
       "value": false,
-      "serial": 0,
+      "serial": 1,
       "flags": ["global"],
       "name": "isAllowLocalUnlockTerminal",
       "name[zh_CN]": "是否容许本地解锁终端",
       "description": "Whether to allow local unlocking of the terminal",
       "permissions": "readwrite",
-      "visibility": "private"
+      "visibility": "public"
     },
     "passwordEncryptionAlgorithm": {
       "value": "sm3",

--- a/misc/dsg-configs/org.deepin.dde.daemon.keyboard.json
+++ b/misc/dsg-configs/org.deepin.dde.daemon.keyboard.json
@@ -124,13 +124,13 @@
         },
         "capslockToggle": {
             "value": true,
-            "serial": 0,
+            "serial": 1,
             "flags": [],
             "name": "capslockToggle",
             "name[zh_CN]": "大写锁定切换通知",
             "description": "Control whether show CapsLock notify",
             "permissions": "readwrite",
-            "visibility": "private"
+            "visibility": "public"
         },
         "saveNumlockState": {
             "value": true,

--- a/misc/dsg-configs/org.deepin.dde.daemon.timedate.json
+++ b/misc/dsg-configs/org.deepin.dde.daemon.timedate.json
@@ -4,13 +4,13 @@
     "contents": {
         "timeZone": {
             "value": "Asia/Shanghai",
-            "serial": 0,
+            "serial": 1,
             "flags": [],
             "name": "time zone of user set",
             "name[zh_CN]": "用户设置的时区",
             "description": "time zone property",
             "permissions": "readwrite",
-            "visibility": "private"
+            "visibility": "public"
         },
         "ntpServer": {
             "value": "",


### PR DESCRIPTION
feat: add private permission management for dconfig daemon

## 变更说明
- 在 dde-dconfig-daemon 中实现 private 权限认证，防止跨 appid 访问私有配置
- 修正 dde-dconfig 中 getAppid 返回值（从 appName 改为 appId 用于权限检测）
- 修正 dconfig-private-permission 计划文档中的技术方案描述

## 具体修改的配置项
- [dde-daemon 相关配置项](#)

## 技术方案简述
- 跨总线 AM Identify 通过 DSessionManager::currentSession() 获取 AMIdentity
- 利用 getProcessNameByPid() 和 getUidByPid() 做权限验证兜底
- 移除 getLastError() 误导字段，统一改为 getLastErrorString()

## 关联的其他 PR
- dde-appearance: https://github.com/linuxdeepin/dde-appearance/pull/...
- dde-shell: https://github.com/linuxdeepin/dde-shell/pull/...
- dde-app-services: https://github.com/linuxdeepin/dde-app-services/pull/...

## Summary by Sourcery

New Features:
- Add or adjust dsg configuration schemas for display, account, keyboard, and timedate daemons to align with private permission-aware dconfig access.