### PR TITLE
chore(debian): adjust dde-services version requirement

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -84,7 +84,7 @@ Depends:
  x11-utils,
  xkb-data,
  dde-dconfig-daemon,
- dde-services (>= 1.0.40),
+ dde-services (>> 1.0.39),
  ${dist:Depends},
  ${misc:Depends},
  ${shlibs:Depends},


### PR DESCRIPTION
1. Change dde-services minimum version in debian/control from `>= 1.0.40` to `>> 1.0.39`.
2. `>> 1.0.39` is the standard Debian syntax for strictly-newer-than, covering 1.0.39.x and later.

Log: Relax dde-services version constraint to standard Debian strict-greater-than syntax.
Influence: Packaging only; no runtime behavior change.

chore(debian): 调整 dde-services 版本依赖

1. 将 debian/control 中 dde-services 的最低版本约束由 `>= 1.0.40` 改为 `>> 1.0.39`。
2. `>> 1.0.39` 是 Debian 标准的严格大于语法，涵盖 1.0.39.x 及之后版本。

Log: 将 dde-services 版本约束调整为 Debian 标准严格大于语法。
Influence: 仅打包变更，不影响运行时行为。

## Summary by Sourcery

Build:
- Relax dde-services minimum version in debian/control from an explicit >= 1.0.40 bound to the Debian-standard strict-greater-than 1.0.39 constraint.