### PR TITLE
fix(power1): avoid incorrect power mode restoration during short idle

### DIFF
--- a/session/power1/power_save_plan.go
+++ b/session/power1/power_save_plan.go
@@ -1089,13 +1089,7 @@ func (psp *powerSavePlan) handleIdleOff() {
 		return
 	}
 
-	if psp.modeBeforeIdle != "" && psp.modeBeforeIdle != "performance" {
-		err := psp.manager.helper.Power.SetMode(0, psp.modeBeforeIdle)
-		if err != nil {
-			logger.Warning(err)
-		}
-		psp.modeBeforeIdle = ""
-	}
+	psp.modeBeforeIdle = ""
 
 	psp.manager.setPrepareSuspend(suspendStateFinish)
 	logger.Info("HandleIdleOff")

--- a/system/power1/manager.go
+++ b/system/power1/manager.go
@@ -860,9 +860,14 @@ func (m *Manager) doSetMode(mode string) {
 
 	logger.Info(" doSetMode, shortIdleState : ", m.ShortIdleState)
 	// 如果恢复性能模式时，当前处于短idle状态，则需要恢复模式后，将TlpMode设置为节能模式
+	// 在延时回调中重新检查短idle状态，避免在延时期间短idle退出后，错误地恢复节能模式
 	if m.ShortIdleState {
 		// 连续两次调用deepin-power-control，有概率会设置失败，因此使用延时500ms
 		time.AfterFunc(500*time.Millisecond, func() {
+			if !m.ShortIdleState {
+				logger.Info("shortIdle state has changed, skip restoring power save mode")
+				return
+			}
 			err := m.setTlpMode(ddePowerSave)
 			if err != nil {
 				logger.Warning(err)


### PR DESCRIPTION
1. Remove mode restoration from handleIdleOff to prevent restoring saved power mode when short idle simply exits
2. Add short idle state re-check in doSetMode delayed callback to skip restoring power save mode if state has changed during the delay
3. Fix race condition where short idle exits and re-enters during the restoration delay window

Log: Fix power save mode restoration logic to check short idle state before restoring
Influence: Prevents wrong power mode when short idle state changes during delay

fix(power1): 避免短 idle 状态切换时错误恢复电源模式

1. 从 handleIdleOff 中移除模式恢复逻辑，避免短 idle 退出时错误恢复电源模式
2. 在 doSetMode 延时回调中增加短 idle 状态检查，状态变化时跳过恢复
3. 修复延时窗口内短 idle 退出再进入导致的竞态条件

Log: 修复短 idle 状态变化时电源模式恢复的判断逻辑
PMS: BUG-367283
PMS: BUG-367279
Influence: 防止短 idel 状态变化时设置错误的电源模式

## Summary by Sourcery

Adjust short idle power save restoration to avoid incorrect mode changes when the short idle state transitions during the delay window.

Bug Fixes:
- Prevent restoring pre-idle power mode on short idle exit by clearing the saved mode instead of applying it in handleIdleOff.
- Avoid restoring power save mode after a delayed callback when the short idle state has changed during the delay, eliminating a race condition in mode restoration logic.