### PR TITLE
feat(accounts1): support autologin configuration for DDM

### DIFF
--- a/accounts1/user.go
+++ b/accounts1/user.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2018 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -780,7 +780,12 @@ func loadUserConfigInfo(u *User) {
 	var isSave = false
 	xSession, _ := kf.GetString(confGroupUser, confKeyXSession)
 	u.XSession = xSession
-	if u.XSession == "" {
+	if dm, _ := users.GetDefaultDM(); dm == "ddm" {
+		if u.XSession != "treeland" {
+			u.XSession = "treeland"
+			isSave = true
+		}
+	} else if u.XSession == "" {
 		xSession, _ = users.GetDefaultXSession()
 		u.XSession = xSession
 		isSave = true

--- a/accounts1/users/display_manager.go
+++ b/accounts1/users/display_manager.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2018 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -26,6 +26,7 @@ const (
 	gdmConfig             = "/etc/gdm/custom.conf"
 	sddmConfig            = "/etc/sddm.conf"
 	lxdmConfig            = "/etc/lxdm/lxdm.conf"
+	ddmConfig             = "/etc/ddm.conf"
 
 	kfGroupLightdmSeat            = "Seat:*"
 	kfKeyLightdmAutoLoginUser     = "autologin-user"
@@ -42,6 +43,9 @@ const (
 	kfKeySDDMSession              = "Session"
 	kfGroupLXDMBase               = "base"
 	kfKeyLXDMAutologin            = "autologin"
+	kfGroupDDMAutologin           = "Autologin"
+	kfKeyDDMUser                  = "User"
+	kfKeyDDMSession               = "Session"
 
 	// values: 'yes', 'no'
 	slimKeyAutoLogin   = "auto_login"
@@ -116,6 +120,15 @@ func SetAutoLoginUser(username, session string) error {
 		}
 		return setIniKeys(sddmConfig, kfGroupSDDMAutologin,
 			keys, values)
+	case "ddm":
+		keys := []string{kfKeyDDMUser}
+		values := []string{username}
+		if session != "" {
+			keys = append(keys, kfKeyDDMSession)
+			values = append(values, session)
+		}
+		return setIniKeys(ddmConfig, kfGroupDDMAutologin,
+			keys, values)
 	case "lxdm":
 		keys := []string{kfKeySDDMUser}
 		values := []string{username}
@@ -159,6 +172,9 @@ func GetAutoLoginUser() (string, error) {
 	case "sddm":
 		return getIniKeys(sddmConfig, kfGroupSDDMAutologin,
 			[]string{kfKeySDDMUser}, []string{""})
+	case "ddm":
+		return getIniKeys(ddmConfig, kfGroupDDMAutologin,
+			[]string{kfKeyDDMUser}, []string{""})
 	case "lxdm":
 		return getIniKeys(lxdmConfig, kfGroupLXDMBase,
 			[]string{kfKeyLXDMAutologin}, []string{""})
@@ -322,6 +338,8 @@ func GetDefaultXSession() (string, error) {
 			return "", err
 		}
 		return strings.TrimRight(v, ".desktop"), nil
+	case "ddm":
+		return "treeland", nil
 	case "lxdm":
 		// TODO: the session value is the binary file path
 		// such as: session=/usr/bin/startlxde
@@ -347,6 +365,8 @@ func GetDMConfig() (string, error) {
 		return kdmConfig, nil
 	case "gdm", "gdm3":
 		return gdmConfig, nil
+	case "ddm":
+		return ddmConfig, nil
 	}
 	return "", fmt.Errorf("Not supported the display manager: %q", dm)
 }
@@ -442,6 +462,18 @@ func setIniKeys(filename, group string, keys, values []string) error {
 	return err
 }
 
+// GetDefaultDM return the current display manager name
+func GetDefaultDM() (string, error) {
+	dm, err := getDefaultDM(defaultDMFile)
+	if err != nil {
+		dm, err = getDMFromSystemService(defaultDisplayService)
+		if err != nil {
+			return "", err
+		}
+	}
+	return dm, nil
+}
+
 // Default config: /etc/X11/default-display-manager
 func getDefaultDM(file string) (string, error) {
 	if !dutils.IsFileExist(file) {
@@ -482,6 +514,8 @@ func getDMFromSystemService(service string) (string, error) {
 		return "lightdm", nil
 	case base == "gdm.service" || base == "gdm3.service":
 		return "gdm", nil
+	case base == "ddm.service":
+		return "ddm", nil
 	}
 	return "", fmt.Errorf("Unsupported the login manager: %s", base)
 }

--- a/accounts1/users/display_manager.org
+++ b/accounts1/users/display_manager.org
@@ -28,6 +28,13 @@
 **XSession**: =Autologin/Session=
 
 
+** DDM
+
+**Config**: =/etc/ddm.conf=
+**Autologin**: =Autologin/User=
+**XSession**: =Autologin/Session=
+
+
 ** Slim
 
 **Config**: =/etc/slim.conf=

--- a/accounts1/users/testdata/autologin/ddm.conf
+++ b/accounts1/users/testdata/autologin/ddm.conf
@@ -1,0 +1,3 @@
+[Autologin]
+#User=wen
+Session=treeland.desktop

--- a/accounts1/users/testdata/autologin/ddm.service
+++ b/accounts1/users/testdata/autologin/ddm.service
@@ -1,0 +1,1 @@
+./ddmdir/ddm.service

--- a/accounts1/users/testdata/autologin/ddm_autologin.conf
+++ b/accounts1/users/testdata/autologin/ddm_autologin.conf
@@ -1,0 +1,3 @@
+[Autologin]
+User=wen
+Session=treeland.desktop

--- a/accounts1/users/testdata/autologin/ddmdir/ddm.service
+++ b/accounts1/users/testdata/autologin/ddmdir/ddm.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Deepin Display Manager
+
+[Service]
+ExecStart=/usr/bin/ddm
+
+[Install]
+Alias=display-manager.service

--- a/accounts1/users/users_test.go
+++ b/accounts1/users/users_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2018 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -168,6 +168,18 @@ func TestGetAutoLoginUser(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, name, "")
 
+	// ddm
+	name, err = getIniKeys("testdata/autologin/ddm_autologin.conf",
+		kfGroupDDMAutologin,
+		[]string{kfKeyDDMUser}, []string{""})
+	assert.NoError(t, err)
+	assert.Equal(t, name, "wen")
+	name, err = getIniKeys("testdata/autologin/ddm.conf",
+		kfGroupDDMAutologin,
+		[]string{kfKeyDDMUser}, []string{""})
+	assert.NoError(t, err)
+	assert.Equal(t, name, "")
+
 	// lxdm
 	name, err = getIniKeys("testdata/autologin/lxdm_autologin.conf",
 		kfGroupLXDMBase,
@@ -209,6 +221,9 @@ func Test_XSession(t *testing.T) {
 	session, _ = getIniKeys("testdata/autologin/sddm.conf", kfGroupSDDMAutologin,
 		[]string{kfKeySDDMSession}, []string{""})
 	assert.Equal(t, session, "kde-plasma.desktop")
+	session, _ = getIniKeys("testdata/autologin/ddm.conf", kfGroupDDMAutologin,
+		[]string{kfKeyDDMSession}, []string{""})
+	assert.Equal(t, session, "treeland.desktop")
 }
 
 func Test_WriteStrvData(t *testing.T) {
@@ -278,6 +293,9 @@ func Test_GetAdmGroup(t *testing.T) {
 func Test_DMFromService(t *testing.T) {
 	dm, _ := getDMFromSystemService("testdata/autologin/display-manager.service")
 	assert.Equal(t, dm, "lightdm")
+
+	dm, _ = getDMFromSystemService("testdata/autologin/ddm.service")
+	assert.Equal(t, dm, "ddm")
 }
 
 func Test_IsPasswordExpired(t *testing.T) {


### PR DESCRIPTION
Add DDM support to the accounts module, so the autologin setting is persisted to /etc/ddm.conf and the default session is forced to treeland when DDM is active.

为账户模块增加DDM适配，自动登录配置写入 /etc/ddm.conf，并
在DDM下强制默认会话为treeland。

Log: 适配DDM自动登录配置
PMS: BUG-294419
Influence: DDM环境下自动登录配置生效，默认会话固定为treeland。

## Summary by Sourcery

Support DDM account integration by persisting autologin settings and enforcing treeland as the default session.

New Features:
- Add account-module support for DDM autologin users and sessions through /etc/ddm.conf.

Bug Fixes:
- Ensure DDM environments use treeland as the default session.

Enhancements:
- Detect DDM from the configured display manager or system service and expose its configuration path.

Tests:
- Add coverage and fixtures for DDM autologin configuration, session handling, and service detection.