### PR TITLE
fix(grub2): harden SetBackgroundSourceFile with fd passing

### DIFF
--- a/grub2/exported_methods_auto.go
+++ b/grub2/exported_methods_auto.go
@@ -81,7 +81,7 @@ func (v *Theme) GetExportedMethods() dbusutil.ExportedMethods {
 		{
 			Name:   "SetBackgroundSourceFile",
 			Fn:     v.SetBackgroundSourceFile,
-			InArgs: []string{"filename"},
+			InArgs: []string{"fd"},
 		},
 	}
 }

--- a/grub2/theme_ifc.go
+++ b/grub2/theme_ifc.go
@@ -5,6 +5,8 @@
 package grub2
 
 import (
+	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -13,34 +15,42 @@ import (
 
 	"github.com/godbus/dbus/v5"
 	"github.com/linuxdeepin/go-lib/dbusutil"
-	"github.com/linuxdeepin/go-lib/utils"
 )
 
 const (
 	themeDBusPath            = dbusPath + "/Theme"
 	themeDBusInterface       = dbusInterface + ".Theme"
 	grubBackgroundRuntimeDir = "/run/deepin-grub2"
+
+	// maxBackgroundSourceSize 限制通过 dbus fd 传入的壁纸源文件大小，避免资源耗尽
+	maxBackgroundSourceSize = 32 * 1024 * 1024
 )
 
 func (*Theme) GetInterfaceName() string {
 	return themeDBusInterface
 }
 
-func (theme *Theme) SetBackgroundSourceFile(sender dbus.Sender, filename string) *dbus.Error {
+func (theme *Theme) SetBackgroundSourceFile(sender dbus.Sender, fd dbus.UnixFD) *dbus.Error {
 	err := checkInvokePermission(theme.service, sender)
 	if err != nil {
 		return dbusutil.ToError(err)
 	}
 	theme.service.DelayAutoQuit()
 
-	logger.Debugf("SetBackgroundSourceFile: %q", filename)
+	logger.Debugf("SetBackgroundSourceFile: fd %d", fd)
 	err = theme.g.checkAuth(sender, polikitActionIdCommon)
 	if err != nil {
 		return dbusutil.ToError(err)
 	}
 
-	filename = utils.DecodeURI(filename)
-	cmd := exec.Command(adjustThemeCmd, "-set-background", filename)
+	tempPath, err := writeBackgroundSourceToTemp(fd)
+	if err != nil {
+		logger.Warning(err)
+		return dbusutil.ToError(err)
+	}
+	defer os.Remove(tempPath)
+
+	cmd := exec.Command(adjustThemeCmd, "-set-background", tempPath)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	err = cmd.Run()
@@ -50,6 +60,60 @@ func (theme *Theme) SetBackgroundSourceFile(sender dbus.Sender, filename string)
 	}
 	theme.emitSignalBackgroundChanged()
 	return nil
+}
+
+// writeBackgroundSourceToTemp 将 dbus fd 中的壁纸源文件内容写入运行时目录下的临时文件，
+// 并返回临时文件路径。调用方使用完后应删除返回的文件；fd 在读取后被关闭。
+func writeBackgroundSourceToTemp(fd dbus.UnixFD) (string, error) {
+	if fd < 0 {
+		return "", errors.New("invalid background source fd")
+	}
+	f := os.NewFile(uintptr(fd), "background-source")
+	if f == nil {
+		return "", errors.New("invalid background source fd")
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return "", err
+	}
+	if !info.Mode().IsRegular() {
+		return "", errors.New("background source is not a regular file")
+	}
+	if info.Size() > maxBackgroundSourceSize {
+		return "", fmt.Errorf("file size %d > %d", info.Size(), maxBackgroundSourceSize)
+	}
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return "", err
+	}
+
+	tempFile, err := os.CreateTemp(grubBackgroundRuntimeDir, ".background-source-*")
+	if err != nil {
+		return "", err
+	}
+	tempPath := tempFile.Name()
+	removeTemp := true
+	defer func() {
+		if removeTemp {
+			_ = os.Remove(tempPath)
+		}
+	}()
+
+	n, err := io.Copy(tempFile, io.LimitReader(f, maxBackgroundSourceSize+1))
+	if err != nil {
+		_ = tempFile.Close()
+		return "", err
+	}
+	if n > maxBackgroundSourceSize {
+		_ = tempFile.Close()
+		return "", fmt.Errorf("file size %d > %d", n, maxBackgroundSourceSize)
+	}
+	if err := tempFile.Close(); err != nil {
+		return "", err
+	}
+	removeTemp = false
+	return tempPath, nil
 }
 
 func (theme *Theme) GetBackground(sender dbus.Sender) (background string, busErr *dbus.Error) {

--- a/misc/systemd/services/system/deepin-grub2.service
+++ b/misc/systemd/services/system/deepin-grub2.service
@@ -29,13 +29,13 @@ ReadWritePaths=-/etc/grub.d
 ReadWritePaths=-/boot
 
 NoNewPrivileges=yes
-# 允许只读访问 /home 以读取 .Xauthority 文件
-ProtectHome=read-only
+# 壁纸源文件通过 dbus fd 传入，服务无需访问 /home
+ProtectHome=yes
 ProtectKernelTunables=yes
 ProtectKernelModules=yes
 ProtectControlGroups=yes
 PrivateMounts=yes
-#PrivateTmp=yes
+PrivateTmp=yes
 # /usr/sbin/grub-probe需要使用
 #PrivateDevices=yes
 PrivateNetwork=yes


### PR DESCRIPTION
1. Pass D-Bus UnixFD instead of file path to SetBackgroundSourceFile
2. Validate fd is a regular file within 32MiB and stage content under /run/deepin-grub2 before handing the temp path to adjust-grub-theme
3. Harden deepin-grub2.service with ProtectHome=yes and PrivateTmp=yes

Log: Pass UnixFD instead of file path to SetBackgroundSourceFile and harden deepin-grub2.service (ProtectHome=yes, PrivateTmp=yes)

Influence:
1. Verify grub2 theme background can still be customized via SetBackgroundSourceFile with an open file descriptor
2. Verify large (over 32MiB) or non-regular-file fd inputs are rejected
3. Verify deepin-grub2.service unit passes systemd filesystem sandbox security checks with ProtectHome=yes and PrivateTmp=yes

fix(grub2): SetBackgroundSourceFile 改为接收 fd 并强化服务沙箱

1. SetBackgroundSourceFile 参数由文件路径改为 D-Bus UnixFD
2. 校验 fd 为不超过 32MiB 的常规文件，内容暂存 /run/deepin-grub2 后将临时路径交给 adjust-grub-theme
3. 强化 deepin-grub2.service：ProtectHome=yes、PrivateTmp=yes

Log: SetBackgroundSourceFile 改为传递 UnixFD 并强化
deepin-grub2.service 沙箱（ProtectHome=yes、PrivateTmp=yes）

Influence:
1. 验证通过 SetBackgroundSourceFile 传入打开的文件描述符仍可正常 自定义 grub2 主题背景
2. 验证超过 32MiB 或非常规文件的 fd 输入被正确拒绝
3. 验证 deepin-grub2.service 通过 systemd 文件系统沙箱安全检查 （ProtectHome=yes、PrivateTmp=yes）

PMS: BUG-376055

## Summary by Sourcery

Harden GRUB2 background updates by replacing path-based input with validated Unix file descriptors and tightening service sandboxing.

Bug Fixes:
- Harden background customization by accepting only validated regular files up to 32 MiB through SetBackgroundSourceFile and staging their contents for theme updates.

Enhancements:
- Change SetBackgroundSourceFile to receive a D-Bus Unix file descriptor instead of a file path.

Deployment:
- Strengthen deepin-grub2.service filesystem sandboxing with ProtectHome=yes and PrivateTmp=yes.