### PR TITLE
fix(accounts1): authorize group info D-Bus methods to prevent info leak

### DIFF
--- a/accounts1/manager.go
+++ b/accounts1/manager.go
@@ -154,7 +154,7 @@ func NewManager(service *dbusutil.Service) *Manager {
 		}
 	}
 
-	m.GroupList, _ = m.GetGroups()
+	m.GroupList, _ = users.GetAllGroups()
 	m.watcher = dutils.NewWatchProxy()
 	if m.watcher != nil {
 		m.delayTaskManager = tasker.NewDelayTaskManager()

--- a/accounts1/manager_ifc.go
+++ b/accounts1/manager_ifc.go
@@ -368,12 +368,20 @@ func (m *Manager) IsPasswordValid(password string) (valid bool, msg string, code
 	return errCode.IsOk(), errCode.Prompt(), int32(errCode), nil
 }
 
-func (m *Manager) GetGroups() (groups []string, busErr *dbus.Error) {
+func (m *Manager) GetGroups(sender dbus.Sender) (groups []string, busErr *dbus.Error) {
+	if err := m.checkAuth(sender); err != nil {
+		logger.Debug("[GetGroups] access denied:", err)
+		return nil, dbusutil.ToError(err)
+	}
 	groups, err := users.GetAllGroups()
 	return groups, dbusutil.ToError(err)
 }
 
-func (m *Manager) GetGroupInfoByName(name string) (groupInfo string, busErr *dbus.Error) {
+func (m *Manager) GetGroupInfoByName(sender dbus.Sender, name string) (groupInfo string, busErr *dbus.Error) {
+	if err := m.checkAuth(sender); err != nil {
+		logger.Debug("[GetGroupInfoByName] access denied:", err)
+		return "", dbusutil.ToError(err)
+	}
 	info, err := users.GetGroupByName(name)
 	if err != nil {
 		logger.Warning(err)
@@ -447,7 +455,7 @@ func (m *Manager) CreateGroup(sender dbus.Sender, groupName string, gid uint32, 
 		logger.Warning(err)
 		return dbusutil.ToError(err)
 	}
-	groupList, _ := m.GetGroups()
+	groupList, _ := users.GetAllGroups()
 	m.setPropGroupList(groupList)
 	return nil
 }
@@ -475,7 +483,7 @@ func (m *Manager) DeleteGroup(sender dbus.Sender, groupName string, force bool) 
 		logger.Warning(err)
 		return dbusutil.ToError(err)
 	}
-	groupList, _ := m.GetGroups()
+	groupList, _ := users.GetAllGroups()
 	m.setPropGroupList(groupList)
 	return nil
 }
@@ -513,7 +521,7 @@ func (m *Manager) ModifyGroup(sender dbus.Sender, currentGroupName string, newGr
 		logger.Warning(err)
 		return dbusutil.ToError(err)
 	}
-	groupList, _ := m.GetGroups()
+	groupList, _ := users.GetAllGroups()
 	m.setPropGroupList(groupList)
 	return nil
 }


### PR DESCRIPTION
fix(accounts1): authorize group info D-Bus methods to prevent info leak

1. Add PolicyKit authorization (org.deepin.dde.accounts.user-administration)
   to the GetGroups method before returning all system group names;
2. Add the same authorization to the GetGroupInfoByName method before
   returning a group's full info, which includes its member list;
3. Switch internal callers (NewManager init and the
   CreateGroup/DeleteGroup/ModifyGroup property refresh) to the
   data-layer users.GetAllGroups() so already-authenticated paths do
   not re-authorize;
Log: Authorize the accounts group-info reading D-Bus methods to block
unauthorized disclosure of system group names and group membership.
Influence: Prevents unprivileged local users from enumerating system
groups and reading privileged group (sudo/wheel/root) member lists.

fix(accounts1): 为组信息 D-Bus 方法补充鉴权以防信息泄露

1. 为 GetGroups 方法在返回全部系统组名前补充 PolicyKit 鉴权
   (org.deepin.dde.accounts.user-administration);
2. 为 GetGroupInfoByName 方法在返回组完整信息(含组成员名单)前补充
   同一鉴权;
3. 将内部调用方(NewManager 初始化及 CreateGroup/DeleteGroup/ModifyGroup
   刷新属性)改为直接调用数据层 users.GetAllGroups(),避免在已鉴权路径上
   重复鉴权;
Log: 为 accounts 组信息读取类 D-Bus 方法补充管理员鉴权,阻止未授权读取
系统组名与组成员名单。
PMS: BUG-370877
Influence: 防止本地非特权用户经 D-Bus 枚举系统组并读取特权组
(sudo/wheel/root)成员名单。

Change-Id: I09dee0d436f331df8cd3da55d2e783652b65321f

## Summary by Sourcery

Authorize group information D-Bus methods and avoid redundant authorization for internal group list refreshes.

Bug Fixes:
- Protect GetGroups and GetGroupInfoByName D-Bus methods with authorization checks to prevent unauthorized disclosure of system group names and membership.

Enhancements:
- Use the data-layer users.GetAllGroups for internal group list initialization and refresh to bypass redundant authorization in trusted code paths.