### PR TITLE
fix(accounts): avoid following symlinks when recovering ownership

### DIFF
--- a/accounts1/utils.go
+++ b/accounts1/utils.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2018 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -354,7 +354,7 @@ func recoverOwnership(u *User) error {
 	}
 	return filepath.Walk(u.HomeDir, func(name string, info os.FileInfo, err error) error {
 		if err == nil {
-			err = os.Chown(name, uid, gid)
+			err = os.Lchown(name, uid, gid)
 		}
 		return err
 	})

--- a/accounts1/utils_test.go
+++ b/accounts1/utils_test.go
@@ -1,10 +1,13 @@
-// SPDX-FileCopyrightText: 2018 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 package accounts
 
 import (
+	"os"
+	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/godbus/dbus/v5"
@@ -59,6 +62,24 @@ func TestIsStrvEqual(t *testing.T) {
 func TestGetValueFromLine(t *testing.T) {
 	ret := getValueFromLine("testdata/shells", "/")
 	assert.Equal(t, ret, "shells")
+}
+
+func TestRecoverOwnershipDoesNotDereferenceSymlink(t *testing.T) {
+	homeDir := t.TempDir()
+	linkPath := filepath.Join(homeDir, "dde-computer.desktop")
+	missingTarget := filepath.Join(homeDir, "missing-target")
+	if err := os.Symlink(missingTarget, linkPath); err != nil {
+		t.Fatal(err)
+	}
+
+	user := &User{
+		Uid:     strconv.Itoa(os.Getuid()),
+		Gid:     strconv.Itoa(os.Getgid()),
+		HomeDir: homeDir,
+	}
+	if err := recoverOwnership(user); err != nil {
+		t.Fatalf("recoverOwnership followed the symbolic link: %v", err)
+	}
 }
 
 func Test_getDetailsKey(t *testing.T) {


### PR DESCRIPTION
fix(accounts): avoid following symlinks when recovering ownership

1. Use os.Lchown while restoring retained home directory ownership
2. Add a regression test for dangling symbolic links

Influence:
1. Verify recreating an account with a retained home does not change symlink targets
2. Verify accounts1 tests and the target-machine account recreation scenario

fix(accounts): 恢复目录属主时避免跟随软链接

1. 恢复保留的用户目录属主时使用 os.Lchown
2. 增加悬空软链接回归测试

Influence:
1. 验证重建保留 HOME 的账户时不修改软链接目标
2. 验证 accounts1 测试及调试机账户重建场景

PMS: BUG-371731

## Summary by Sourcery

Prevent account home directory ownership recovery from following symbolic links.

Bug Fixes:
- Ensure recoverOwnership changes ownership without dereferencing symlinks by using link-aware chown semantics.

Enhancements:
- Update SPDX copyright years to extend through 2026 in accounts1 utilities.

Tests:
- Add a regression test verifying recoverOwnership does not follow dangling symbolic links in retained home directories.