### PR TITLE
fix: resolve authorization popup issue for apps not adapted to secure boot

### DIFF
--- a/misc/polkit-action/org.deepin.dde.airplane.policy
+++ b/misc/polkit-action/org.deepin.dde.airplane.policy
@@ -12,7 +12,7 @@
     <defaults>
       <allow_any>no</allow_any>
       <allow_inactive>no</allow_inactive>
-      <allow_active>auth_admin_keep</allow_active>
+      <allow_active>yes</allow_active>
     </defaults>
   </action>
 

--- a/misc/polkit-action/org.deepin.dde.power.policy
+++ b/misc/polkit-action/org.deepin.dde.power.policy
@@ -10,7 +10,7 @@
                 <defaults>
                         <allow_any>no</allow_any>
                         <allow_inactive>no</allow_inactive>
-                        <allow_active>auth_admin_keep</allow_active>
+                        <allow_active>yes</allow_active>
                 </defaults>
                 <description xml:lang="en_US">Check Authentication</description>
                 <message xml:lang="en_US">Authentication is required to perform this action</message>


### PR DESCRIPTION
fix: resolve authorization popup issue for apps not adapted to secure boot

The relevant interfaces have been integrated with secure boot checks. For apps
not adapted to secure boot, the call falls back to polkit authentication, which
prompts an authorization dialog. However, the taskbar and shortcut daemon were
not adapted to secure boot due to project architecture limitations, causing
authorization popups on normal operations like toggling airplane mode and power
mode. This degrades UX for local users.

Note: The current polkit policy is a fallback. Before secure boot was added,
this was the existing policy. Since the taskbar plugin and shortcut daemon call
these interfaces and are not adapted to secure boot, the interface behavior is
temporarily reverted to the old policy to avoid affecting user experience.

Future plan: The security design will be re-evaluated to develop a
security interface implementation plan that fits the V25 architecture.

Log: Authorization popup no longer appears for local users toggling airplane
and power modes via taskbar or shortcuts

Influence:
1. Verify local active users can toggle airplane mode via shortcut without
   auth dialog
2. Verify local active users can toggle power mode via taskbar plugin without
   auth dialog
3. Verify inactive users (e.g., SSH/VNC) are still blocked
4. Ensure no other polkit policies are affected

涉及接口已加入安全启动校验。对于未适配安全启动的应用，则 fallback 到
polkit 鉴权，polkit 会弹出提权弹窗。但任务栏和快捷键因项目架构限制未适配
安全启动，导致触发设置飞行模式和电源模式等常规操作时弹出授权弹窗。
如果是本地用户，影响用户体验。

目前的 polkit 策略是一个回退，在加 security-loader 之前就是这样的策略。
当前由于任务栏插件、快捷键中有相关接口的调用，且未适配安全启动，为了不
影响用户体验，先将接口的行为暂时回退到旧的策略。

后续计划：后续会重新评估安全方案的整体设计，制定更契合 V25 架构的安全
接口的实施方案。

Log: 本地用户通过任务栏/快捷键切换飞行模式和电源模式不再弹出授权弹窗

Influence:
1. 测试本地激活用户使用快捷键切换飞行模式，不应弹出授权弹窗
2. 测试本地激活用户通过任务栏插件切换电源模式，不应弹出授权弹窗
3. 验证非激活用户（如 SSH/VNC 会话）仍无法执行这些操作
4. 确认不影响其他 polkit 策略

PMS: TASK-393313


## Summary by Sourcery

Bug Fixes:
- Allow active local users to toggle airplane and power modes without polkit authorization prompts while retaining restrictions for inactive users.

## Summary by Sourcery

Bug Fixes:
- Allow active local users to toggle airplane and power modes without authorization prompts while retaining restrictions for inactive users.