### PR TITLE
fix: avoid duplicate GRUB background preview refresh

### DIFF
--- a/grub2/theme.go
+++ b/grub2/theme.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2018 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -16,7 +16,8 @@ type Theme struct {
 	g       *Grub2
 	service *dbusutil.Service
 
-	PropsMu sync.RWMutex
+	PropsMu            sync.RWMutex
+	backgroundExportMu sync.Mutex
 
 	//nolint
 	signals *struct {

--- a/grub2/theme_ifc.go
+++ b/grub2/theme_ifc.go
@@ -5,9 +5,10 @@
 package grub2
 
 import (
+	"io"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/godbus/dbus/v5"
@@ -16,8 +17,9 @@ import (
 )
 
 const (
-	themeDBusPath      = dbusPath + "/Theme"
-	themeDBusInterface = dbusInterface + ".Theme"
+	themeDBusPath            = dbusPath + "/Theme"
+	themeDBusInterface       = dbusInterface + ".Theme"
+	grubBackgroundRuntimeDir = "/run/deepin-grub2"
 )
 
 func (*Theme) GetInterfaceName() string {
@@ -79,33 +81,63 @@ func (theme *Theme) GetBackground(sender dbus.Sender) (background string, busErr
 		return "", nil
 	}
 
-	ext := path.Ext(background)
-	backGroundTmpFile, err := os.CreateTemp("/tmp", "dde-grub-background-*"+ext)
+	// source is selected from the fixed packaged default/fallback theme paths above,
+	// so it is not controlled by the D-Bus caller.
+	theme.backgroundExportMu.Lock()
+	defer theme.backgroundExportMu.Unlock()
+
+	destination, err := exportBackground(background, grubBackgroundRuntimeDir)
 	if err != nil {
+		logger.Warningf("GetBackground: export %q failed: %v", background, err)
 		return "", dbusutil.ToError(err)
 	}
+	return destination, nil
+}
 
-	backGroundTmpPath := backGroundTmpFile.Name()
-	backGroundTmpFile.Close()
-
-	err = utils.CopyFile(background, backGroundTmpPath)
+func exportBackground(source, destinationDir string) (string, error) {
+	sourceFile, err := os.Open(source)
 	if err != nil {
-		logger.Warningf("GetBackground: copy %q to %q failed: %v", background, backGroundTmpPath, err)
-		_ = os.Remove(backGroundTmpPath)
-		return "", dbusutil.ToError(err)
+		return "", err
+	}
+	defer sourceFile.Close()
+
+	ext := filepath.Ext(source)
+	destination := filepath.Join(destinationDir, "background"+ext)
+	tempFile, err := os.CreateTemp(destinationDir, ".background-*"+ext)
+	if err != nil {
+		return "", err
+	}
+	tempPath := tempFile.Name()
+	removeTemp := true
+	tempClosed := false
+	defer func() {
+		if !tempClosed {
+			_ = tempFile.Close()
+		}
+		if removeTemp {
+			_ = os.Remove(tempPath)
+		}
+	}()
+
+	// The selected sources are bounded regular theme images; arbitrary paths or
+	// unbounded streams cannot reach this exporter through GetBackground.
+	if _, err := io.Copy(tempFile, sourceFile); err != nil {
+		return "", err
+	}
+	if err := tempFile.Chmod(0644); err != nil {
+		return "", err
+	}
+	closeErr := tempFile.Close()
+	tempClosed = true
+	if closeErr != nil {
+		return "", closeErr
+	}
+	if err := os.Rename(tempPath, destination); err != nil {
+		return "", err
 	}
 
-	err = os.Chmod(backGroundTmpPath, 0644)
-	if err != nil {
-		logger.Warningf("GetBackground: chmod %q 0644 failed: %v", backGroundTmpPath, err)
-		_ = os.Remove(backGroundTmpPath)
-		return "", dbusutil.ToError(err)
-	}
-	logger.Debugf("Copy file %s to %s", background, backGroundTmpPath)
-
-	// 已知问题：返回的临时文件由调用方使用，本服务不清理。每次调用产生一个
-	// 唯一命名的新文件，重复调用会在 /tmp 中累积（依赖重启清空 tmpfs）。
-	return backGroundTmpPath, nil
+	removeTemp = false
+	return destination, nil
 }
 
 func (theme *Theme) emitSignalBackgroundChanged() {

--- a/misc/systemd/services/system/deepin-grub2.service
+++ b/misc/systemd/services/system/deepin-grub2.service
@@ -18,6 +18,8 @@ InaccessiblePaths=-/etc/pam.d
 ReadWritePaths=-/etc/default/grub.d
 # /run/deepin-gfxmode-detect/ready，作为 gfxmode 探测完成信号文件
 RuntimeDirectory=deepin-gfxmode-detect
+# /run/deepin-grub2/background.<ext>，作为控制中心可读的启动菜单壁纸
+RuntimeDirectory=deepin-grub2
 RuntimeDirectoryPreserve=yes
 ReadWritePaths=-/tmp/
 # /var/cache/deepin/grub2.log


### PR DESCRIPTION
1. Add a revision property for refreshing background content at a stable path
2. Avoid emitting path changes when the background path remains unchanged
3. Refresh the preview only after a pending background update completes
4. Restrict automatic theme enabling to control-center initiated updates
5. Replace timestamp-based cache busting with an explicit revision

Log: Avoid duplicate flickering when refreshing the GRUB background preview

Influence:
1. Verify changing the background refreshes the preview once
2. Verify changing the background while the theme is disabled enables it
3. Verify opening the boot menu page does not trigger duplicate refreshes
4. Verify repeated reads of the same background path do not cause flickering
5. Verify the updated image is loaded when the exported path stays unchanged

fix: 避免 GRUB 背景预览重复刷新

1. 增加背景版本属性，用于刷新固定路径下的图片内容
2. 背景路径未变化时不再发送路径变化信号
3. 仅在待处理的背景修改完成后刷新预览
4. 仅对控制中心发起的背景修改自动开启主题
5. 使用显式版本号替代时间戳刷新图片缓存

Log: 避免刷新 GRUB 背景预览时出现两次闪烁

Influence:
1. 验证修改背景后预览只刷新一次
2. 验证主题关闭时修改背景可以正常开启主题
3. 验证打开启动菜单页面不会触发重复刷新
4. 验证重复读取相同背景路径不会造成闪烁
5. 验证导出路径不变时仍能加载更新后的图片

PMS: BUG-371485

## Summary by Sourcery

Stabilize GRUB background export to avoid duplicate preview refreshes and flickering.

Enhancements:
- Export GRUB background images to a fixed runtime path instead of creating new temp files per request.
- Add synchronization around background export to ensure consistent file updates during concurrent access.