### PR TITLE
fix: do not stop dde-daemon service on upgrade

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -61,7 +61,7 @@ override_dh_auto_install:
 endif
 
 override_dh_installsystemd:
-	dh_installsystemd --no-start
+	dh_installsystemd --no-start --no-stop-on-upgrade
 
 override_dh_auto_clean:
 	dh_auto_clean --


### PR DESCRIPTION
When upgrading the dde-daemon package, the service should not be stopped to avoid compatibility issues. Added `--no-stop-on-upgrade` option to `dh_installsystemd` to prevent service interruption during upgrades.

Log: Fixed service stopping during dde-daemon upgrade

Influence:
1. Verify that dde-daemon is not stopped during package upgrade
2. Check that the service remains functional after upgrade
3. Test upgrade from previous version to new version
4. Confirm no compatibility issues arise from service restart

fix: 升级dde-daemon时不停止服务

升级dde-daemon软件包时不应停止服务，以避免兼容性问题。为
`dh_installsystemd`添加`--no-stop-on-upgrade`选项，防止升级过程中服务 中断。

Log: 修复升级dde-daemon时服务被停止的问题

Influence:
1. 验证软件包升级过程中dde-daemon服务不会被停止
2. 确认升级后服务仍然正常运行
3. 测试从旧版本升级到新版本的过程
4. 确保不会因重启服务引发兼容性问题

PMS: TASK-393313

## Summary by Sourcery

Keep dde-daemon running while upgrading its package.

Bug Fixes:
- Prevent stopping the dde-daemon service during package upgrades to maintain service availability and avoid upgrade-related compatibility issues.

Build:
- Update Debian packaging to preserve dde-daemon service continuity during upgrades.