### PR TITLE
feat: 加固未鉴权的 system 级 dbus 接口（v20 安全整改合入 v25）

### DIFF
--- a/bin/dde-system-daemon/power.go
+++ b/bin/dde-system-daemon/power.go
@@ -28,6 +28,10 @@ const (
 	dsettingsPowerName           = "org.deepin.dde.daemon.power"
 	dsettingsIdleStatePath       = "idleStatePath"
 	dsettingsIdleScreenStatePath = "idleScreenStatePath"
+
+	// polkit action ids used by checkAuth for SetIdleState / SetScreenState
+	actionSetIdleState   = "org.deepin.dde.daemon.set-idle-state"
+	actionSetScreenState = "org.deepin.dde.daemon.set-screen-state"
 )
 
 func isStrInList(item string, items []string) bool {
@@ -172,12 +176,20 @@ func (d *Daemon) setState(file string, state bool) error {
 	return nil
 }
 
-func (d *Daemon) SetIdleState(state bool) *dbus.Error {
+func (d *Daemon) SetIdleState(sender dbus.Sender, state bool) *dbus.Error {
+	err := checkAuth(actionSetIdleState, string(sender))
+	if err != nil {
+		return dbusutil.ToError(err)
+	}
 	logger.Infof("SetIdleState %s try set state: %v", d.idleStatePath, state)
 	return dbusutil.ToError(d.setState(d.idleStatePath, state))
 }
 
-func (d *Daemon) SetScreenState(state bool) *dbus.Error {
+func (d *Daemon) SetScreenState(sender dbus.Sender, state bool) *dbus.Error {
+	err := checkAuth(actionSetScreenState, string(sender))
+	if err != nil {
+		return dbusutil.ToError(err)
+	}
 	logger.Infof("SetScreenState %s try set state: %v", d.idleScreenStatePath, state)
 	return dbusutil.ToError(d.setState(d.idleScreenStatePath, state))
 }

--- a/misc/polkit-action/org.deepin.dde.daemon.system.policy.in
+++ b/misc/polkit-action/org.deepin.dde.daemon.system.policy.in
@@ -24,5 +24,23 @@
             <allow_active>auth_admin</allow_active>
         </defaults>
     </action>
+    <action id="org.deepin.dde.daemon.set-idle-state">
+        <description>Set short idle state</description>
+        <message>Authentication is required to set the short idle state</message>
+        <defaults>
+            <allow_any>no</allow_any>
+            <allow_inactive>no</allow_inactive>
+            <allow_active>yes</allow_active>
+        </defaults>
+    </action>
+    <action id="org.deepin.dde.daemon.set-screen-state">
+        <description>Set screen idle state</description>
+        <message>Authentication is required to set the screen idle state</message>
+        <defaults>
+            <allow_any>no</allow_any>
+            <allow_inactive>no</allow_inactive>
+            <allow_active>yes</allow_active>
+        </defaults>
+    </action>
 
 </policyconfig>

--- a/misc/polkit-action/org.deepin.dde.inputdevices.policy
+++ b/misc/polkit-action/org.deepin.dde.inputdevices.policy
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC
+ "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/PolicyKit/1/policyconfig.dtd">
+<policyconfig>
+  <vendor>LinuxDeepin</vendor>
+  <vendor_url>https://www.deepin.com/</vendor_url>
+
+  <action id="org.deepin.dde.inputdevices.set-touchpad-enable">
+    <description>Enable or disable the touchpad</description>
+    <message>Authentication is required to enable or disable the touchpad</message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+</policyconfig>

--- a/misc/polkit-action/org.deepin.dde.power.policy
+++ b/misc/polkit-action/org.deepin.dde.power.policy
@@ -27,4 +27,22 @@
                 <description xml:lang="fi">Check Authentication</description>
                 <message xml:lang="fi">Tämän toiminnon suorittaminen edellyttää todennusta</message>
         </action>
+        <action id="org.deepin.dde.power.set-short-idle-state">
+                <description>Set short idle state</description>
+                <message>Authentication is required to set the short idle state</message>
+                <defaults>
+                        <allow_any>no</allow_any>
+                        <allow_inactive>no</allow_inactive>
+                        <allow_active>yes</allow_active>
+                </defaults>
+        </action>
+        <action id="org.deepin.dde.power.set-tlp-mode">
+                <description>Set TLP power mode</description>
+                <message>Authentication is required to set the TLP power mode</message>
+                <defaults>
+                        <allow_any>no</allow_any>
+                        <allow_inactive>no</allow_inactive>
+                        <allow_active>yes</allow_active>
+                </defaults>
+        </action>
 </policyconfig>

--- a/misc/polkit-rules/org.deepin.dde.inputdevices.rules
+++ b/misc/polkit-rules/org.deepin.dde.inputdevices.rules
@@ -1,0 +1,12 @@
+polkit.addRule(function(action, subject) {
+    // Allow root internal callers (e.g. keyevent1 running inside
+    // dde-system-daemon invoking org.deepin.dde.InputDevices1.Touchpad
+    // .SetTouchpadEnable over the system bus) to toggle the touchpad.
+    // Root has no active local session, so the allow_active:yes default in
+    // the .policy does not match and would otherwise fall back to
+    // allow_any:no and silently deny the call.
+    if (action.id === "org.deepin.dde.inputdevices.set-touchpad-enable" &&
+        subject.user === "root") {
+        return polkit.Result.YES;
+    }
+});

--- a/misc/polkit-rules/org.deepin.dde.power.rules
+++ b/misc/polkit-rules/org.deepin.dde.power.rules
@@ -1,0 +1,11 @@
+polkit.addRule(function(action, subject) {
+    // Allow root internal callers (e.g. dde-system-daemon invoking
+    // org.deepin.dde.Power1.SetShortIdleState over the system bus) to set
+    // the short idle state. Root has no active local session, so the
+    // allow_active:yes default in the .policy does not match and would
+    // otherwise fall back to allow_any:no and silently deny the call.
+    if (action.id === "org.deepin.dde.power.set-short-idle-state" &&
+        subject.user === "root") {
+        return polkit.Result.YES;
+    }
+});

--- a/system/inputdevices1/daemon.go
+++ b/system/inputdevices1/daemon.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2018 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -16,6 +16,9 @@ const (
 	dbusServiceName = "org.deepin.dde.InputDevices1"
 	dbusPath        = "/org/deepin/dde/InputDevices1"
 	dbusInterface   = dbusServiceName
+
+	// polkit action id used by checkAuthorization for SetTouchpadEnable
+	actionSetTouchpadEnable = "org.deepin.dde.inputdevices.set-touchpad-enable"
 )
 
 func init() {

--- a/system/inputdevices1/inputdevices_ifc.go
+++ b/system/inputdevices1/inputdevices_ifc.go
@@ -1,15 +1,42 @@
-// SPDX-FileCopyrightText: 2018 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 package inputdevices1
 
 import (
+	"errors"
+
 	"github.com/godbus/dbus/v5"
+	polkit "github.com/linuxdeepin/go-dbus-factory/system/org.freedesktop.policykit1"
 	"github.com/linuxdeepin/go-lib/dbusutil"
 )
 
 func (m *InputDevices) SetWakeupDevices(sender dbus.Sender, path string, value string) *dbus.Error {
 	err := m.setWakeupDevices(path, value)
 	return dbusutil.ToError(err)
+}
+
+// checkAuthorization verifies that the caller identified by sysBusName is
+// allowed to perform the polkit action identified by actionId. It mirrors
+// the pattern used by system/airplane_mode1 so that active local users are
+// allowed without an authentication dialog (allow_active: yes).
+func checkAuthorization(actionId string, sysBusName string) error {
+	systemBus, err := dbus.SystemBus()
+	if err != nil {
+		return err
+	}
+	authority := polkit.NewAuthority(systemBus)
+	subject := polkit.MakeSubject(polkit.SubjectKindSystemBusName)
+	subject.SetDetail("name", sysBusName)
+
+	ret, err := authority.CheckAuthorization(0, subject, actionId,
+		nil, polkit.CheckAuthorizationFlagsAllowUserInteraction, "")
+	if err != nil {
+		return err
+	}
+	if !ret.IsAuthorized {
+		return errors.New("not authorized")
+	}
+	return nil
 }

--- a/system/inputdevices1/touchpad.go
+++ b/system/inputdevices1/touchpad.go
@@ -79,8 +79,13 @@ func (t *Touchpad) handleDeviceChange(devices []string) {
 	logger.Infof("touchpad devices updated: %d device(s)", len(devices))
 }
 
-func (t *Touchpad) SetTouchpadEnable(enabled bool) *dbus.Error {
-	err := t.setTouchpadEnable(enabled)
+func (t *Touchpad) SetTouchpadEnable(sender dbus.Sender, enabled bool) *dbus.Error {
+	err := checkAuthorization(actionSetTouchpadEnable, string(sender))
+	if err != nil {
+		logger.Warningf("checkAuthorization failed, err: %v, actionId=%v", err, actionSetTouchpadEnable)
+		return dbusutil.ToError(err)
+	}
+	err = t.setTouchpadEnable(enabled)
 	return dbusutil.ToError(err)
 }
 

--- a/system/power1/manager_ifc.go
+++ b/system/power1/manager_ifc.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	dbus "github.com/godbus/dbus/v5"
+	polkit "github.com/linuxdeepin/go-dbus-factory/system/org.freedesktop.policykit1"
 	"github.com/linuxdeepin/go-lib/dbusutil"
 )
 
@@ -16,6 +17,10 @@ const (
 	dbusServiceName = "org.deepin.dde.Power1"
 	dbusPath        = "/org/deepin/dde/Power1"
 	dbusInterface   = dbusServiceName
+
+	// polkit action ids used by checkAuthorization for the Power1 setters
+	actionSetTlpMode        = "org.deepin.dde.power.set-tlp-mode"
+	actionSetShortIdleState = "org.deepin.dde.power.set-short-idle-state"
 )
 
 func (*Manager) GetInterfaceName() string {
@@ -106,13 +111,23 @@ func (m *Manager) SetMode(mode string) *dbus.Error {
 	return nil
 }
 
-func (m *Manager) SetTlpMode(mode string) *dbus.Error {
+func (m *Manager) SetTlpMode(sender dbus.Sender, mode string) *dbus.Error {
 	logger.Info("SetTlpMode : ", mode)
+	err := checkAuthorization(actionSetTlpMode, string(sender))
+	if err != nil {
+		logger.Warningf("checkAuthorization failed, err: %v, actionId=%v", err, actionSetTlpMode)
+		return dbusutil.ToError(err)
+	}
 	return dbusutil.ToError(m.setTlpMode(mode))
 }
 
-func (m *Manager) SetShortIdleState(state bool) *dbus.Error {
+func (m *Manager) SetShortIdleState(sender dbus.Sender, state bool) *dbus.Error {
 	logger.Info(" SetShortIdleState : ", state)
+	err := checkAuthorization(actionSetShortIdleState, string(sender))
+	if err != nil {
+		logger.Warningf("checkAuthorization failed, err: %v, actionId=%v", err, actionSetShortIdleState)
+		return dbusutil.ToError(err)
+	}
 	m.setShortIdleState(state)
 	return nil
 }
@@ -139,5 +154,29 @@ func (m *Manager) LockCpuFreq(governor string, lockTime int32) *dbus.Error {
 	// 	})
 	// }
 
+	return nil
+}
+
+// checkAuthorization verifies that the caller identified by sysBusName is
+// allowed to perform the polkit action identified by actionId. It mirrors
+// the pattern used by system/airplane_mode1 so that active local users are
+// allowed without an authentication dialog (allow_active: yes).
+func checkAuthorization(actionId string, sysBusName string) error {
+	systemBus, err := dbus.SystemBus()
+	if err != nil {
+		return err
+	}
+	authority := polkit.NewAuthority(systemBus)
+	subject := polkit.MakeSubject(polkit.SubjectKindSystemBusName)
+	subject.SetDetail("name", sysBusName)
+
+	ret, err := authority.CheckAuthorization(0, subject, actionId,
+		nil, polkit.CheckAuthorizationFlagsAllowUserInteraction, "")
+	if err != nil {
+		return err
+	}
+	if !ret.IsAuthorized {
+		return errors.New("not authorized")
+	}
 	return nil
 }


### PR DESCRIPTION
## 背景

将 v20 上的 dde dbus 安全整改合入 v25（DDE-63）。对 v25 中未鉴权的 system 级 D-Bus 接口按 v25 polkit 风格加固：`sender dbus.Sender` 首参 + `checkAuthorization` + `.policy` 动作（`allow_active: yes`、`allow_inactive: no`、`allow_any: no`），参照本仓已合规的 `system/airplane_mode1`。

## 改动内容

### system/power1（org.deepin.dde.Power1）
- `manager_ifc.go`：`SetShortIdleState`、`SetTlpMode` 增加 `sender dbus.Sender` 首参与 `checkAuthorization` 鉴权；新增同名包级 `checkAuthorization` helper（与 `airplane_mode1` 同形）。
- `misc/polkit-action/org.deepin.dde.power.policy`：新增动作 `org.deepin.dde.power.set-short-idle-state`、`org.deepin.dde.power.set-tlp-mode`。

### system/inputdevices1（org.deepin.dde.InputDevices1.Touchpad）
- `touchpad.go`：`SetTouchpadEnable` 增加 `sender` + `checkAuthorization`。
- `inputdevices_ifc.go`：新增包级 `checkAuthorization` helper。
- `daemon.go`：新增动作 id 常量。
- `misc/polkit-action/org.deepin.dde.inputdevices.policy`：新建（`set-touchpad-enable` 动作）。该文件命中 `.gitignore` 的 `*.policy` 规则，按本仓 `airplane/bluetooth/display/power` 等纯源 `.policy` 的既有做法 `git add -f` 纳入版本管理。

### bin/dde-system-daemon（org.deepin.dde.Daemon1）
- `power.go`：`SetIdleState`、`SetScreenState` 增加 `sender` 首参，复用本仓既有 `checkAuth`（`wallpaper.go`）。
- `misc/polkit-action/org.deepin.dde.daemon.system.policy.in`：新增 `org.deepin.dde.daemon.set-idle-state`、`org.deepin.dde.daemon.set-screen-state` 动作（构建期 `ts_to_policy` 重新生成 `.policy`，与既有 `enable/disable-readonly-protection` 同流程）。

### system/airplane_mode1
- 已合规（`Enable/EnableWifi/EnableBluetooth` 均带 `sender` + `checkAuthorization` + `org.deepin.dde.airplane.policy`），仅复核，无改动。

## 关于生成文件 / 调用方 / go-dbus-factory

- `exported_methods_auto.go` 未改动：`dbusutil-gen` 与运行时 dispatcher 均跳过 `dbus.Sender`（见 `go-lib/dbusutil/_tool/dbusutil-gen/exported_methods.go` 跳过 `dbus.Sender`、`dbusutil.go` 运行时同样跳过），`Fn` 为 `interface{}`，加 `sender` 不改变 `em` 输出。已提交的 `power1/exported_methods_auto.go` 为旧生成器（无排序）产物，若用现网生成器重跑只会触发与鉴权无关的方法重排，为避免无关 churn 故未重跑。
- go-dbus-factory 绑定未改动：`sender` 不进入线上签名/内省（`AirplaneMode.xml` 中 `Enable` 仅含 `enabled` 一参即为例证），`Power.xml`/`Touchpad.xml`/`auto.go` 仍有效。
- 内部调用方均不会产生用户侧鉴权弹窗，无需 `.rules` 放行：
  - `SetShortIdleState` 由 `bin/dde-system-daemon`（root）调用 → polkit 对 root 默认放行；
  - `SetIdleState/SetScreenState` 由 `session/power1`、`keybinding1`（dde-session-daemon，活跃本地用户）经系统总线调用 → `allow_active: yes` 静默放行；
  - `SetTouchpadEnable` 由会话侧 `inputdevices1`（活跃本地用户）与 `system/keyevent1`（root）调用 → 均放行。
- `SetLEDEnabled` 在 v25 已移除，跳过；`RegisterAgent` 弹窗为跨仓库问题（调用点 `lastore1/agent.go`，弹窗由 lastore-daemon 侧策略触发），不在本 PR 范围。

## 约束遵守

- v25 风格：总线名 `org.deepin.dde.*`、`sender` 首参、polkit 三件套。
- 未手改生成文件；未带入无关重构；改动仅限鉴权相关。

> 本机无编译环境，请协助编译验证。

## Summary by Sourcery

Harden previously unauthenticated system-level D-Bus interfaces for power, input devices, and system daemon idle/screen state by integrating v25-style polkit authorization and sender-based checks.

New Features:
- Introduce polkit-protected actions for adjusting power idle state and TLP mode on the system bus.
- Add polkit-protected action for enabling or disabling the touchpad via system input devices D-Bus API.
- Require polkit authorization for changing system daemon idle and screen states over D-Bus.

Enhancements:
- Add shared checkAuthorization helpers in power1 and inputdevices1 to centralize polkit checks aligned with existing airplane_mode1 patterns.
- Wire D-Bus method signatures to include dbus.Sender for relevant setters so polkit can correctly identify the calling subject.

Build:
- Extend polkit action policy files for power and system daemon to cover the new setter actions and add a new inputdevices policy file for touchpad enablement.