### PR TITLE
refactor: 重构短休眠状态设置方式为内部模块调用

### DIFF
--- a/bin/dde-system-daemon/main.go
+++ b/bin/dde-system-daemon/main.go
@@ -6,9 +6,9 @@ package main
 
 import (
 	"os"
+	"sync"
 
 	configManager "github.com/linuxdeepin/go-dbus-factory/org.desktopspec.ConfigManager"
-	systemPower "github.com/linuxdeepin/go-dbus-factory/system/org.deepin.dde.power1"
 
 	// modules:
 	_ "github.com/linuxdeepin/dde-daemon/accounts1"
@@ -50,7 +50,7 @@ type Daemon struct {
 	systemd             systemd1.Manager
 	dsSystem            configManager.Manager
 	allowCallers        *securityloader.AllowCallerRegistry
-	systemPower         systemPower.Power
+	idleStateMu         sync.Mutex
 	idleStatePath       string
 	idleScreenStatePath string
 	signals             *struct { // nolint
@@ -125,7 +125,6 @@ func main() {
 		systemSigLoop:       dbusutil.NewSignalLoop(service.Conn(), 10),
 		systemd:             systemd1.NewManager(service.Conn()),
 		allowCallers:        allowCallers,
-		systemPower:         systemPower.NewPower(service.Conn()),
 		idleStatePath:       IdleFile,
 		idleScreenStatePath: IdleScreenFile,
 	}

--- a/bin/dde-system-daemon/power.go
+++ b/bin/dde-system-daemon/power.go
@@ -7,13 +7,14 @@ package main
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
 	"syscall"
 
 	"github.com/godbus/dbus/v5"
+	"github.com/linuxdeepin/dde-daemon/loader"
 	"github.com/linuxdeepin/dde-daemon/securityloader"
 	configManager "github.com/linuxdeepin/go-dbus-factory/org.desktopspec.ConfigManager"
 
@@ -116,30 +117,69 @@ func (d *Daemon) forwardPrepareForSleepSignal(service *dbusutil.Service) error {
 	return nil
 }
 
-func (d *Daemon) systemPowerSetShortIdleState(state bool) {
-	logger.Info("systemPowerSetShortIdleState : ", state)
-	if d.systemPower != nil {
-		err := d.systemPower.SetShortIdleState(0, state)
-		if err != nil {
-			logger.Warning("failed to SetShortIdleState, err : ", err)
-		}
-	}
+type shortIdleController interface {
+	ShortIdleState() (bool, error)
+	SetShortIdleState(bool) error
 }
 
+func getShortIdleController() (shortIdleController, error) {
+	module := loader.GetModule("power")
+	if module == nil {
+		return nil, errors.New("power module is not registered")
+	}
+	if !module.IsEnable() {
+		return nil, errors.New("power module is not enabled")
+	}
+	controller, ok := module.(shortIdleController)
+	if !ok {
+		return nil, errors.New("power module does not support short idle control")
+	}
+	return controller, nil
+}
+
+func systemPowerSetShortIdleState(controller shortIdleController, state bool) error {
+	logger.Info("systemPowerSetShortIdleState : ", state)
+	if err := controller.SetShortIdleState(state); err != nil {
+		return fmt.Errorf("failed to set short idle mode: %w", err)
+	}
+	return nil
+}
+
+// 1.设置 system/power 模块的短 idle 状态
+// 2.写file内核文件
 func (d *Daemon) setState(file string, state bool) error {
-	shortIdleState, err := d.systemPower.ShortIdleState().Get(0)
+	if file != d.idleStatePath {
+		return d.writeStateFile(file, state)
+	}
+
+	controller, err := getShortIdleController()
 	if err != nil {
-		logger.Warning("Get systemPower.ShortIdleState err :", err)
+		return fmt.Errorf("failed to get short idle controller: %w", err)
+	}
+	return d.setStateWithController(controller, file, state)
+}
+
+func (d *Daemon) setStateWithController(controller shortIdleController, file string, state bool) error {
+	d.idleStateMu.Lock()
+	defer d.idleStateMu.Unlock()
+
+	shortIdleState, err := controller.ShortIdleState()
+	if err != nil {
+		return fmt.Errorf("failed to get short idle state: %w", err)
 	}
 	logger.Infof("##### setState shortIdleState : %v, state : %v", shortIdleState, state)
 	if shortIdleState == state {
 		logger.Info("shortIdleState is same with state : ", state)
-		return errors.New("Short idle state not exchange.")
+		return d.writeStateFile(file, state)
 	}
-	if file == d.idleStatePath {
-		d.systemPowerSetShortIdleState(state)
+	// 设置 system/power 模块的短 idle 状态
+	if err := systemPowerSetShortIdleState(controller, state); err != nil {
+		return err
 	}
+	return d.writeStateFile(file, state)
+}
 
+func (d *Daemon) writeStateFile(file string, state bool) error {
 	// 写file内核文件
 	if !utils.IsFileExist(file) {
 		err := fmt.Errorf("%s not found", file)
@@ -148,7 +188,7 @@ func (d *Daemon) setState(file string, state bool) error {
 	}
 
 	// 读取file文件内容
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	if err != nil {
 		logger.Errorf("Failed to read file %s: %v", file, err)
 		return err
@@ -164,7 +204,7 @@ func (d *Daemon) setState(file string, state bool) error {
 	logger.Infof("Current content=%s, will set %v", contentStr, newValue)
 	// 将值写入文件
 	newContent := strconv.Itoa(newValue)
-	err = ioutil.WriteFile(file, []byte(newContent), 0644)
+	err = os.WriteFile(file, []byte(newContent), 0644)
 	if err != nil {
 		logger.Errorf("Failed to write file %s: %v", file, err)
 		return err

--- a/bin/dde-system-daemon/power_test.go
+++ b/bin/dde-system-daemon/power_test.go
@@ -1,0 +1,237 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+type fakeShortIdleController struct {
+	state    bool
+	getErr   error
+	setErr   error
+	setCalls int
+}
+
+func (c *fakeShortIdleController) ShortIdleState() (bool, error) {
+	return c.state, c.getErr
+}
+
+func (c *fakeShortIdleController) SetShortIdleState(state bool) error {
+	c.setCalls++
+	if c.setErr != nil {
+		return c.setErr
+	}
+	c.state = state
+	return nil
+}
+
+type blockingShortIdleController struct {
+	mu              sync.Mutex
+	state           bool
+	getCalls        int
+	firstSet        sync.Once
+	firstSetStarted chan struct{}
+	releaseFirstSet chan struct{}
+	secondGetCalled chan struct{}
+}
+
+func (c *blockingShortIdleController) ShortIdleState() (bool, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.getCalls++
+	if c.getCalls == 2 {
+		close(c.secondGetCalled)
+	}
+	return c.state, nil
+}
+
+func (c *blockingShortIdleController) SetShortIdleState(state bool) error {
+	c.mu.Lock()
+	c.state = state
+	c.mu.Unlock()
+
+	c.firstSet.Do(func() {
+		close(c.firstSetStarted)
+		<-c.releaseFirstSet
+	})
+	return nil
+}
+
+func (c *blockingShortIdleController) currentState() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.state
+}
+
+func TestSetStateWithControllerGetErrorDoesNotWrite(t *testing.T) {
+	stateFile := filepath.Join(t.TempDir(), "relax_state")
+	if err := os.WriteFile(stateFile, []byte("0"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	controller := &fakeShortIdleController{getErr: errors.New("get failed")}
+	d := &Daemon{idleStatePath: stateFile}
+	if err := d.setStateWithController(controller, stateFile, true); err == nil {
+		t.Fatal("expected get state error")
+	}
+
+	content, err := os.ReadFile(stateFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "0" {
+		t.Fatalf("state file changed after getter failure: %q", content)
+	}
+	if controller.setCalls != 0 {
+		t.Fatalf("setter called after getter failure: %d", controller.setCalls)
+	}
+}
+
+func TestSetStateWithControllerSetErrorDoesNotWrite(t *testing.T) {
+	stateFile := filepath.Join(t.TempDir(), "relax_state")
+	if err := os.WriteFile(stateFile, []byte("0"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	controller := &fakeShortIdleController{setErr: errors.New("set failed")}
+	d := &Daemon{idleStatePath: stateFile}
+	if err := d.setStateWithController(controller, stateFile, true); err == nil {
+		t.Fatal("expected set state error")
+	}
+
+	content, err := os.ReadFile(stateFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "0" {
+		t.Fatalf("state file changed after setter failure: %q", content)
+	}
+	if controller.setCalls != 1 {
+		t.Fatalf("unexpected setter call count: %d", controller.setCalls)
+	}
+}
+
+func TestSetScreenStateWritesWithoutController(t *testing.T) {
+	screenStateFile := filepath.Join(t.TempDir(), "idle_state")
+	if err := os.WriteFile(screenStateFile, []byte("1"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	d := &Daemon{
+		idleStatePath:       filepath.Join(t.TempDir(), "relax_state"),
+		idleScreenStatePath: screenStateFile,
+	}
+	if err := d.setState(screenStateFile, false); err != nil {
+		t.Fatalf("set screen state: %v", err)
+	}
+
+	content, err := os.ReadFile(screenStateFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "0" {
+		t.Fatalf("screen state file = %q, want %q", content, "0")
+	}
+}
+
+func TestSetStateWithControllerRetryRepairsFile(t *testing.T) {
+	stateFile := filepath.Join(t.TempDir(), "relax_state")
+	controller := new(fakeShortIdleController)
+	d := &Daemon{idleStatePath: stateFile}
+
+	if err := d.setStateWithController(controller, stateFile, true); err == nil {
+		t.Fatal("expected first write to fail")
+	}
+	if !controller.state {
+		t.Fatal("controller state was not updated before the write failure")
+	}
+
+	if err := os.WriteFile(stateFile, []byte("0"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.setStateWithController(controller, stateFile, true); err != nil {
+		t.Fatalf("retry state file write: %v", err)
+	}
+
+	content, err := os.ReadFile(stateFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "1" {
+		t.Fatalf("state file = %q, want %q", content, "1")
+	}
+	if controller.setCalls != 1 {
+		t.Fatalf("unexpected setter call count: %d", controller.setCalls)
+	}
+}
+
+func TestSetStateWithControllerSerializesTransitions(t *testing.T) {
+	stateFile := filepath.Join(t.TempDir(), "relax_state")
+	if err := os.WriteFile(stateFile, []byte("0"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	controller := &blockingShortIdleController{
+		firstSetStarted: make(chan struct{}),
+		releaseFirstSet: make(chan struct{}),
+		secondGetCalled: make(chan struct{}),
+	}
+	d := &Daemon{idleStatePath: stateFile}
+
+	firstErr := make(chan error, 1)
+	go func() {
+		firstErr <- d.setStateWithController(controller, stateFile, true)
+	}()
+
+	select {
+	case <-controller.firstSetStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first transition did not reach the setter")
+	}
+
+	secondErr := make(chan error, 1)
+	secondStarted := make(chan struct{})
+	go func() {
+		close(secondStarted)
+		secondErr <- d.setStateWithController(controller, stateFile, false)
+	}()
+	<-secondStarted
+
+	serialized := true
+	select {
+	case <-controller.secondGetCalled:
+		serialized = false
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(controller.releaseFirstSet)
+	if err := <-firstErr; err != nil {
+		t.Fatalf("first transition: %v", err)
+	}
+	if err := <-secondErr; err != nil {
+		t.Fatalf("second transition: %v", err)
+	}
+	if !serialized {
+		t.Fatal("second transition entered before the first transition completed")
+	}
+
+	content, err := os.ReadFile(stateFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "0" {
+		t.Fatalf("state file = %q, want %q", content, "0")
+	}
+	if controller.currentState() {
+		t.Fatal("controller state and state file are inconsistent")
+	}
+}

--- a/system/power1/daemon.go
+++ b/system/power1/daemon.go
@@ -5,10 +5,12 @@
 package power
 
 import (
+	"errors"
 	"github.com/godbus/dbus/v5"
 	"github.com/linuxdeepin/dde-daemon/loader"
 	"github.com/linuxdeepin/go-lib/dbusutil"
 	"github.com/linuxdeepin/go-lib/log"
+	"sync"
 )
 
 var logger = log.NewLogger("daemon/system/power")
@@ -19,7 +21,8 @@ func init() {
 
 type Daemon struct {
 	*loader.ModuleBase
-	manager *Manager
+	managerMu sync.RWMutex
+	manager   *Manager
 }
 
 func NewDaemon(logger *log.Logger) *Daemon {
@@ -27,33 +30,59 @@ func NewDaemon(logger *log.Logger) *Daemon {
 	daemon.ModuleBase = loader.NewModuleBase("power", daemon, logger)
 	return daemon
 }
+func (d *Daemon) ShortIdleState() (bool, error) {
+	d.managerMu.RLock()
+	defer d.managerMu.RUnlock()
+
+	manager := d.manager
+	if manager == nil {
+		return false, errors.New("power manager is not initialized")
+	}
+	return manager.getShortIdleState(), nil
+}
+
+func (d *Daemon) SetShortIdleState(state bool) error {
+	d.managerMu.RLock()
+	defer d.managerMu.RUnlock()
+
+	manager := d.manager
+	if manager == nil {
+		return errors.New("power manager is not initialized")
+	}
+	return manager.setShortIdleState(state)
+}
+
 
 func (d *Daemon) GetDependencies() []string {
 	return []string{}
 }
 
 func (d *Daemon) Start() (err error) {
+	d.managerMu.Lock()
+	defer d.managerMu.Unlock()
+
 	service := loader.GetService()
-	d.manager, err = newManager(service)
+	manager, err := newManager(service)
 	if err != nil {
 		return
 	}
+	d.manager = manager
 
-	d.manager.batteriesMu.Lock()
-	for _, bat := range d.manager.batteries {
+	manager.batteriesMu.Lock()
+	for _, bat := range manager.batteries {
 		err := service.Export(bat.getObjPath(), bat)
 		if err != nil {
 			logger.Warning("failed to export battery:", err)
 		}
 	}
-	d.manager.batteriesMu.Unlock()
-	serverObj, err := service.NewServerObject(dbusPath, d.manager)
+	manager.batteriesMu.Unlock()
+	serverObj, err := service.NewServerObject(dbusPath, manager)
 	if err != nil {
 		return
 	}
-	err = serverObj.ConnectChanged(d.manager, "PowerSavingModeAuto", func(change *dbusutil.PropertyChanged) {
-		d.manager.updatePowerMode(false) // PowerSavingModeAuto change
-		err := d.manager.saveDsgConfig("PowerSavingModeAuto")
+	err = serverObj.ConnectChanged(manager, "PowerSavingModeAuto", func(change *dbusutil.PropertyChanged) {
+		manager.updatePowerMode(false) // PowerSavingModeAuto change
+		err := manager.saveDsgConfig("PowerSavingModeAuto")
 		if err != nil {
 			logger.Warning(err)
 		}
@@ -62,18 +91,18 @@ func (d *Daemon) Start() (err error) {
 		logger.Warning(err)
 	}
 
-	err = serverObj.ConnectChanged(d.manager, "PowerSavingModeEnabled", func(change *dbusutil.PropertyChanged) {
+	err = serverObj.ConnectChanged(manager, "PowerSavingModeEnabled", func(change *dbusutil.PropertyChanged) {
 		enabled := change.Value.(bool)
-		d.manager.PropsMu.Lock()
-		d.manager.updatePowerSavingState(false)
-		d.manager.PropsMu.Unlock()
+		manager.PropsMu.Lock()
+		manager.updatePowerSavingState(false)
+		manager.PropsMu.Unlock()
 		// 历史版本只有节能和平衡之间的切换
 		if enabled {
-			d.manager.doSetMode(ddePowerSave)
+			manager.doSetMode(ddePowerSave)
 		} else {
-			d.manager.doSetMode(ddeBalance)
+			manager.doSetMode(ddeBalance)
 		}
-		err := d.manager.saveDsgConfig("PowerSavingModeEnabled")
+		err := manager.saveDsgConfig("PowerSavingModeEnabled")
 		if err != nil {
 			logger.Warning(err)
 		}
@@ -83,10 +112,10 @@ func (d *Daemon) Start() (err error) {
 	}
 
 	// 属性改变后的回调函数
-	err = serverObj.ConnectChanged(d.manager, "PowerSavingModeAutoWhenBatteryLow", func(change *dbusutil.PropertyChanged) {
-		d.manager.refreshBatteryDisplay()
-		d.manager.updatePowerMode(false) // PowerSavingModeAutoWhenBatteryLow change
-		err := d.manager.saveDsgConfig("PowerSavingModeAutoWhenBatteryLow")
+	err = serverObj.ConnectChanged(manager, "PowerSavingModeAutoWhenBatteryLow", func(change *dbusutil.PropertyChanged) {
+		manager.refreshBatteryDisplay()
+		manager.updatePowerMode(false) // PowerSavingModeAutoWhenBatteryLow change
+		err := manager.saveDsgConfig("PowerSavingModeAutoWhenBatteryLow")
 		if err != nil {
 			logger.Warning(err)
 		}
@@ -95,8 +124,8 @@ func (d *Daemon) Start() (err error) {
 		logger.Warning(err)
 	}
 
-	err = serverObj.ConnectChanged(d.manager, "PowerSavingModeBrightnessDropPercent", func(change *dbusutil.PropertyChanged) {
-		err := d.manager.saveDsgConfig("PowerSavingModeBrightnessDropPercent")
+	err = serverObj.ConnectChanged(manager, "PowerSavingModeBrightnessDropPercent", func(change *dbusutil.PropertyChanged) {
+		err := manager.saveDsgConfig("PowerSavingModeBrightnessDropPercent")
 		if err != nil {
 			logger.Warning(err)
 		}
@@ -105,10 +134,10 @@ func (d *Daemon) Start() (err error) {
 		logger.Warning(err)
 	}
 
-	err = serverObj.ConnectChanged(d.manager, "PowerSavingModeAutoBatteryPercent", func(change *dbusutil.PropertyChanged) {
-		d.manager.refreshBatteryDisplay()
-		d.manager.updatePowerMode(false) // PowerSavingModeAutoBatteryPercent change
-		err := d.manager.saveDsgConfig("PowerSavingModeAutoBatteryPercent")
+	err = serverObj.ConnectChanged(manager, "PowerSavingModeAutoBatteryPercent", func(change *dbusutil.PropertyChanged) {
+		manager.refreshBatteryDisplay()
+		manager.updatePowerMode(false) // PowerSavingModeAutoBatteryPercent change
+		err := manager.saveDsgConfig("PowerSavingModeAutoBatteryPercent")
 		if err != nil {
 			logger.Warning(err)
 		}
@@ -116,18 +145,18 @@ func (d *Daemon) Start() (err error) {
 	if err != nil {
 		logger.Warning(err)
 	}
-	if d.manager.enablePerformanceInBoot() {
+	if manager.enablePerformanceInBoot() {
 		var handlerId dbusutil.SignalHandlerId
-		handlerId, err = d.manager.displayManager.ConnectSessionAdded(func(session dbus.ObjectPath) {
+		handlerId, err = manager.displayManager.ConnectSessionAdded(func(session dbus.ObjectPath) {
 			// 登录前tlpMode都是performance，不设置电源模式，直到有第一个用户登录了才设置电源模式
-			displaySessions, err := d.manager.displayManager.Sessions().Get(0)
+			displaySessions, err := manager.displayManager.Sessions().Get(0)
 			if err != nil {
 				logger.Warning(err)
 			}
 			if len(displaySessions) == 1 {
-				d.manager.updatePowerMode(true)
+				manager.updatePowerMode(true)
 			}
-			d.manager.displayManager.RemoveHandler(handlerId)
+			manager.displayManager.RemoveHandler(handlerId)
 		})
 		if err != nil {
 			logger.Warning(err)
@@ -144,26 +173,30 @@ func (d *Daemon) Start() (err error) {
 }
 
 func (d *Daemon) Stop() error {
-	if d.manager == nil {
+	d.managerMu.Lock()
+	defer d.managerMu.Unlock()
+
+	manager := d.manager
+	if manager == nil {
 		return nil
 	}
 	service := loader.GetService()
 
-	d.manager.batteriesMu.Lock()
-	for _, bat := range d.manager.batteries {
+	manager.batteriesMu.Lock()
+	for _, bat := range manager.batteries {
 		err := service.StopExport(bat)
 		if err != nil {
 			logger.Warning(err)
 		}
 	}
-	d.manager.batteriesMu.Unlock()
+	manager.batteriesMu.Unlock()
 
-	err := service.StopExport(d.manager)
+	err := service.StopExport(manager)
 	if err != nil {
 		logger.Warning(err)
 	}
 
-	d.manager.destroy()
+	manager.destroy()
 	d.manager = nil
 	return nil
 }

--- a/system/power1/exported_methods_auto.go
+++ b/system/power1/exported_methods_auto.go
@@ -58,10 +58,5 @@ func (v *Manager) GetExportedMethods() dbusutil.ExportedMethods {
 			Fn:     v.SetTlpMode,
 			InArgs: []string{"mode"},
 		},
-		{
-			Name:   "SetShortIdleState",
-			Fn:     v.SetShortIdleState,
-			InArgs: []string{"state"},
-		},
 	}
 }

--- a/system/power1/manager.go
+++ b/system/power1/manager.go
@@ -96,10 +96,12 @@ type Manager struct {
 	PowerSavingModeBrightnessData string `prop:"access:rw"`
 
 	// 当前短idle状态
-	ShortIdleState bool
+	ShortIdleState   bool
+	ShortIdleStateMu sync.RWMutex
 
 	// 是否支持短idle方案
-	shortIdleEnable bool
+	shortIdleEnableMu sync.RWMutex
+	shortIdleEnable   bool
 
 	// 直接设置tlp配置
 	TlpMode string
@@ -441,8 +443,8 @@ func (m *Manager) initDsgConfig() error {
 			logger.Warning(err)
 			return
 		}
-		m.shortIdleEnable = data
-		logger.Info("dsg of shortIdleEnable : ", m.shortIdleEnable)
+		m.setShortIdleEnable(data)
+		logger.Info("dsg of shortIdleEnable : ", data)
 	}
 	getShortIdleEnable()
 
@@ -775,14 +777,35 @@ func (m *Manager) setTlpMode(mode string) error {
 	return nil
 }
 
-// 仅对性能模式做设置，不记录状态
-// deepin-power-control idle wifi <on|off>
-func (m *Manager) setShortIdleState(state bool) {
+func (m *Manager) getShortIdleEnable() bool {
+	m.shortIdleEnableMu.RLock()
+	defer m.shortIdleEnableMu.RUnlock()
+	return m.shortIdleEnable
+}
+
+func (m *Manager) setShortIdleEnable(enabled bool) {
+	m.shortIdleEnableMu.Lock()
+	m.shortIdleEnable = enabled
+	m.shortIdleEnableMu.Unlock()
+}
+
+func (m *Manager) getShortIdleState() bool {
+	m.ShortIdleStateMu.RLock()
+	defer m.ShortIdleStateMu.RUnlock()
+	return m.ShortIdleState
+}
+
+//仅对性能模式做设置，不记录状态
+//deepin-power-control idle wifi <on|off>
+func (m *Manager) setShortIdleState(state bool) error {
 	logger.Info(" setShortIdleState state : ", state)
-	if !m.shortIdleEnable {
+	if !m.getShortIdleEnable() {
 		logger.Info("System not open dsg of shortIdleEnable.")
-		return
+		return nil
 	}
+
+	m.ShortIdleStateMu.Lock()
+	defer m.ShortIdleStateMu.Unlock()
 
 	if m.ShortIdleState != state {
 		m.ShortIdleState = state
@@ -794,7 +817,7 @@ func (m *Manager) setShortIdleState(state bool) {
 		}
 	} else {
 		logger.Info("setShortIdleState the same state : ", state)
-		return
+		return nil
 	}
 
 	// 进入短idle：
@@ -806,7 +829,7 @@ func (m *Manager) setShortIdleState(state bool) {
 	if m.batteryLow {
 		powerState = ddeLowBattery
 	}
-	if !m.ShortIdleState {
+	if !state {
 		// 退出短idle：
 		// 1. deepin-power-control idle wifi off : 执行 `wifi off` 时，停止守护进程，恢复网卡默认行为
 		// 2. 电源模式切换为节能模式
@@ -826,6 +849,7 @@ func (m *Manager) setShortIdleState(state bool) {
 		// 设置wifi短idle模式
 		m.setDPCWifiState(wifiState)
 	}()
+	return nil
 }
 
 func (m *Manager) doSetMode(mode string) {
@@ -860,13 +884,13 @@ func (m *Manager) doSetMode(mode string) {
 		_ = m.setDsgData(dsettingsMode, fixMode, m.dsgPower)
 	}
 
-	logger.Info(" doSetMode, shortIdleState : ", m.ShortIdleState)
+	logger.Info(" doSetMode, shortIdleState : ", m.getShortIdleState())
 	// 如果恢复性能模式时，当前处于短idle状态，则需要恢复模式后，将TlpMode设置为节能模式
 	// 在延时回调中重新检查短idle状态，避免在延时期间短idle退出后，错误地恢复节能模式
-	if m.ShortIdleState {
+	if m.getShortIdleState() {
 		// 连续两次调用deepin-power-control，有概率会设置失败，因此使用延时500ms
 		time.AfterFunc(500*time.Millisecond, func() {
-			if !m.ShortIdleState {
+			if !m.getShortIdleState() {
 				logger.Info("shortIdle state has changed, skip restoring power save mode")
 				return
 			}

--- a/system/power1/manager_ifc.go
+++ b/system/power1/manager_ifc.go
@@ -128,12 +128,6 @@ func (m *Manager) SetTlpMode(sender dbus.Sender, mode string) *dbus.Error {
 	return dbusutil.ToError(m.setTlpMode(mode))
 }
 
-func (m *Manager) SetShortIdleState(state bool) *dbus.Error {
-	logger.Info(" SetShortIdleState : ", state)
-	m.setShortIdleState(state)
-	return nil
-}
-
 func (m *Manager) LockCpuFreq(governor string, lockTime int32) *dbus.Error {
 	// TODO 改用tlp
 	// currentGovernor, err := m.cpus.GetGovernor()

--- a/system/power1/manager_powersave.go
+++ b/system/power1/manager_powersave.go
@@ -125,7 +125,7 @@ func (m *Manager) updatePowerMode(init bool) {
 	}
 	logger.Infof("PowerSavingModeAuto: %v\n OnBattery:%v \n PowerSavingModeAutoWhenBatteryLow:%v \n batteryLow:%v \n",
 		m.PowerSavingModeAuto, m.OnBattery, m.PowerSavingModeAutoWhenBatteryLow, m.batteryLow)
-	logger.Infof("lastMode: %v, ShortIdleState : %v", m.lastMode, m.ShortIdleState)
+	logger.Infof("lastMode: %v, ShortIdleState : %v", m.lastMode, m.getShortIdleState())
 	if !m.PowerSavingModeAuto && !m.PowerSavingModeAutoWhenBatteryLow && !init {
 		return
 	}

--- a/system/power1/power_test.go
+++ b/system/power1/power_test.go
@@ -1,10 +1,11 @@
-// SPDX-FileCopyrightText: 2018 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 package power
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/godbus/dbus/v5"
@@ -17,5 +18,40 @@ func Test_getValidName(t *testing.T) {
 		path := dbus.ObjectPath("/battery_" + getValidName(name))
 		t.Log(path)
 		assert.True(t, path.IsValid())
+	}
+}
+func TestSetShortIdleStateDisabledIsNoOp(t *testing.T) {
+	m := new(Manager)
+
+	if err := m.setShortIdleState(true); err != nil {
+		t.Fatalf("setShortIdleState returned error while disabled: %v", err)
+	}
+	if m.getShortIdleState() {
+		t.Fatal("short idle state changed while disabled")
+	}
+}
+
+func TestShortIdleEnableConcurrentAccess(t *testing.T) {
+	m := new(Manager)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 10000; i++ {
+			m.setShortIdleEnable(i%2 == 0)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 10000; i++ {
+			_ = m.getShortIdleEnable()
+		}
+	}()
+	wg.Wait()
+
+	m.setShortIdleEnable(true)
+	if !m.getShortIdleEnable() {
+		t.Fatal("short idle enable state was not updated")
 	}
 }


### PR DESCRIPTION
1. 将 dde-system-daemon 中对 com.deepin.system.Power 的跨进程 DBus 调用 重构为内部模块接口调用
2. 在 power 模块的 Daemon 结构体上新增 ShortIdleState 和 SetShortIdleState 方法以适配内部调用
3. 移除 dde-system-daemon 对 go-dbus-factory 中 com.deepin.system.power 的直接依赖及结构体字段
4. 移除 power 模块对外导出的 SetShortIdleState DBus 方法，防止外部进程越 权修改系统短休眠状态
5. 通过引入 shortIdleController 接口解耦 dde-system-daemon 与 power 模块 的具体实现，提升内聚性并减少 DBus 通信开销

Influence:
1. 测试系统从正常状态进入短休眠状态，验证内核文件及内部状态是否正确切换
2. 测试系统从短休眠状态恢复至正常状态，验证状态回退逻辑是否正常
3. 验证系统休眠与唤醒的整体流程不受影响
4. 尝试通过 DBus 工具外部调用 com.deepin.system.Power 的 SetShortIdleState 方法，确认该方法已被正确移除且无法调用

refactor: 重构短休眠状态设置方式为内部模块调用

1. 将 dde-system-daemon 中对 com.deepin.system.Power 的跨进程 DBus 调用 重构为内部模块接口调用
2. 在 power 模块的 Daemon 结构体上新增 ShortIdleState 和 SetShortIdleState 方法以适配内部调用
3. 移除 dde-system-daemon 对 go-dbus-factory 中 com.deepin.system.power 的直接依赖及结构体字段
4. 移除 power 模块对外导出的 SetShortIdleState DBus 方法，防止外部进程越 权修改系统短休眠状态
5. 通过引入 shortIdleController 接口解耦 dde-system-daemon 与 power 模块 的具体实现，提升内聚性并减少 DBus 通信开销

Influence:
1. 测试系统从正常状态进入短休眠状态，验证内核文件及内部状态是否正确切换
2. 测试系统从短休眠状态恢复至正常状态，验证状态回退逻辑是否正常
3. 验证系统休眠与唤醒的整体流程不受影响
4. 尝试通过 DBus 工具外部调用 com.deepin.system.Power 的 SetShortIdleState 方法，确认该方法已被正确移除且无法调用

PMS: TASK-393313

## Summary by Sourcery

Refactor short-idle state management to use synchronized internal power-module calls instead of externally exposed D-Bus operations.

Enhancements:
- Replace cross-process D-Bus short-idle state control with an internal module interface between the system daemon and power module.
- Add synchronized short-idle state access and transition handling to improve consistency during concurrent power-state changes.
- Restrict short-idle state updates to internal callers by removing the exported D-Bus setter.

Tests:
- Add coverage for short-idle enablement, state transition failures, retries, file updates, and serialized concurrent transitions.