### PR TITLE
fix: add rollback hook to clean user locale settings

### DIFF
--- a/debian/dde-daemon.install
+++ b/debian/dde-daemon.install
@@ -1,1 +1,2 @@
 debian/reconfigure-dde-daemon /etc/kernel/postinst.d/
+misc/scripts/reset-user-locale.sh /var/lib/deepin-rollback-hooks/

--- a/misc/scripts/reset-user-locale.sh
+++ b/misc/scripts/reset-user-locale.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# 遍历所有普通用户, 删除 ~/.dde_env 和 ~/.config/locale.conf 中的 LANG/LANGUAGE 配置
+
+# 如果文件是普通文件且非软链接，执行 sed 删除匹配行
+sed_safe() {
+    [ -f "$1" ] && [ ! -L "$1" ] && sed -i "$2" "$1"
+}
+
+clean_user_locale() {
+    sed_safe "$1/.dde_env" '/^export LANG=/d; /^export LANGUAGE=/d'
+    if [ -d "$1/.config" ] && [ ! -L "$1/.config" ]; then
+        sed_safe "$1/.config/locale.conf" '/^LANG=/d; /^LANGUAGE=/d'
+    fi
+}
+
+getent passwd | awk -F: '$3 >= 1000 {print $6}' | while read -r home_dir; do
+    [ -z "$home_dir" ] && continue
+    [ "$home_dir" = "/" ] && continue
+    [ -d "$home_dir" ] && [ ! -L "$home_dir" ] || continue
+    clean_user_locale "$home_dir"
+done


### PR DESCRIPTION
1. Add a new reset-user-locale.sh script that runs as a rollback hook
2. The script removes LANG/LANGUAGE configuration from all regular users' ~/.dde_env and ~/.config/locale.conf files
3. This ensures that after a system rollback, user-level locale overrides are cleaned up
4. Users with UID >= 1000 are considered regular users for processing

Log: Added rollback hook to reset user locale configuration on system rollback

Influence:
1. Test rollback scenario with users having LANG/LANGUAGE set in ~/.dde_env
2. Test rollback scenario with users having LANG/LANGUAGE set in ~/.config/locale.conf
3. Verify that users with UID < 1000 are not affected
4. Test with multiple regular users simultaneously
5. Test with non-existent or empty home directories
6. Verify that the script handles cases where locale files do not exist

feat: 添加强制回滚钩子清理用户区域设置

1. 新增 reset-user-locale.sh 脚本作为回滚钩子
2. 该脚本删除所有普通用户 ~/.dde_env 和 ~/.config/locale.conf 中的 LANG/ LANGUAGE 配置
3. 确保系统回滚后清除用户级别的区域设置覆盖
4. 将 UID >= 1000 的用户视为普通用户进行处理

Log: 系统回滚时自动清理用户区域设置配置

Influence:
1. 测试用户在 ~/.dde_env 设置了 LANG/LANGUAGE 的回滚场景
2. 测试用户在 ~/.config/locale.conf 设置了 LANG/LANGUAGE 的回滚场景
3. 验证 UID < 1000 的用户不受影响
4. 测试同时存在多个普通用户的情况
5. 测试不存在或空的用户主目录场景
6. 验证脚本在区域设置文件不存在时的处理能力

PMS: BUG-359641

## Summary by Sourcery

Add a rollback hook script to clean user-level locale settings for regular users during system rollback.

New Features:
- Introduce reset-user-locale.sh rollback script to remove LANG/LANGUAGE overrides from regular users' ~/.dde_env and ~/.config/locale.conf files.

Enhancements:
- Restrict locale cleanup to users with UID >= 1000 and only on valid, non-symlink home directories to avoid affecting system accounts or special paths.