### PR TITLE
fix(audio): find source by port list instead of active port

### DIFF
--- a/audio1/audio.go
+++ b/audio1/audio.go
@@ -933,8 +933,12 @@ func (a *Audio) findSink(cardId uint32, activePortName string) *Sink {
 
 func (a *Audio) findSource(cardId uint32, activePortName string) *Source {
 	for _, source := range a.sources {
-		if source.Card == cardId && source.ActivePort.Name == activePortName {
-			return source
+		if source.Card == cardId {
+			for _, port := range source.Ports {
+				if port.Name == activePortName {
+					return source
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
## 根因分析

PMS: https://pms.uniontech.com/bug-view-373661.html

切换输入设备不生效，仍按默认设备（line in）输入。

- **根因**：`audio1/audio.go` 的 `findSource(cardId, portName)` 仅在 `source.ActivePort.Name == portName` 时匹配，即只找「当前激活端口」对应的 source。当用户切换到非当前激活端口的输入设备时，`findSource` 返回 `nil`，`setSourcePortDirectly` 直接报错返回，端口与默认 source 均未设置，切换失效。
- **关键证据**：
  - `findSource`（audio1/audio.go:934）与对称的 `findSink`（audio1/audio.go:919-930）不一致——`findSink` 遍历 `sink.Ports` 匹配任意端口，`findSource` 只匹配 `source.ActivePort.Name`。
  - `Source`/`Sink` 结构一致（`Ports []Port` + `ActivePort Port`，source.go:35-36 / sink.go:48,50），`Port.Name`（port.go:14）可比较，可对齐改法。
  - 唯一调用者 `setSourcePortDirectly`（audio1/audio.go:1151-1166）已自行处理「激活端口不匹配则设端口」分支，本就需要 `findSource` 返回「拥有该端口的 source」。

## 修复方案

将 `findSource` 改为遍历 `source.Ports` 检查端口是否存在，与 `findSink` 完全对齐：

```go
func (a *Audio) findSource(cardId uint32, activePortName string) *Source {
	for _, source := range a.sources {
		if source.Card == cardId {
			for _, port := range source.Ports {
				if port.Name == activePortName {
					return source
				}
			}
		}
	}
	return nil
}
```

改动仅限 `findSource` 函数体（6+/2-），签名不变，与 `findSink` 对称。

## 改动安全评估

低风险：函数签名不变；唯一调用者 `setSourcePortDirectly` 已覆盖「激活端口不匹配」分支；改动与已验证正确的 `findSink` 完全对称；无其他外部调用者。近期相关提交 `d773796 fix(audio): honor manual output selection` 修复的是输出（sink）侧手动选择，未触碰 `findSource`，本次输入侧修复与之互补、不冲突。

## Summary by Sourcery

Resolve audio sources by their available port list so selecting a non-active input device takes effect correctly.

Bug Fixes:
- Fix input-device switching by locating the source that owns the requested port, including ports that are not currently active.

Tests:
- Add regression and symmetry tests covering source and sink lookup across ports, cards, missing ports, and empty collections.