### PR TITLE
fix: add Avahi daemon to the short idle service whitelist

### DIFF
--- a/misc/dsg-configs/org.deepin.dde.daemon.power.json
+++ b/misc/dsg-configs/org.deepin.dde.daemon.power.json
@@ -827,7 +827,8 @@
                 "winbind.service",
                 "tpm2-abrmd.service",
                 "fprintd.service",
-                "iio-sensor-proxy.service"
+                "iio-sensor-proxy.service",
+                "avahi-daemon.service"
             ],
             "serial": 0,
             "flags": [


### PR DESCRIPTION
## Summary

- Add `avahi-daemon.service` to the system service whitelist used by short idle checks.
- Prevent the preinstalled Avahi daemon from being treated as a third-party service and blocking short idle.

## Verification

- `GOFLAGS=-mod=mod go test ./session/power1 -count=1`
- Ran a live A/B test on `10.20.8.210` with the actual `power1.isThirdPartyServiceRunning()` implementation and the real Avahi service:
  - Without the whitelist entry: Avahi was detected as a third-party service.
  - With the whitelist entry: Avahi no longer blocked short idle.

PMS: BUG-371875

## Summary by Sourcery

Bug Fixes:
- Ensure the preinstalled Avahi daemon is no longer treated as a third-party service that prevents short idle behavior.