### PR TITLE
fix: keep Type=forking behavior in dde-session-daemon-loader-wrapper

### DIFF
--- a/misc/scripts/dde-session-daemon-loader-wrapper
+++ b/misc/scripts/dde-session-daemon-loader-wrapper
@@ -14,4 +14,5 @@ if [ -x "$LOADER" ] && [ -x "$LOADER_EXEC" ] && \
     exec "$LOADER" --group deepin-daemon -- "$REAL_BINARY" "$@"
 fi
 logger -t dde-session-daemon "starting directly"
-exec "$REAL_BINARY" "$@"
+"$REAL_BINARY" "$@" &
+exit 0


### PR DESCRIPTION
The systemd service was changed to `Type=forking` in https://github.com/linuxdeepin/dde-daemon/commit/ee600cd3994ce25b575ba737cba481ec9d7266bf, but https://github.com/linuxdeepin/dde-daemon/commit/1f4a4415f624924f33625c225e4423a21d071ce4 changed the wrapper back to directly exec the original daemon, which hangs the systemd service indefinitely on Arch since we don't have deepin-security-loader.

Let's revert to the fork-like behavior to fix this.

## Summary by Sourcery

Bug Fixes:
- Restore fork-like wrapper behavior so the Type=forking systemd service can start correctly without deepin-security-loader.