### PR TITLE
fix(inputdevices): fsync udev rule and rebuild on boot for touchpad

### DIFF
--- a/system/inputdevices1/inputdevices.go
+++ b/system/inputdevices1/inputdevices.go
@@ -97,7 +97,12 @@ func (m *InputDevices) init() {
 			logger.Warning(err)
 			return
 		}
-		err = m.touchpad.setTouchpadEnable(v.Value().(bool))
+		enabled := v.Value().(bool)
+		// 启动恢复：直接根据 dconfig 重建 udev 规则文件。
+		// 不调用 setTouchpadEnable，因为 newTouchpad 已将 Enable 设为 dconfig 值，
+		// setPropEnable 会判定 changed=false 从而跳过 udev 写入，
+		// 导致强制关机后 udev 规则文件丢失但无法重建。
+		err = m.touchpad.setTouchpadEnableViaUdev(enabled)
 		if err != nil {
 			logger.Warning(err)
 		}

--- a/system/inputdevices1/touchpad.go
+++ b/system/inputdevices1/touchpad.go
@@ -154,8 +154,24 @@ func (t *Touchpad) setTouchpadEnableViaUdev(enabled bool) error {
 			return nil
 		}
 
-		// 创建或覆盖 udev 规则文件
-		if err := os.WriteFile(udevRuleFile, []byte(udevRuleContent), 0644); err != nil {
+		// 创建或覆盖 udev 规则文件，使用 fsync 确保落盘，
+		// 防止强制关机（断电）时 page cache 丢失导致规则文件丢失
+		f, err := os.Create(udevRuleFile)
+		if err != nil {
+			return err
+		}
+		_, err = f.Write([]byte(udevRuleContent))
+		if err != nil {
+			f.Close()
+			return err
+		}
+		err = f.Sync()
+		if err != nil {
+			f.Close()
+			return err
+		}
+		err = f.Close()
+		if err != nil {
 			return err
 		}
 		logger.Info("created udev rule file:", udevRuleFile)


### PR DESCRIPTION
1. Replace os.WriteFile with os.Create + f.Sync() to ensure the udev rule file is flushed to disk before close
2. On startup, call setTouchpadEnableViaUdev directly instead of setTouchpadEnable to avoid skipped udev rebuild when changed=false due to pre-initialized Enable field
3. Prevents touchpad disable state loss after forced power-off

Log: fix touchpad disabled state lost after forced power-off because udev rule file write was not fsynced and startup rebuild was skipped by changed=false check

Influence:
1. Disable touchpad, force power off, reboot and verify it stays disabled
2. Disable touchpad, normal reboot and verify it stays disabled
3. Enable touchpad, force power off, reboot and verify it stays enabled

fix(inputdevices): 修复强制关机后触控板禁用状态丢失

1. 将 os.WriteFile 改为 os.Create + f.Sync() 确保写入 udev 规则文件时强制刷盘，防止断电丢失
2. 启动恢复时直接调用 setTouchpadEnableViaUdev 重建 udev 规 则，避免 changed=false 导致跳过写入
3. 修复强制关机后触控板禁用失效的问题

Log: 修复强制关机后触控板禁用状态丢失，原因是 udev 规则文件
写入未调用 fsync 导致断电丢失，且启动恢复逻辑因 changed=false
跳过了 udev 规则重建

Influence:
1. 禁用触控板后强制关机，重启后确认触控板仍为禁用状态
2. 禁用触控板后正常重启，确认触控板仍为禁用状态
3. 启用触控板后强制关机，重启后确认触控板仍为启用状态

PMS: BUG-374789

## Summary by Sourcery

Ensure touchpad state survives forced power-offs by reliably persisting and rebuilding its udev configuration.

Bug Fixes:
- Preserve the touchpad enabled or disabled state across forced power-offs and reboots by reliably persisting and restoring its udev rule.

Enhancements:
- Ensure touchpad udev rule updates are flushed to disk before completion and rebuild the rule directly from the configured state during startup.