### PR TITLE
fix(audio): find source by port list instead of active port

### DIFF
--- a/audio1/audio.go
+++ b/audio1/audio.go
@@ -933,8 +933,12 @@ func (a *Audio) findSink(cardId uint32, activePortName string) *Sink {
 
 func (a *Audio) findSource(cardId uint32, activePortName string) *Source {
 	for _, source := range a.sources {
-		if source.Card == cardId && source.ActivePort.Name == activePortName {
-			return source
+		if source.Card == cardId {
+			for _, port := range source.Ports {
+				if port.Name == activePortName {
+					return source
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
## 根因分析

PMS: https://pms.uniontech.com/bug-view-373661.html

切换输入设备不生效，仍按默认设备（line in）输入。

- **根因**：`audio1/audio.go` 的 `findSource(cardId, portName)` 仅在 `source.ActivePort.Name == portName` 时匹配，即只找「当前激活端口」对应的 source。当用户切换到非当前激活端口的输入设备时，`findSource` 返回 `nil`，`setSourcePortDirectly` 直接报错返回，端口与默认 source 均未设置，切换失效。
- **对照**：`findSink`（audio1/audio.go:919-930）遍历 `sink.Ports` 匹配任意端口，行为正确；`Source`/`Sink` 结构一致，可对齐。

## 修复方案

将 `findSource` 改为遍历 `source.Ports` 检查端口是否存在，与 `findSink` 完全对齐。改动仅限 `findSource` 函数体（6+/2-），签名不变。

## Cherry-pick 说明

本 PR 为 master 修复提交 `51e2dd0b`（PR #1205）向 `release/2500` 分支的 cherry-pick。

- 源提交：`51e2dd0b`（`fix(audio): find source by port list instead of active port`，已合入 master）
- `release/2500` 上 `findSource` 实现与修复前 master 一致（同样的 `ActivePort.Name` 匹配），cherry-pick 无冲突，干净应用
- 改动与 master 修复完全一致：仅 `audio1/audio.go` 的 `findSource` 函数，6 增 / 2 删

## 改动安全评估

低风险：函数签名不变；唯一调用者 `setSourcePortDirectly` 已覆盖「激活端口不匹配」分支；改动与已验证正确的 `findSink` 完全对称。

## Summary by Sourcery

Bug Fixes:
- Fix input device switching by locating audio sources through their available port list rather than only the currently active port.