### PR TITLE
revert security loader

### DIFF
--- a/bin/dde-session-daemon/main.go
+++ b/bin/dde-session-daemon/main.go
@@ -173,11 +173,6 @@ func main() {
 			DBusPath:      "/org/deepin/dde/InputDevices1",
 			DBusInterface: "org.deepin.dde.InputDevices1",
 		},
-		{
-			DBusName:      "org.deepin.dde.AirplaneMode1",
-			DBusPath:      "/org/deepin/dde/AirplaneMode1",
-			DBusInterface: "org.deepin.dde.AirplaneMode1",
-		},
 	})
 	os.Args = cleanedArgs
 	if err != nil {

--- a/misc/conf/org.deepin.dde.AirplaneMode1.conf
+++ b/misc/conf/org.deepin.dde.AirplaneMode1.conf
@@ -8,25 +8,11 @@
   <!-- Only root can own the service -->
   <policy user="root">
     <allow own="org.deepin.dde.AirplaneMode1"/>
-    <allow send_destination="org.deepin.dde.AirplaneMode1"
-           send_interface="org.deepin.dde.AirplaneMode1"
-           send_member="SetAllowCaller"/>
-  </policy>
-
-  <!-- Only deepin-daemon group can call SetAllowCaller -->
-  <policy group="deepin-daemon">
-    <allow send_destination="org.deepin.dde.AirplaneMode1"
-           send_interface="org.deepin.dde.AirplaneMode1"
-           send_member="SetAllowCaller"/>
   </policy>
 
   <!-- Allow anyone to invoke methods on the interfaces -->
   <policy context="default">
     <allow send_destination="org.deepin.dde.AirplaneMode1"/>
-
-    <deny send_destination="org.deepin.dde.AirplaneMode1"
-          send_interface="org.deepin.dde.AirplaneMode1"
-          send_member="SetAllowCaller"/>
   </policy>
 
 </busconfig>

--- a/securityloader/allowcaller.go
+++ b/securityloader/allowcaller.go
@@ -28,12 +28,12 @@ const (
 	DaemonScope       = "org.deepin.dde.Daemon1:/org/deepin/dde/Daemon1"
 	PowerScope        = "org.deepin.dde.Power1:/org/deepin/dde/Power1"
 	InputDevicesScope = "org.deepin.dde.InputDevices1:/org/deepin/dde/InputDevices1"
-	AirplaneModeScope = "org.deepin.dde.AirplaneMode1:/org/deepin/dde/AirplaneMode1"
+
+	privilegedGroup = "deepin-daemon"
+	invalidGroupID  = ^uint32(0)
 
 	defaultRuntimeDir = "/run/dde-daemon"
 	defaultStateFile  = defaultRuntimeDir + "/security_loader_allow_callers.json"
-	privilegedGroup   = "deepin-daemon"
-	invalidGroupID    = ^uint32(0)
 )
 
 // AuthResult describes how a caller should be authorized.

--- a/system/airplane_mode1/exported_methods_auto.go
+++ b/system/airplane_mode1/exported_methods_auto.go
@@ -27,10 +27,5 @@ func (v *Manager) GetExportedMethods() dbusutil.ExportedMethods {
 			Fn:     v.EnableWifi,
 			InArgs: []string{"enableAirplaneMode"},
 		},
-		{
-			Name:   "SetAllowCaller",
-			Fn:     v.SetAllowCaller,
-			InArgs: []string{"uniqueName"},
-		},
 	}
 }

--- a/system/airplane_mode1/manager.go
+++ b/system/airplane_mode1/manager.go
@@ -5,6 +5,7 @@
 package airplane_mode
 
 import (
+	"errors"
 	"sync"
 	"time"
 
@@ -34,7 +35,6 @@ type device struct {
 
 type Manager struct {
 	service         *dbusutil.Service
-	allowCallers    *securityloader.AllowCallerRegistry
 	btRfkillDevices map[uint32]device
 	btDevicesMu     sync.RWMutex
 	// Airplane Mode status
@@ -55,7 +55,6 @@ type Manager struct {
 func newManager(service *dbusutil.Service) *Manager {
 	mgr := &Manager{
 		service:         service,
-		allowCallers:    securityloader.DefaultRegistry(),
 		btRfkillDevices: make(map[uint32]device),
 		config:          NewConfig(),
 	}
@@ -75,18 +74,16 @@ func (mgr *Manager) DumpState() *dbus.Error {
 	return nil
 }
 
-func (mgr *Manager) SetAllowCaller(sender dbus.Sender, uniqueName string) *dbus.Error {
-	return dbusutil.ToError(mgr.allowCallers.AddCaller(securityloader.AirplaneModeScope, sender, uniqueName))
-}
 
 func (mgr *Manager) authorize(sender dbus.Sender) error {
-	return securityloader.AuthorizeWithPolkit(
-		mgr.allowCallers,
-		securityloader.AirplaneModeScope,
-		sender,
-		mgr.service.Conn(),
-		actionId,
-	)
+	ok, err := securityloader.CheckPolkitAuth(mgr.service.Conn(), string(sender), actionId)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return errors.New("access denied")
+	}
+	return nil
 }
 
 // Enable enable or disable *Airplane Mode*, isn't enable the devices


### PR DESCRIPTION
Revert security loader. Plan to be revised

## Summary by Sourcery

Revert the Airplane Mode security loader integration and return to direct polkit authorization.

Enhancements:
- Revert the Airplane Mode security-loader caller registry and restore direct polkit authorization checks.

Chores:
- Remove the Airplane Mode allow-caller D-Bus method and its associated bus-policy permissions and session-daemon registration.