### PR TITLE
fix: grub2 hash validation and mkconfig fallback

### DIFF
--- a/grub2/edit_auth_ifc.go
+++ b/grub2/edit_auth_ifc.go
@@ -6,6 +6,7 @@ package grub2
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"unicode"
 
@@ -17,6 +18,10 @@ const (
 	editAuthDBusPath      = dbusPath + "/EditAuthentication"
 	editAuthDBusInterface = dbusInterface + ".EditAuthentication"
 )
+
+// pbkdf2HashReg 用于校验 grub 编辑认证密码的 PBKDF2 哈希格式：
+// grub.pbkdf2.sha<alg>.<iterations>.<salt>.<hash>
+var pbkdf2HashReg = regexp.MustCompile(`^grub\.pbkdf2\.sha\d+\.\d+\.[0-9A-Fa-f]+\.[0-9A-Fa-f]+$`)
 
 func (e *EditAuth) GetInterfaceName() string {
 	return editAuthDBusInterface
@@ -35,6 +40,10 @@ func (e *EditAuth) Enable(sender dbus.Sender, username, password string) *dbus.E
 		!e.reg.MatchString(username) ||
 		strings.IndexFunc(password, unicode.IsSpace) >= 0 {
 		return dbusutil.ToError(fmt.Errorf("username or password invalid"))
+	}
+
+	if !pbkdf2HashReg.MatchString(password) {
+		return dbusutil.ToError(fmt.Errorf("invalid pbkdf2 hash format"))
 	}
 
 	err = e.setGrubEditShellAuth(username, password)

--- a/grub2/modify_manger.go
+++ b/grub2/modify_manger.go
@@ -162,8 +162,7 @@ func (m *modifyManager) runUpdateGrubWithUnit() error {
 	var command []string
 	path, err := exec.LookPath(updateGrubCmd)
 	if err != nil {
-		path = grubMkconfigCmd
-		command = append(command, updateGrubCmd, "-o", grubScriptFile)
+		command = append(command, grubMkconfigCmd, "-o", grubScriptFile)
 	} else {
 		command = append(command, path)
 	}


### PR DESCRIPTION
## 修复 grub 编辑认证哈希校验与 update-grub 回退缺陷

### 改动
- `grub2/edit_auth_ifc.go`：新增包级 `pbkdf2HashReg` 正则，`Enable()` 写入前校验 PBKDF2 哈希格式，非法返回 `invalid pbkdf2 hash format` 错误，防止错误数据静默写入 `/etc/grub.d/42_uos_menu_crypto` 后被 grub 忽略（症状同原 bug：静默不校验）。新增 `regexp` import。
- `grub2/modify_manger.go`：`runUpdateGrubWithUnit()` 中 `update-grub` 不在 PATH 时的 fallback 改为 `grub-mkconfig -o <grub.cfg>`（原错误地仍 append `update-grub`，导致 `grub-mkconfig` 从未执行），并删除死赋值 `path = grubMkconfigCmd`。

### 关联
- Multica issue: https://agent-dev.uniontech.com/dde/issues/afa07fcb-a545-4913-b0d2-71dc1c5d27c3
- PMS: BUG-371591 (https://pms.uniontech.com/bug-view-371591.html)

### 审核 / 编译状态
- 代码审核：已通过（95 分 / 优秀）
- amd64 编译验证：已通过

## Summary by Sourcery

Validate grub edit authentication hashes and correct the grub configuration fallback command.

Bug Fixes:
- Validate PBKDF2 hash format for grub edit authentication to prevent invalid hashes from being written and silently ignored.
- Fix fallback behavior to invoke grub-mkconfig with the correct arguments when update-grub is not available.