### PR TITLE
fix(display): add SupportBacklight() check in transition type decision

### DIFF
--- a/display1/manager.go
+++ b/display1/manager.go
@@ -3864,7 +3864,11 @@ func (m *Manager) initTransitionManager() {
 		case brightness.SetterBacklight:
 			return brightness.TypeBacklight
 		case brightness.SetterAuto:
-			if isBuiltin {
+			// 必须同时检查 SupportBacklight()：DVI 等"isBuiltin 为真但实际无背光控制器"
+			// 的外接输出（见 isBuiltinMonitor 历史遗留）应走 Gamma 路径，否则会被误路由到
+			// TypeBacklight，写入 /sys/class/backlight/ 对该输出不生效，亮度调节失效。
+			// 与 createBrightnessSetter 的降级路径保持一致。
+			if isBuiltin && brightness.SupportBacklight() {
 				return brightness.TypeBacklight
 			}
 			return brightness.TypeGamma


### PR DESCRIPTION
getBrightnessTypeFunc 在 BrightnessSetterAuto 分支只判断了 isBuiltin， 遗漏了 brightness.SupportBacklight() 检查。DVI 是唯一被 isBuiltinMonitor 判为 true 的外接接口，台式独显环境下 DVI 无背光控制器，被错误路由到
TypeBacklight 执行器，写入 /sys/class/backlight/ 对 DVI 输出不生效， 导致亮度调节完全失效；而 DP/HDMI 走 TypeGamma 正常。

这是 25.1.1 引入 TransitionManager 重构时的回归：旧版 brightness.Set() 及降级路径 createBrightnessSetter 均为 isBuiltin && SupportBacklight()， 主路径迁移时漏掉了该条件。

补回 SupportBacklight() 使主路径与降级路径一致，DVI 回到 Gamma 路径， 内屏（eDP/LVDS，有背光）仍走 Backlight 路径，DP/HDMI 行为不变。

Closes: BUG-367551

## Summary by Sourcery

Bug Fixes:
- Prevent DVI and other builtin-flagged but backlight-less outputs from being incorrectly routed to the backlight-based brightness path, restoring functional gamma-based brightness adjustment.