### PR TITLE
feat: tiered camera disable hotkey with hardware persistence

### DIFF
--- a/bin/dde-system-daemon/camera_privacy.go
+++ b/bin/dde-system-daemon/camera_privacy.go
@@ -1,0 +1,628 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"unsafe"
+
+	"github.com/godbus/dbus/v5"
+	"github.com/linuxdeepin/dde-daemon/common/dconfig"
+	"github.com/linuxdeepin/dde-daemon/securityloader"
+	"github.com/linuxdeepin/go-lib/dbusutil"
+	"golang.org/x/sys/unix"
+)
+
+// V4L2 ioctl constants derived from <linux/videodev2.h> /
+// <linux/v4l2-controls.h>. Verified empirically against the kernel UAPI.
+const (
+	// V4L2_CID_CAMERA_PRIVACY = V4L2_CID_CAMERA_CLASS_BASE(0x9a0900) + 16
+	v4l2CtrlIDPrivacy = 0x9a0910
+	// VIDIOC_G_CTRL      _IOWR('V', 27, struct v4l2_control)
+	vidIocGCTRL = 0xc008561b
+	// VIDIOC_S_CTRL      _IOWR('V', 28, struct v4l2_control)
+	vidIocSCTRL = 0xc008561c
+	// VIDIOC_QUERYCTRL   _IOWR('V', 36, struct v4l2_queryctrl)
+	vidIocQueryCtrl = 0xc0445624
+)
+
+// struct v4l2_control { __u32 id; __s32 value; }
+type v4l2Ctrl struct {
+	ID    uint32
+	Value int32
+}
+
+// struct v4l2_queryctrl (fields needed for probing):
+// { __u32 id; __u32 type; char name[32]; __s32 min/max/step/default_value;
+//
+//	__u32 flags; __u32 reserved[2]; }
+type v4l2QueryCtrl struct {
+	ID       uint32
+	CtrlType uint32
+	Name     [32]uint8
+	Minimum  int32
+	Maximum  int32
+	Step     int32
+	Default  int32
+	Flags    uint32
+	Reserved [2]uint32
+}
+
+// sysfs paths, overridable in tests.
+var (
+	usbDevicesRoot = "/sys/bus/usb/devices"
+	v4lClassPath   = "/sys/class/video4linux"
+	uvcDriverPath  = "/sys/bus/usb/drivers/uvcvideo"
+	// sysfsRoot is the mount point DEVPATH-based uevent prechecks resolve
+	// against (kernel DEVPATH values are relative to it). Overridable in tests.
+	sysfsRoot = "/sys"
+)
+
+const usbIfaceClassVID = "0e"
+
+// dconfig key persisting the camera privacy switch so it survives daemon
+// restart and is reapplied on hotplug.
+const dsKeyCameraPrivacyEnabled = "cameraPrivacyEnabled"
+
+var (
+	cameraDConfig   *dconfig.DConfig
+	cameraPrivacyMu sync.Mutex
+	cameraOpMu      sync.Mutex
+	cameraPrivacyOn bool
+)
+
+// 说明:本模块是相机禁用快捷键的底层实现,负责识别摄像头并通过硬件
+// 手段开关它。
+//
+// 识别信号来自内核 uevent(原生 netlink 监听):设备插入后,内核先广播
+// usb_device add 事件(此时接口信息可能还没生成,只作兜底);uvcvideo
+// 驱动完成 probe、注册 /dev/videoN 节点后,再广播 video4linux add 事件
+// (此时设备一定可读,是可靠的识别信号)。
+//
+// 收到事件后按优先级尝试两种关闭方式:
+//  1. 优先用摄像头自带的 V4L2_CID_CAMERA_PRIVACY 控制(部分摄像头
+//     硬件支持的物理遮挡开关),通过 ioctl 设置;
+//  2. 不支持该控制的,按 USB 接口类 0e(视频类)找出摄像头接口,写
+//     uvcvideo 驱动的 unbind 关闭、bind 恢复。同设备的音频接口类不是
+//     0e,不受影响,内置麦克风可正常使用。
+//
+// 采集卡、U 盘等设备没有 0e 接口,不会被误操作。切换硬件状态和保存
+// 配置都在同一把锁内完成,热插拔触发的重新关闭会先重新读取开关状态,
+// 不会把用户刚切换的状态覆盖回去。
+//
+// initCameraPrivacy loads the persisted switch state, re-applies it to any
+// camera currently present, and starts a uevent watcher so that a camera
+// plugged in later is switched off again while the switch is on. It must
+// be called once after the system daemon's dconfig is ready.
+func initCameraPrivacy() {
+	dc, err := dconfig.NewDConfig(dsettingsSystemDaemonID, dsettingsSystemDaemonName, "")
+	if err != nil {
+		logger.Warning("initCameraPrivacy: new dconfig failed:", err)
+		return
+	}
+	cameraDConfig = dc
+
+	on, err := dc.GetValueBool(dsKeyCameraPrivacyEnabled)
+	if err != nil {
+		logger.Warning("initCameraPrivacy: read dconfig failed:", err)
+	}
+	cameraPrivacyMu.Lock()
+	cameraPrivacyOn = on
+	cameraPrivacyMu.Unlock()
+
+	// Re-apply the persisted state to cameras present at startup.
+	if on {
+		if _, err := setCameraPrivacy(true); err != nil {
+			logger.Warning("initCameraPrivacy: re-apply failed:", err)
+		}
+	}
+
+	// Watch for camera hotplug with a raw netlink uevent monitor. gudev
+	// cannot be used here: its "uevent" signal is dispatched by the GLib
+	// main loop, which dde-system-daemon does not run (verified on a real
+	// machine: the netlink socket fills up and is never read). Subscribing
+	// to the kernel broadcast group directly keeps the same event source
+	// without a GLib dependency. A video4linux "add" uevent is emitted by
+	// video_register_device() after /dev/videoN is created, so both privacy
+	// tiers see a fully populated device; the usb_device "add" fallback
+	// covers cameras that bypass the video4linux event path.
+	if err := startCameraUeventMonitor(); err != nil {
+		logger.Warning("initCameraPrivacy: start uevent monitor failed:", err)
+		return
+	}
+	logger.Info("initCameraPrivacy: uevent monitor started, privacy on=", on)
+}
+
+// startCameraUeventMonitor joins the kernel uevent broadcast group and reads
+// it on a dedicated goroutine. The socket is non-blocking friendly via
+// blocking reads: the goroutine lives for the process lifetime.
+func startCameraUeventMonitor() error {
+	fd, err := unix.Socket(unix.AF_NETLINK, unix.SOCK_RAW, unix.NETLINK_KOBJECT_UEVENT)
+	if err != nil {
+		return fmt.Errorf("socket: %w", err)
+	}
+	addr := &unix.SockaddrNetlink{Family: unix.AF_NETLINK, Groups: 1}
+	if err := unix.Bind(fd, addr); err != nil {
+		unix.Close(fd)
+		return fmt.Errorf("bind: %w", err)
+	}
+	go cameraUeventLoop(fd)
+	return nil
+}
+
+// cameraUeventLoop reads raw uevent messages until the process exits. The
+// kernel payload is "ACTION@DEVPATH\0KEY=VALUE\0KEY=VALUE\0..."; parse
+// ACTION, SUBSYSTEM and DEVTYPE from it and re-apply privacy when a camera
+// became usable.
+func cameraUeventLoop(fd int) {
+	defer unix.Close(fd)
+	buf := make([]byte, 8192)
+	for {
+		n, _, err := unix.Recvfrom(fd, buf, 0)
+		if err != nil {
+			if err == unix.EINTR {
+				continue
+			}
+			logger.Warningf("cameraUeventLoop: recvfrom failed: %v", err)
+			return
+		}
+		msg := parseUevent(buf[:n])
+		if !shouldReapplyCamera(msg.action, msg.subsystem, msg.devtype, msg.devpath) {
+			logger.Debugf("handleCameraUEvent: ignore uevent action=%q subsystem=%q devtype=%q",
+				msg.action, msg.subsystem, msg.devtype)
+			continue
+		}
+		logger.Infof("handleCameraUEvent: camera event action=%q subsystem=%q devtype=%q, re-apply privacy",
+			msg.action, msg.subsystem, msg.devtype)
+		reapplyCameraPrivacy()
+	}
+}
+
+// ueventMsg holds the fields the filter needs from a raw uevent payload.
+type ueventMsg struct {
+	action    string
+	subsystem string
+	devtype   string
+	devpath   string
+}
+
+// parseUevent extracts ACTION and DEVPATH (from the "ACTION@DEVPATH" header)
+// and the SUBSYSTEM/DEVTYPE environment keys of a netlink uevent message.
+// Keys are NUL-separated, per kobject_uevent_env().
+func parseUevent(payload []byte) ueventMsg {
+	var msg ueventMsg
+	fields := strings.Split(string(payload), "\x00")
+	if len(fields) == 0 {
+		return msg
+	}
+	header := fields[0]
+	if idx := strings.IndexByte(header, '@'); idx >= 0 {
+		msg.action = header[:idx]
+		msg.devpath = header[idx+1:]
+	}
+	for _, field := range fields[1:] {
+		switch {
+		case strings.HasPrefix(field, "SUBSYSTEM="):
+			msg.subsystem = strings.TrimPrefix(field, "SUBSYSTEM=")
+		case strings.HasPrefix(field, "DEVTYPE="):
+			msg.devtype = strings.TrimPrefix(field, "DEVTYPE=")
+		}
+	}
+	return msg
+}
+
+// usbDeviceHasVideoInterface reports whether the sysfs device directory at
+// devpath (a usb_device DEVPATH, e.g. /devices/.../usb1/1-4) contains an
+// interface with bInterfaceClass 0e (video). ok is false when the directory
+// or the interface attributes cannot be read — the caller must treat that
+// as "unknown", not "no", because at usb_device add time the interfaces may
+// not be created yet.
+func usbDeviceHasVideoInterface(devpath string) (found bool, ok bool) {
+	base := filepath.Join(sysfsRoot, devpath)
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		return false, false
+	}
+	sawInterface := false
+	for _, e := range entries {
+		if !strings.Contains(e.Name(), ":") {
+			continue
+		}
+		sawInterface = true
+		data, err := os.ReadFile(filepath.Join(base, e.Name(), "bInterfaceClass"))
+		if err != nil {
+			return false, false
+		}
+		if strings.TrimSpace(string(data)) == usbIfaceClassVID {
+			return true, true
+		}
+	}
+	return false, sawInterface
+}
+
+// shouldReapplyCamera reports whether a uevent means a camera may have
+// become usable. The reliable signal is a video4linux "add" uevent (emitted
+// by video_register_device() after the /dev/videoN node exists). usb_device
+// "add" is kept as a fallback: it arrives before the driver probe, so a
+// DEVPATH precheck filters out non-camera devices (flash drives, mice)
+// while keeping the reapply when the interfaces are not readable yet — the
+// precheck must never turn "unknown" into "no", that would break the
+// fallback for cameras whose interfaces are not populated at event time.
+func shouldReapplyCamera(action, subsystem, devtype, devpath string) bool {
+	if action != "add" {
+		return false
+	}
+	if subsystem == "video4linux" {
+		return true
+	}
+	if subsystem == "usb" && devtype == "usb_device" {
+		found, ok := usbDeviceHasVideoInterface(devpath)
+		return !ok || found
+	}
+	return false
+}
+
+// reapplyCameraPrivacy re-disables the camera when the privacy switch is on.
+// Called on hotplug and at startup. Idempotent: setCameraPrivacy(true)
+// unbinds every UVC video interface, so already-disabled cameras stay off.
+// The flag is re-checked inside the operation mutex: a uevent may arrive
+// while a concurrent SetCameraPrivacy(false) is waiting for the mutex, and
+// applying without re-checking would re-enable the camera the caller just
+// disabled.
+func reapplyCameraPrivacy() {
+	cameraOpMu.Lock()
+	defer cameraOpMu.Unlock()
+	cameraPrivacyMu.Lock()
+	on := cameraPrivacyOn
+	cameraPrivacyMu.Unlock()
+	if !on {
+		logger.Debug("reapplyCameraPrivacy: privacy off, skip")
+		return
+	}
+	logger.Info("reapplyCameraPrivacy: re-applying privacy on")
+	if _, err := setCameraPrivacy(true); err != nil {
+		logger.Warning("reapplyCameraPrivacy: re-apply failed:", err)
+	}
+}
+
+// setCameraPrivacyState persists and stores the privacy switch. Called by
+// SetCameraPrivacy after applying the hardware state.
+func setCameraPrivacyState(on bool) {
+	cameraPrivacyMu.Lock()
+	cameraPrivacyOn = on
+	cameraPrivacyMu.Unlock()
+	if cameraDConfig != nil {
+		if err := cameraDConfig.SetValue(dsKeyCameraPrivacyEnabled, on); err != nil {
+			logger.Warning("setCameraPrivacyState: persist failed:", err)
+		}
+	}
+}
+
+// setCameraPrivacyOp runs the hardware switch and the persist step under one
+// operation mutex. Concurrent D-Bus calls and hotplug reapplications must not
+// interleave bind/unbind writes or persist out of order: the mutex guarantees
+// the hardware state and the persisted flag come from the last requested
+// state, not from whichever caller finished last.
+func setCameraPrivacyOp(state bool) (bool, error) {
+	cameraOpMu.Lock()
+	defer cameraOpMu.Unlock()
+	applied, err := setCameraPrivacy(state)
+	if err != nil {
+		logger.Warningf("setCameraPrivacyOp: set to %v failed: %v", state, err)
+		return applied, err
+	}
+	setCameraPrivacyState(state)
+	logger.Infof("setCameraPrivacyOp: set to %v, applied=%v", state, applied)
+	return applied, nil
+}
+
+// setCameraPrivacy applies the requested privacy state with a tiered strategy:
+//  1. Standard V4L2 camera privacy control (V4L2_CID_CAMERA_PRIVACY) — the
+//     kernel/hardware privacy capability, no device list needed.
+//  2. uvcvideo driver unbind/bind at the video-interface level — removes
+//     /dev/video* while privacy is on without touching other interfaces on
+//     the same USB device, so a built-in mic (bound to snd-usb-audio) keeps
+//     working.
+func setCameraPrivacy(state bool) (bool, error) {
+	applied := false
+
+	devs, err := listVideoDevices()
+	if err != nil {
+		logger.Warningf("setCameraPrivacy: list video devices failed: %v", err)
+	}
+	if len(devs) == 0 {
+		logger.Debug("setCameraPrivacy: no V4L2 devices found")
+	}
+	for _, dev := range devs {
+		ok, err := setV4L2Privacy(dev, state)
+		if err != nil {
+			logger.Warningf("setCameraPrivacy: %s: %v", dev, err)
+		}
+		if ok {
+			applied = true
+		}
+	}
+	if applied {
+		return true, nil
+	}
+
+	ok, err := setUVCVideoUnbound(state)
+	if err != nil {
+		logger.Warningf("setCameraPrivacy: uvcvideo unbind switch failed: %v", err)
+		return false, err
+	}
+	return ok, nil
+}
+
+// listVideoDevices returns /dev/videoN paths backed by a UVC camera interface.
+func listVideoDevices() ([]string, error) {
+	entries, err := os.ReadDir(v4lClassPath)
+	if err != nil {
+		return nil, err
+	}
+	var devs []string
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasPrefix(name, "video") {
+			continue
+		}
+		devLink, err := os.Readlink(filepath.Join(v4lClassPath, name, "device"))
+		if err != nil {
+			continue
+		}
+		if ifaceClassOfLink(devLink) != usbIfaceClassVID {
+			continue
+		}
+		devs = append(devs, "/dev/"+name)
+	}
+	return devs, nil
+}
+
+// ifaceClassOfLink resolves a video4linux device symlink (e.g. "../../../1-7:1.0")
+// to its USB interface bInterfaceClass, "" when undeterminable.
+func ifaceClassOfLink(devLink string) string {
+	base := filepath.Base(devLink)
+	if !strings.Contains(base, ":") {
+		return ""
+	}
+	data, err := os.ReadFile(filepath.Join(usbDevicesRoot, base, "bInterfaceClass"))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+// setV4L2Privacy sets the camera privacy control on dev; ok is false when the
+// device does not expose V4L2_CID_CAMERA_PRIVACY.
+func setV4L2Privacy(dev string, state bool) (ok bool, err error) {
+	f, err := os.OpenFile(dev, os.O_RDWR, 0)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	if !v4l2HasControl(f.Fd(), v4l2CtrlIDPrivacy) {
+		return false, nil
+	}
+
+	val := int32(0)
+	if state {
+		val = 1
+	}
+	if err := v4l2SetControl(f.Fd(), v4l2CtrlIDPrivacy, val); err != nil {
+		return false, err
+	}
+	logger.Infof("setV4L2Privacy: privacy=%d on %s", val, dev)
+	return true, nil
+}
+
+func v4l2HasControl(fd uintptr, ctrlID uint32) bool {
+	qc := v4l2QueryCtrl{ID: ctrlID}
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, fd, vidIocQueryCtrl,
+		uintptr(unsafe.Pointer(&qc)))
+	return errno == 0
+}
+
+func v4l2SetControl(fd uintptr, ctrlID uint32, value int32) error {
+	ctrl := v4l2Ctrl{ID: ctrlID, Value: value}
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, fd, vidIocSCTRL,
+		uintptr(unsafe.Pointer(&ctrl)))
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+// setUVCVideoUnbound disables (privacy=true) or re-enables (privacy=false) the
+// camera by unbinding/binding the uvcvideo driver on every UVC video interface
+// (bInterfaceClass 0e). Because the operation is limited to the video
+// interface, a built-in mic on an audio interface of the same USB device stays
+// bound to snd-usb-audio and keeps working. Returns applied=false when no UVC
+// video interface is found.
+func setUVCVideoUnbound(privacy bool) (bool, error) {
+	ifaces, err := listUVCVideoInterfaces()
+	if err != nil {
+		return false, err
+	}
+	if len(ifaces) == 0 {
+		return false, nil
+	}
+
+	for _, iface := range ifaces {
+		var op string
+		if privacy {
+			op = "unbind"
+		} else {
+			op = "bind"
+		}
+		// Idempotence: an already-unbound interface must not be unbound
+		// again (the kernel returns -ENODEV), and a bound one not re-bound.
+		if op == "unbind" && !interfaceHasDriver(filepath.Join(usbDevicesRoot, iface)) {
+			continue
+		}
+		if op == "bind" && interfaceHasDriver(filepath.Join(usbDevicesRoot, iface)) {
+			continue
+		}
+		if err := writeDriverAttr(op, iface); err != nil {
+			// ENODEV is expected when unbinding a metadata interface (the
+			// second 0e-class interface) while the main video interface of
+			// the same camera tears the driver probe down concurrently:
+			// the driver symlink lags the kernel state for a moment. That
+			// interface is already effectively unbound, so demote to Debug.
+			if errors.Is(err, unix.ENODEV) || errors.Is(err, unix.ENOENT) {
+				logger.Debugf("setUVCVideoUnbound: %s %s: %v (already gone)", op, iface, err)
+			} else {
+				logger.Warningf("setUVCVideoUnbound: %s %s: %v", op, iface, err)
+			}
+			continue
+		}
+		logger.Infof("setUVCVideoUnbound: %s %s", op, iface)
+	}
+	return true, nil
+}
+
+// listUVCVideoInterfaces returns USB interface IDs (e.g. "1-7:1.0") whose
+// bInterfaceClass is 0e (video).
+func listUVCVideoInterfaces() ([]string, error) {
+	entries, err := os.ReadDir(usbDevicesRoot)
+	if err != nil {
+		return nil, err
+	}
+	var ifaces []string
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.Contains(name, ":") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(usbDevicesRoot, name, "bInterfaceClass"))
+		if err != nil {
+			continue
+		}
+		if strings.TrimSpace(string(data)) == usbIfaceClassVID {
+			ifaces = append(ifaces, name)
+		}
+	}
+	sort.Strings(ifaces)
+	return ifaces, nil
+}
+
+// writeDriverAttr writes iface (e.g. "1-7:1.0") to the uvcvideo driver's
+// bind/unbind attribute.
+var writeDriverAttr = func(op, iface string) error {
+	return os.WriteFile(filepath.Join(uvcDriverPath, op), []byte(iface), 0644)
+}
+
+// cameraPrivacy reports the current privacy state using the same tier order as
+// setCameraPrivacy: the V4L2 privacy control when available, otherwise the
+// uvcvideo driver binding state. known is false when no camera device can be
+// queried, letting the caller keep its own state.
+func cameraPrivacy() (privacy bool, known bool) {
+	devs, err := listVideoDevices()
+	if err != nil {
+		logger.Warningf("cameraPrivacy: list video devices failed: %v", err)
+	}
+	for _, dev := range devs {
+		on, ok := v4l2Privacy(dev)
+		if ok {
+			return on, true
+		}
+	}
+
+	ifaces, err := listUVCVideoInterfaces()
+	if err != nil {
+		logger.Warningf("cameraPrivacy: list uvc video interfaces failed: %v", err)
+		return false, false
+	}
+	for _, iface := range ifaces {
+		// When the uvcvideo driver is rebound the interface points at it and
+		// /dev/video* is back; when unbound the driver link is gone. An
+		// unbound video interface means privacy (camera off) is on.
+		return !interfaceHasDriver(filepath.Join(usbDevicesRoot, iface)), true
+	}
+	return false, false
+}
+
+// v4l2Privacy reads the camera privacy control on dev; ok is false when the
+// device does not expose V4L2_CID_CAMERA_PRIVACY.
+func v4l2Privacy(dev string) (privacy bool, ok bool) {
+	f, err := os.OpenFile(dev, os.O_RDWR, 0)
+	if err != nil {
+		return false, false
+	}
+	defer f.Close()
+
+	if !v4l2HasControl(f.Fd(), v4l2CtrlIDPrivacy) {
+		return false, false
+	}
+	val, err := v4l2GetControl(f.Fd(), v4l2CtrlIDPrivacy)
+	if err != nil {
+		logger.Warningf("v4l2Privacy: %s: %v", dev, err)
+		return false, false
+	}
+	return val != 0, true
+}
+
+func v4l2GetControl(fd uintptr, ctrlID uint32) (int32, error) {
+	ctrl := v4l2Ctrl{ID: ctrlID}
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, fd, vidIocGCTRL,
+		uintptr(unsafe.Pointer(&ctrl)))
+	if errno != 0 {
+		return 0, errno
+	}
+	return ctrl.Value, nil
+}
+
+// interfaceHasDriver reports whether the USB interface still has a driver
+// bound (its `driver` symlink resolves), i.e. it is not unbound.
+func interfaceHasDriver(ifaceDir string) bool {
+	_, err := os.Readlink(filepath.Join(ifaceDir, "driver"))
+	return err == nil
+}
+
+// authorize checks the caller via the security loader registry with a polkit
+// fallback for the given action id.
+func (d *Daemon) authorize(sender dbus.Sender, actionID string) error {
+	return securityloader.AuthorizeWithPolkit(
+		d.allowCallers,
+		securityloader.DaemonScope,
+		sender,
+		d.service.Conn(),
+		actionID,
+	)
+}
+
+// SetCameraPrivacy is the exported D-Bus method: authorizes the caller,
+// applies the tiered privacy switch and reports whether hardware switching
+// happened so the caller can fall back to app-level handling.
+func (d *Daemon) SetCameraPrivacy(sender dbus.Sender, state bool) (applied bool, busErr *dbus.Error) {
+	if err := d.authorize(sender, "org.deepin.dde.daemon.set-camera-privacy"); err != nil {
+		logger.Warningf("SetCameraPrivacy authorization failed: %q", err.Error())
+		return false, dbusutil.ToError(err)
+	}
+
+	logger.Infof("SetCameraPrivacy set state: %v", state)
+	applied, err := setCameraPrivacyOp(state)
+	if err != nil {
+		logger.Warningf("SetCameraPrivacy failed: %v", err)
+		return false, dbusutil.ToError(err)
+	}
+	return applied, nil
+}
+
+// GetCameraPrivacy is the exported D-Bus method reporting the current camera
+// privacy state. known is false when no camera device can be queried, so the
+// caller can fall back to its own tracking. Reading the state needs no
+// privileges, so no authorization is required.
+func (d *Daemon) GetCameraPrivacy() (privacy bool, known bool, busErr *dbus.Error) {
+	privacy, known = cameraPrivacy()
+	logger.Infof("GetCameraPrivacy privacy=%v known=%v", privacy, known)
+	return privacy, known, nil
+}

--- a/bin/dde-system-daemon/camera_privacy_test.go
+++ b/bin/dde-system-daemon/camera_privacy_test.go
@@ -1,0 +1,789 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// newCameraTestEnv builds an isolated sysfs tree for camera privacy tests.
+func newCameraTestEnv(t *testing.T) (usbRoot, v4lDir string) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	usbRoot = filepath.Join(tmpDir, "usb")
+	v4lDir = filepath.Join(tmpDir, "v4l")
+	for _, d := range []string{usbRoot, v4lDir} {
+		if err := os.MkdirAll(d, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return usbRoot, v4lDir
+}
+
+// restoreSysfsPaths restores the global sysfs path vars after each test.
+func restoreSysfsPaths(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		usbDevicesRoot = "/sys/bus/usb/devices"
+		v4lClassPath = "/sys/class/video4linux"
+		uvcDriverPath = "/sys/bus/usb/drivers/uvcvideo"
+	})
+}
+
+// addUSBDevice creates a USB device and its interface entries as siblings
+// directly under usbRoot, mirroring the real sysfs layout
+// (/sys/bus/usb/devices/1-7 and /sys/bus/usb/devices/1-7:1.0). Each interface
+// gets a bInterfaceClass; a "0e" (video) interface is bound to uvcvideo by
+// symlink so interfaceHasDriver() reports true until an unbind removes it.
+func addUSBDevice(t *testing.T, usbRoot, dev string, interfaces map[string]string) {
+	t.Helper()
+	devDir := filepath.Join(usbRoot, dev)
+	if err := os.MkdirAll(devDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	for iface, class := range interfaces {
+		addUVCInterface(t, usbRoot, iface, class)
+	}
+}
+
+// addUVCInterface creates a USB interface entry (e.g. "1-7:1.0") directly
+// under usbRoot with the given interface class.
+func addUVCInterface(t *testing.T, usbRoot, iface, class string) {
+	t.Helper()
+	ifaceDir := filepath.Join(usbRoot, iface)
+	if err := os.MkdirAll(ifaceDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(ifaceDir, "bInterfaceClass"), []byte(class+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if class == "0e" {
+		// Bound to uvcvideo by default.
+		if err := os.Symlink(filepath.Join("..", "drivers", "uvcvideo"),
+			filepath.Join(ifaceDir, "driver")); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// unbindUVCInterface simulates a successful uvcvideo unbind by removing the
+// driver symlink on the interface dir.
+func unbindUVCInterface(t *testing.T, usbRoot, iface string) {
+	t.Helper()
+	if err := os.Remove(filepath.Join(usbRoot, iface, "driver")); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestListUVCVideoInterfacesFiltersByVideoClass(t *testing.T) {
+	usbRoot, _ := newCameraTestEnv(t)
+	restoreSysfsPaths(t)
+	usbDevicesRoot = usbRoot
+
+	// Video interface 1-7:1.0 + audio 1-7:1.1.
+	addUSBDevice(t, usbRoot, "1-7", map[string]string{"1-7:1.0": "0e", "1-7:1.1": "01"})
+	// Video only 2-4:1.0.
+	addUSBDevice(t, usbRoot, "2-4", map[string]string{"2-4:1.0": "0e"})
+	// Audio only 3-9:1.0, must be excluded.
+	addUSBDevice(t, usbRoot, "3-9", map[string]string{"3-9:1.0": "01"})
+	// Device dir "usb1" (hub) and non-interface entries must be excluded.
+	hubDir := filepath.Join(usbRoot, "usb1")
+	if err := os.MkdirAll(hubDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// A video entry under a device dir but without ":" prefix must be ignored.
+	dev4Dir := filepath.Join(usbRoot, "4-1")
+	if err := os.MkdirAll(dev4Dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dev4Dir, "bInterfaceClass"), []byte("0e\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	devs, err := listUVCVideoInterfaces()
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := []string{"1-7:1.0", "2-4:1.0"}
+	if !reflect.DeepEqual(devs, expected) {
+		t.Fatalf("expected %v, got %v", expected, devs)
+	}
+}
+
+func TestSetUVCVideoUnboundTogglesVideoInterfaceOnly(t *testing.T) {
+	usbRoot, _ := newCameraTestEnv(t)
+	restoreSysfsPaths(t)
+	usbDevicesRoot = usbRoot
+	uvcDriverPath = filepath.Join(usbRoot, "drivers", "uvcvideo")
+	if err := os.MkdirAll(uvcDriverPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	addUSBDevice(t, usbRoot, "1-7", map[string]string{"1-7:1.0": "0e", "1-7:1.1": "01"})
+
+	// Spy on writeDriverAttr, simulating the kernel driver side effects:
+	// on "bind" the driver symlink is (re)created on the interface dir, so
+	// the skip-already-bound guard sees the interface as bound afterwards.
+	var calls []string
+	writeDriverAttr = func(op, iface string) error {
+		calls = append(calls, op+":"+iface)
+		// Kernel side effects: "unbind" removes the driver symlink,
+		// "bind" recreates it.
+		link := filepath.Join(usbRoot, iface, "driver")
+		switch op {
+		case "unbind":
+			if err := os.Remove(link); err != nil {
+				t.Fatal(err)
+			}
+		case "bind":
+			if err := os.Symlink(filepath.Join("..", "drivers", "uvcvideo"), link); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return nil
+	}
+
+	applied, err := setUVCVideoUnbound(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !applied {
+		t.Fatal("expected applied=true when a video interface exists")
+	}
+	if !reflect.DeepEqual(calls, []string{"unbind:1-7:1.0"}) {
+		t.Fatalf("expected only video iface unbind, got %v", calls)
+	}
+	// The audio interface must never be touched by the camera switch.
+	for _, c := range calls {
+		if strings.Contains(c, "1-7:1.1") {
+			t.Fatalf("audio interface must not be unbound/bound: %v", calls)
+		}
+	}
+
+	calls = nil
+	applied, err = setUVCVideoUnbound(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !applied {
+		t.Fatal("expected applied=true when re-enabling")
+	}
+	if !reflect.DeepEqual(calls, []string{"bind:1-7:1.0"}) {
+		t.Fatalf("expected only video iface bind, got %v", calls)
+	}
+}
+
+func TestSetUVCVideoUnboundNoCameraReturnsNotApplied(t *testing.T) {
+	usbRoot, _ := newCameraTestEnv(t)
+	restoreSysfsPaths(t)
+	usbDevicesRoot = usbRoot
+
+	applied, err := setUVCVideoUnbound(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if applied {
+		t.Fatal("expected applied=false when no video interface exists")
+	}
+}
+
+func TestSetCameraPrivacyFallsBackToUVCUnbindWhenNoV4L2(t *testing.T) {
+	usbRoot, v4lDir := newCameraTestEnv(t)
+	restoreSysfsPaths(t)
+	usbDevicesRoot = usbRoot
+	v4lClassPath = v4lDir
+
+	// Empty video4linux dir: no V4L2 devices.
+	addUSBDevice(t, usbRoot, "1-7", map[string]string{"1-7:1.0": "0e", "1-7:1.1": "01"})
+
+	var calls []string
+	writeDriverAttr = func(op, iface string) error {
+		calls = append(calls, op+":"+iface)
+		return nil
+	}
+
+	applied, err := setCameraPrivacy(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !applied {
+		t.Fatal("expected applied=true via uvcvideo unbind fallback")
+	}
+	if !reflect.DeepEqual(calls, []string{"unbind:1-7:1.0"}) {
+		t.Fatalf("expected video interface unbind, got %v", calls)
+	}
+}
+
+func TestSetCameraPrivacyNoDevicesNotApplied(t *testing.T) {
+	usbRoot, v4lDir := newCameraTestEnv(t)
+	restoreSysfsPaths(t)
+	usbDevicesRoot = usbRoot
+	v4lClassPath = v4lDir
+
+	applied, err := setCameraPrivacy(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if applied {
+		t.Fatal("expected applied=false when no camera devices exist")
+	}
+}
+
+func TestV4L2ControlIoctlConstants(t *testing.T) {
+	// These constants must match <linux/videodev2.h> so ioctl calls target the
+	// right control; guard against silent UAPI drift.
+	if v4l2CtrlIDPrivacy != 0x9a0910 {
+		t.Fatalf("V4L2_CID_CAMERA_PRIVACY mismatch: got 0x%x", v4l2CtrlIDPrivacy)
+	}
+	if vidIocSCTRL != 0xc008561c {
+		t.Fatalf("VIDIOC_S_CTRL mismatch: got 0x%x", vidIocSCTRL)
+	}
+	if vidIocQueryCtrl != 0xc0445624 {
+		t.Fatalf("VIDIOC_QUERYCTRL mismatch: got 0x%x", vidIocQueryCtrl)
+	}
+}
+
+func TestListVideoDevicesFiltersByUVCInterface(t *testing.T) {
+	usbRoot, v4lDir := newCameraTestEnv(t)
+	restoreSysfsPaths(t)
+	usbDevicesRoot = usbRoot
+	v4lClassPath = v4lDir
+
+	// video0 -> UVC camera interface 1-7:1.0 (class 0e).
+	ifaceDir := filepath.Join(usbRoot, "1-7:1.0")
+	if err := os.MkdirAll(ifaceDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(ifaceDir, "bInterfaceClass"), []byte("0e\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	video0Dir := filepath.Join(v4lDir, "video0")
+	if err := os.MkdirAll(video0Dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join("..", "..", "usb", "1-7:1.0"),
+		filepath.Join(video0Dir, "device")); err != nil {
+		t.Fatal(err)
+	}
+
+	// video1 -> a non-video interface (class 01, e.g. audio), must be excluded.
+	audioIfaceDir := filepath.Join(usbRoot, "1-7:1.1")
+	if err := os.MkdirAll(audioIfaceDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(audioIfaceDir, "bInterfaceClass"), []byte("01\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	video1Dir := filepath.Join(v4lDir, "video1")
+	if err := os.MkdirAll(video1Dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join("..", "..", "usb", "1-7:1.1"),
+		filepath.Join(video1Dir, "device")); err != nil {
+		t.Fatal(err)
+	}
+
+	// A "video" prefixed entry whose device symlink is not a USB interface.
+	otherDir := filepath.Join(v4lDir, "video99")
+	if err := os.MkdirAll(otherDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join("..", "..", "somewhere"), filepath.Join(otherDir, "device")); err != nil {
+		t.Fatal(err)
+	}
+
+	devs, err := listVideoDevices()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(devs) != 1 || devs[0] != "/dev/video0" {
+		t.Fatalf("expected only /dev/video0, got %v", devs)
+	}
+}
+
+func TestListUVCVideoInterfacesNoVideoNotApplied(t *testing.T) {
+	usbRoot, _ := newCameraTestEnv(t)
+	restoreSysfsPaths(t)
+	usbDevicesRoot = usbRoot
+
+	// Only audio interfaces; no video -> nothing to switch.
+	addUSBDevice(t, usbRoot, "3-9", map[string]string{"3-9:1.0": "01"})
+
+	devs, err := listUVCVideoInterfaces()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(devs) != 0 {
+		t.Fatalf("expected no devices, got %v", devs)
+	}
+}
+
+func TestCameraPrivacyReadsDriverBindingState(t *testing.T) {
+	usbRoot, v4lDir := newCameraTestEnv(t)
+	restoreSysfsPaths(t)
+	usbDevicesRoot = usbRoot
+	v4lClassPath = v4lDir
+
+	// No V4L2 devices, one camera interface that is currently bound.
+	addUSBDevice(t, usbRoot, "1-7", map[string]string{"1-7:1.0": "0e", "1-7:1.1": "01"})
+
+	privacy, known := cameraPrivacy()
+	if !known {
+		t.Fatal("expected known=true when a camera device exists")
+	}
+	if privacy {
+		t.Fatal("expected privacy=false while the video interface is bound")
+	}
+
+	// Unbind the video interface: privacy must now report on.
+	unbindUVCInterface(t, usbRoot, "1-7:1.0")
+	privacy, known = cameraPrivacy()
+	if !known {
+		t.Fatal("expected known=true after unbind")
+	}
+	if !privacy {
+		t.Fatal("expected privacy=true while the video interface is unbound")
+	}
+}
+
+func TestCameraPrivacyUnknownWithoutDevices(t *testing.T) {
+	usbRoot, v4lDir := newCameraTestEnv(t)
+	restoreSysfsPaths(t)
+	usbDevicesRoot = usbRoot
+	v4lClassPath = v4lDir
+
+	if _, known := cameraPrivacy(); known {
+		t.Fatal("expected known=false when no camera device exists")
+	}
+}
+
+// TestSetCameraPrivacyReenableAfterDisable guards the regression where a
+// deauthorized camera could never be switched back on. The re-enable path must
+// still find and rebind the same video interface.
+func TestSetCameraPrivacyReenableAfterDisable(t *testing.T) {
+	usbRoot, v4lDir := newCameraTestEnv(t)
+	restoreSysfsPaths(t)
+	usbDevicesRoot = usbRoot
+	v4lClassPath = v4lDir
+
+	addUSBDevice(t, usbRoot, "1-7", map[string]string{"1-7:1.0": "0e", "1-7:1.1": "01"})
+
+	var calls []string
+	writeDriverAttr = func(op, iface string) error {
+		calls = append(calls, op+":"+iface)
+		// Kernel side effects: "unbind" removes the driver symlink,
+		// "bind" recreates it.
+		link := filepath.Join(usbRoot, iface, "driver")
+		switch op {
+		case "unbind":
+			if err := os.Remove(link); err != nil {
+				t.Fatal(err)
+			}
+		case "bind":
+			if err := os.Symlink(filepath.Join("..", "drivers", "uvcvideo"), link); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return nil
+	}
+
+	applied, err := setCameraPrivacy(true)
+	if err != nil || !applied {
+		t.Fatalf("privacy on: applied=%v err=%v", applied, err)
+	}
+	if !reflect.DeepEqual(calls, []string{"unbind:1-7:1.0"}) {
+		t.Fatalf("expected unbind, got %v", calls)
+	}
+
+	// Re-enable must rebind the same video interface even though the driver
+	// link is gone.
+	calls = nil
+	applied, err = setCameraPrivacy(false)
+	if err != nil || !applied {
+		t.Fatalf("privacy off: applied=%v err=%v", applied, err)
+	}
+	if !reflect.DeepEqual(calls, []string{"bind:1-7:1.0"}) {
+		t.Fatalf("BUG: re-enable must bind video iface, got %v", calls)
+	}
+
+	// The audio interface must never be touched by the camera switch.
+	for _, c := range calls {
+		if c == "bind:1-7:1.1" || c == "unbind:1-7:1.1" {
+			t.Fatalf("audio interface must not be touched: %v", calls)
+		}
+	}
+}
+
+// TestSetCameraPrivacyAudioOnlyUntouched ensures an audio-only USB device is
+// never switched by the camera privacy path.
+func TestSetCameraPrivacyAudioOnlyUntouched(t *testing.T) {
+	usbRoot, v4lDir := newCameraTestEnv(t)
+	restoreSysfsPaths(t)
+	usbDevicesRoot = usbRoot
+	v4lClassPath = v4lDir
+
+	addUSBDevice(t, usbRoot, "3-9", map[string]string{"3-9:1.0": "01"})
+
+	applied, err := setCameraPrivacy(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if applied {
+		t.Fatal("expected applied=false for audio-only device")
+	}
+}
+
+// TestSetCameraPrivacyStateUpdatesMemory verifies the in-memory privacy flag
+// is updated (persistence is skipped when no dconfig is wired in tests).
+func TestSetCameraPrivacyStateUpdatesMemory(t *testing.T) {
+	t.Cleanup(func() { cameraPrivacyOn = false })
+
+	setCameraPrivacyState(true)
+	cameraPrivacyMu.Lock()
+	on := cameraPrivacyOn
+	cameraPrivacyMu.Unlock()
+	if !on {
+		t.Fatal("expected cameraPrivacyOn=true after setCameraPrivacyState(true)")
+	}
+
+	setCameraPrivacyState(false)
+	cameraPrivacyMu.Lock()
+	on = cameraPrivacyOn
+	cameraPrivacyMu.Unlock()
+	if on {
+		t.Fatal("expected cameraPrivacyOn=false after setCameraPrivacyState(false)")
+	}
+}
+
+// TestReapplyCameraPrivacyWhenOn verifies that a hotplug re-apply disables the
+// camera while privacy is on.
+func TestReapplyCameraPrivacyWhenOn(t *testing.T) {
+	usbRoot, v4lDir := newCameraTestEnv(t)
+	restoreSysfsPaths(t)
+	usbDevicesRoot = usbRoot
+	v4lClassPath = v4lDir
+	t.Cleanup(func() { cameraPrivacyOn = false })
+
+	addUSBDevice(t, usbRoot, "1-7", map[string]string{"1-7:1.0": "0e", "1-7:1.1": "01"})
+
+	var calls []string
+	writeDriverAttr = func(op, iface string) error {
+		calls = append(calls, op+":"+iface)
+		return nil
+	}
+
+	cameraPrivacyMu.Lock()
+	cameraPrivacyOn = true
+	cameraPrivacyMu.Unlock()
+
+	reapplyCameraPrivacy()
+	if !reflect.DeepEqual(calls, []string{"unbind:1-7:1.0"}) {
+		t.Fatalf("expected video iface unbind on re-apply, got %v", calls)
+	}
+}
+
+// TestReapplyCameraPrivacyNoopWhenOff verifies nothing is switched while the
+// privacy switch is off — a hotplug must not silently disable the camera.
+func TestReapplyCameraPrivacyNoopWhenOff(t *testing.T) {
+	usbRoot, v4lDir := newCameraTestEnv(t)
+	restoreSysfsPaths(t)
+	usbDevicesRoot = usbRoot
+	v4lClassPath = v4lDir
+	t.Cleanup(func() { cameraPrivacyOn = false })
+
+	addUSBDevice(t, usbRoot, "1-7", map[string]string{"1-7:1.0": "0e"})
+
+	var calls []string
+	writeDriverAttr = func(op, iface string) error {
+		calls = append(calls, op+":"+iface)
+		return nil
+	}
+
+	cameraPrivacyMu.Lock()
+	cameraPrivacyOn = false
+	cameraPrivacyMu.Unlock()
+
+	reapplyCameraPrivacy()
+	if len(calls) != 0 {
+		t.Fatalf("expected no driver ops while privacy off, got %v", calls)
+	}
+}
+
+// TestShouldReapplyCamera verifies the uevent filter: video4linux add is the
+// reliable signal, usb_device add is the fallback with a DEVPATH precheck,
+// and everything else (usb_interface add — arrives before uvcvideo probe —
+// and non-add actions) must not trigger a re-apply.
+func TestShouldReapplyCamera(t *testing.T) {
+	usbRoot, _ := newCameraTestEnv(t)
+	restoreSysfsPaths(t)
+	usbDevicesRoot = usbRoot
+	sysfsRoot = filepath.Dir(usbRoot)
+	t.Cleanup(func() { sysfsRoot = "/sys" })
+	usbRel := strings.TrimPrefix(usbRoot, sysfsRoot)
+
+	// DEVPATH prechecks read the device directory CHILDREN (real sysfs:
+	// /sys/devices/.../1-4/1-4:1.0), unlike the flat usbDevicesRoot layout
+	// the other fixtures mirror. Build the child layout directly.
+	mkDev := func(dev string, ifaces map[string]string) {
+		t.Helper()
+		for iface, class := range ifaces {
+			dir := filepath.Join(sysfsRoot, usbRel, dev, iface)
+			if err := os.MkdirAll(dir, 0755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, "bInterfaceClass"),
+				[]byte(class+"\n"), 0644); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	mkDev("1-4", map[string]string{"1-4:1.0": "0e"}) // camera
+	mkDev("1-5", map[string]string{"1-5:1.0": "08"}) // flash drive
+
+	cameraDev := usbRel + "/1-4"
+	usbStickDev := usbRel + "/1-5"
+
+	cases := []struct {
+		name                      string
+		action, subsystem, devtyp string
+		devpath                   string
+		want                      bool
+	}{
+		{"v4l add always fires", "add", "video4linux", "video4linux", "/nonexistent", true},
+		{"usb_device add with 0e iface fires", "add", "usb", "usb_device", cameraDev, true},
+		{"usb_device add without 0e iface (flash drive) skipped", "add", "usb", "usb_device", usbStickDev, false},
+		// Interfaces not yet created at event time: unknown must not become
+		// "no", the fallback has to fire.
+		{"usb_device add unreadable devpath fires", "add", "usb", "usb_device", usbRel + "/9-9", true},
+		{"usb_interface add never fires", "add", "usb", "usb_interface", cameraDev, false},
+		{"remove never fires", "remove", "video4linux", "video4linux", "/nonexistent", false},
+		{"change never fires", "change", "usb", "usb_device", cameraDev, false},
+		{"bind never fires", "bind", "usb", "usb_interface", cameraDev, false},
+		{"other subsystems never fire", "add", "block", "disk", "/nonexistent", false},
+	}
+	for _, c := range cases {
+		if got := shouldReapplyCamera(c.action, c.subsystem, c.devtyp, c.devpath); got != c.want {
+			t.Errorf("%s: shouldReapplyCamera(%q, %q, %q, %q) = %v, want %v",
+				c.name, c.action, c.subsystem, c.devtyp, c.devpath, got, c.want)
+		}
+	}
+}
+
+// TestUsbDeviceHasVideoInterfaceUnknownVsNo pins the distinction the
+// fallback depends on: unreadable attribute means unknown (ok=false), a
+// device whose interfaces are all non-video means a confident "no".
+func TestUsbDeviceHasVideoInterfaceUnknownVsNo(t *testing.T) {
+	sysfsRoot = t.TempDir()
+	t.Cleanup(func() { sysfsRoot = "/sys" })
+	usbRel := "/usb/1-5"
+
+	found, ok := usbDeviceHasVideoInterface("/usb/9-9")
+	if ok || found {
+		t.Fatal("absent device dir must be unknown, not no")
+	}
+
+	// Child layout, as in real sysfs DEVPATH dirs.
+	ifaceDir := filepath.Join(sysfsRoot, usbRel, "1-5:1.0")
+	if err := os.MkdirAll(ifaceDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(ifaceDir, "bInterfaceClass"),
+		[]byte("08\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	found, ok = usbDeviceHasVideoInterface(usbRel)
+	if !ok {
+		t.Fatal("readable non-video device must be a confident answer")
+	}
+	if found {
+		t.Fatal("mass-storage-only device must not be reported as video")
+	}
+}
+
+// TestSetUVCVideoUnboundSkipsAlreadyUnbound guards the idempotence fix: a
+// re-apply over an already-disabled camera must not write unbind again (the
+// kernel rejects it with -ENODEV).
+func TestSetUVCVideoUnboundSkipsAlreadyUnbound(t *testing.T) {
+	usbRoot, _ := newCameraTestEnv(t)
+	restoreSysfsPaths(t)
+	usbDevicesRoot = usbRoot
+
+	addUSBDevice(t, usbRoot, "1-7", map[string]string{"1-7:1.0": "0e"})
+	unbindUVCInterface(t, usbRoot, "1-7:1.0")
+
+	var calls []string
+	writeDriverAttr = func(op, iface string) error {
+		calls = append(calls, op+":"+iface)
+		return nil
+	}
+
+	applied, err := setUVCVideoUnbound(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// applied stays true: an already-disabled camera must not be reported as
+	// "nothing switchable", otherwise hotkey consumers would see the toggle
+	// as a no-op failure.
+	if !applied {
+		t.Fatal("expected applied=true even when all interfaces already unbound")
+	}
+	if len(calls) != 0 {
+		t.Fatalf("expected no unbind writes for already-unbound interfaces, got %v", calls)
+	}
+
+	// Re-enable must still bind the unbound interface.
+	calls = nil
+	writeDriverAttr = func(op, iface string) error {
+		calls = append(calls, op+":"+iface)
+		// Simulate the kernel binding the driver on "bind".
+		if op == "bind" {
+			if err := os.Symlink(filepath.Join("..", "drivers", "uvcvideo"),
+				filepath.Join(usbRoot, iface, "driver")); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return nil
+	}
+	applied, err = setUVCVideoUnbound(false)
+	if err != nil || !applied {
+		t.Fatalf("privacy off: applied=%v err=%v", applied, err)
+	}
+	if !reflect.DeepEqual(calls, []string{"bind:1-7:1.0"}) {
+		t.Fatalf("expected bind for previously unbound interface, got %v", calls)
+	}
+
+	// And a second disable after re-enable writes unbind again (interface
+	// has a driver once more).
+	calls = nil
+	applied, err = setUVCVideoUnbound(true)
+	if err != nil || !applied {
+		t.Fatalf("privacy on again: applied=%v err=%v", applied, err)
+	}
+	if !reflect.DeepEqual(calls, []string{"unbind:1-7:1.0"}) {
+		t.Fatalf("expected unbind after re-enable, got %v", calls)
+	}
+}
+
+// TestSetUVCVideoUnboundSkipsAlreadyBound verifies re-enable does not write
+// bind for interfaces that already have the driver — a hotplug re-apply with
+// privacy off stays a no-op on the wire.
+func TestSetUVCVideoUnboundSkipsAlreadyBound(t *testing.T) {
+	usbRoot, _ := newCameraTestEnv(t)
+	restoreSysfsPaths(t)
+	usbDevicesRoot = usbRoot
+
+	addUSBDevice(t, usbRoot, "1-7", map[string]string{"1-7:1.0": "0e"})
+
+	var calls []string
+	writeDriverAttr = func(op, iface string) error {
+		calls = append(calls, op+":"+iface)
+		return nil
+	}
+
+	applied, err := setUVCVideoUnbound(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !applied {
+		t.Fatal("expected applied=true when a bound video interface exists")
+	}
+	if len(calls) != 0 {
+		t.Fatalf("expected no bind writes for already-bound interfaces, got %v", calls)
+	}
+}
+
+// TestSetUVCVideoUnboundENODEVTolerated verifies that a write failing with
+// ENODEV (metadata interface racing the main interface unbind) does not
+// abort the loop: remaining interfaces still get their write, and the
+// overall result stays applied=true.
+func TestSetUVCVideoUnboundENODEVTolerated(t *testing.T) {
+	usbRoot, _ := newCameraTestEnv(t)
+	restoreSysfsPaths(t)
+	usbDevicesRoot = usbRoot
+
+	addUSBDevice(t, usbRoot, "1-2", map[string]string{"1-2:1.0": "0e", "1-2:1.1": "0e"})
+
+	writeDriverAttr = func(op, iface string) error {
+		// First interface (main video) succeeds and removes its driver
+		// symlink; the metadata interface write races and gets ENODEV.
+		if iface == "1-2:1.0" {
+			if err := os.Remove(filepath.Join(usbRoot, iface, "driver")); err != nil {
+				t.Fatal(err)
+			}
+			return nil
+		}
+		return &os.PathError{Op: "write", Path: "/sys/bus/usb/drivers/uvcvideo/unbind",
+			Err: unix.ENODEV}
+	}
+
+	applied, err := setUVCVideoUnbound(true)
+	if err != nil {
+		t.Fatalf("ENODEV on a metadata interface must not fail the call: %v", err)
+	}
+	if !applied {
+		t.Fatal("expected applied=true despite ENODEV on metadata interface")
+	}
+}
+
+// TestParseUevent verifies the raw netlink uevent parser against the kernel
+// payload format: "ACTION@DEVPATH\0KEY=VALUE\0KEY=VALUE\0...".
+func TestParseUevent(t *testing.T) {
+	// A real video4linux add uevent shape.
+	payload := []byte("add@/devices/pci0000:00/0000:00:14.0/usb1/1-4/video4linux/video0\x00" +
+		"ACTION=add\x00" +
+		"DEVPATH=/devices/pci0000:00/0000:00:14.0/usb1/1-4/video4linux/video0\x00" +
+		"SUBSYSTEM=video4linux\x00" +
+		"DEVNAME=/dev/video0\x00" +
+		"DEVTYPE=video4linux\x00" +
+		"MAJOR=81\x00")
+	msg := parseUevent(payload)
+	if msg.action != "add" || msg.subsystem != "video4linux" || msg.devtype != "video4linux" {
+		t.Fatalf("unexpected parse: %+v", msg)
+	}
+	if msg.devpath != "/devices/pci0000:00/0000:00:14.0/usb1/1-4/video4linux/video0" {
+		t.Fatalf("unexpected devpath: %q", msg.devpath)
+	}
+	if !shouldReapplyCamera(msg.action, msg.subsystem, msg.devtype, msg.devpath) {
+		t.Fatal("expected video4linux add uevent to trigger re-apply")
+	}
+
+	// A usb_device add uevent (fallback path): DEVTYPE distinguishes it
+	// from the usb_interface add which must not trigger.
+	usbPayload := []byte("add@/devices/pci0000:00/0000:00:99.9/usb9/9-9\x00" +
+		"ACTION=add\x00SUBSYSTEM=usb\x00DEVTYPE=usb_device\x00")
+	msg = parseUevent(usbPayload)
+	if msg.action != "add" || msg.subsystem != "usb" || msg.devtype != "usb_device" {
+		t.Fatalf("unexpected parse: %+v", msg)
+	}
+	if msg.devpath != "/devices/pci0000:00/0000:00:99.9/usb9/9-9" {
+		t.Fatalf("unexpected devpath: %q", msg.devpath)
+	}
+	// The devpath does not exist in this environment, so the precheck
+	// result is "unknown" — which must not suppress the re-apply.
+	if !shouldReapplyCamera(msg.action, msg.subsystem, msg.devtype, msg.devpath) {
+		t.Fatal("expected usb_device add uevent with unknown sysfs to trigger re-apply")
+	}
+
+	ifacePayload := []byte("add@/devices/usb1/1-4/1-4:1.0\x00" +
+		"ACTION=add\x00SUBSYSTEM=usb\x00DEVTYPE=usb_interface\x00")
+	msg = parseUevent(ifacePayload)
+	if shouldReapplyCamera(msg.action, msg.subsystem, msg.devtype, msg.devpath) {
+		t.Fatal("usb_interface add must not trigger re-apply")
+	}
+
+	// Remove and change actions must not trigger.
+	removePayload := []byte("remove@/devices/usb1/1-4/video4linux/video0\x00" +
+		"ACTION=remove\x00SUBSYSTEM=video4linux\x00")
+	msg = parseUevent(removePayload)
+	if shouldReapplyCamera(msg.action, msg.subsystem, msg.devtype, msg.devpath) {
+		t.Fatal("remove action must not trigger re-apply")
+	}
+}

--- a/bin/dde-system-daemon/exported_methods_auto.go
+++ b/bin/dde-system-daemon/exported_methods_auto.go
@@ -29,6 +29,11 @@ func (v *Daemon) GetExportedMethods() dbusutil.ExportedMethods {
 			InArgs: []string{"username", "file"},
 		},
 		{
+			Name:    "GetCameraPrivacy",
+			Fn:      v.GetCameraPrivacy,
+			OutArgs: []string{"privacy", "known"},
+		},
+		{
 			Name:    "GetCustomWallPapers",
 			Fn:      v.GetCustomWallPapers,
 			InArgs:  []string{"username"},
@@ -52,6 +57,17 @@ func (v *Daemon) GetExportedMethods() dbusutil.ExportedMethods {
 			InArgs: []string{"scale"},
 		},
 		{
+			Name:   "SetAllowCaller",
+			Fn:     v.SetAllowCaller,
+			InArgs: []string{"uniqueName"},
+		},
+		{
+			Name:    "SetCameraPrivacy",
+			Fn:      v.SetCameraPrivacy,
+			InArgs:  []string{"state"},
+			OutArgs: []string{"applied"},
+		},
+		{
 			Name:   "SetLogindTTY",
 			Fn:     v.SetLogindTTY,
 			InArgs: []string{"NAutoVTs", "resetCustom", "live"},
@@ -70,11 +86,6 @@ func (v *Daemon) GetExportedMethods() dbusutil.ExportedMethods {
 			Name:   "SetReadOnlyProtection",
 			Fn:     v.SetReadOnlyProtection,
 			InArgs: []string{"enable"},
-		},
-		{
-			Name:   "SetAllowCaller",
-			Fn:     v.SetAllowCaller,
-			InArgs: []string{"uniqueName"},
 		},
 	}
 }

--- a/bin/dde-system-daemon/main.go
+++ b/bin/dde-system-daemon/main.go
@@ -122,6 +122,9 @@ func main() {
 	}
 	_daemon.service = service
 	_daemon.initSystemDaemonDConfig()
+	// Start the camera privacy switch: restore persisted state and watch
+	// hotplug so a re-plugged camera stays disabled while privacy is on.
+	initCameraPrivacy()
 	err = service.Export(dbusPath, _daemon)
 	if err != nil {
 		logger.Fatal("failed to export:", err)

--- a/misc/dsg-configs/org.deepin.dde.daemon.system.json
+++ b/misc/dsg-configs/org.deepin.dde.daemon.system.json
@@ -11,6 +11,16 @@
       "description": "Maximum Custom Wallpaper Limit",
       "permissions": "readwrite",
       "visibility": "private"
+    },
+    "cameraPrivacyEnabled": {
+      "value": false,
+      "serial": 0,
+      "flags": ["global"],
+      "name": "cameraPrivacyEnabled",
+      "name[zh_CN]": "摄像头隐私开关",
+      "description": "Whether the camera hardware privacy switch is enabled",
+      "permissions": "readwrite",
+      "visibility": "private"
     }
   }
 }

--- a/misc/polkit-action/org.deepin.dde.hardware-control.policy.in
+++ b/misc/polkit-action/org.deepin.dde.hardware-control.policy.in
@@ -5,6 +5,17 @@
 <policyconfig>
     <vendor/>
     <vendor_url/>
+
+    <action id="org.deepin.dde.daemon.set-camera-privacy">
+        <description>Set camera privacy</description>
+        <message>Authentication is required to set camera privacy</message>
+        <defaults>
+            <allow_any>no</allow_any>
+            <allow_inactive>no</allow_inactive>
+            <allow_active>yes</allow_active>
+        </defaults>
+    </action>
+
     <action id="org.deepin.dde.inputdevices.set-touchpad">
         <description>Enable or disable touchpad</description>
         <message>Authentication is required to enable or disable touchpad</message>


### PR DESCRIPTION
1. Add SetCameraPrivacy/GetCameraPrivacy D-Bus methods on the system daemon applying a tiered strategy: the camera's built-in V4L2遮挡 control first, then uvcvideo driver unbind/bind at the video-interface level, so a built-in mic on the same USB device keeps working.
2. Persist the switch state in dconfig (cameraPrivacyEnabled) and watch hotplug with a raw netlink NETLINK_KOBJECT_UEVENT monitor so a re-plugged camera stays disabled while the switch is on, and the state survives daemon restart. gudev cannot be used here: it dispatches its uevent signal from the GLib main loop, which dde-system-daemon does not run, so hotplug events were queued but never read.
3. The hotplug filter treats a video4linux add as the reliable signal (emitted after /dev/videoN exists) and keeps a usb_device add fallback with a DEVPATH precheck that skips non-camera devices but never turns an unreadable sysfs state into "not a camera".
4. Serialize the hardware switch and dconfig persist under one operation mutex and re-check the switch flag inside it, so a queued hotplug reapply cannot re-enable a camera the user has just re-enabled by toggling back.
5. Skip bind/unbind writes when the interface already sits in the target state (idempotent reapply) and demote the expected ENODEV from the metadata-interface race to debug level.
6. Cover the event filter, uevent parsing, precheck semantics, idempotence and the ENODEV tolerance with tests; test spies simulate real kernel side effects (driver symlink removal/creation).
7. Keep cameraSwitch.sh and the legacy webCam hotkey behavior: the hotkey still toggles the deepin-camera app as before. Document the camera detection algorithm above initCameraPrivacy.

Log: 相机禁用热键分级硬件开关（V4L2遮挡控制/uvcvideo解绑），支持热插拔与持久化；热插拔经原生 netlink 监听，开关开启时重插相机保持禁用

Influence:
1. On a camera with the V4L2遮挡 control, press the camera hotkey and confirm the camera toggles off/on with OSD feedback.
2. On a UVC camera without that control, call SetCameraPrivacy(true) then SetCameraPrivacy(false) and confirm the camera and its built-in mic both recover.
3. With the switch on, unplug and replug the camera and confirm it is disabled again automatically; with the switch off, confirm it comes back.

feat: 相机禁用热键分级硬件开关，支持热插拔与持久化

1. 在系统守护进程新增 SetCameraPrivacy/GetCameraPrivacy D-Bus 接口，分级施策：优先相机自带的 V4L2 遮挡控制，否则对视频接口解绑/绑定 uvcvideo 驱动，同设备内置麦克风不受影响。
2. 开关状态持久化到 dconfig（cameraPrivacyEnabled），并以原生 netlink（NETLINK_KOBJECT_UEVENT）监听热插拔，开关开启时重新插入的相机自动禁用，重启后状态恢复。gudev 在此不可用：其 uevent 信号依赖 GLib 主循环分发，而 dde-system-daemon 未运行 GLib 循环，事件会积压无人读取。
3. 热插拔过滤以 video4linux add（/dev/videoN 创建后发出）为可靠信号，保留 usb_device add 兜底并经 DEVPATH 预判跳过非相机设备，sysfs 不可读时不会误判为"非相机"。
4. 硬件切换与 dconfig 保存统一到一把操作互斥锁下，并在锁内重查开关标志，排队的热插拔重放不会把用户刚切换的状态覆盖回去。
5. 接口已处于目标状态时跳过 bind/unbind 写入（重放幂等），metadata 接口竞态产生的预期 ENODEV 降级为 debug 日志。
6. 为事件过滤、uevent 解析、预判语义、幂等与 ENODEV 容忍补充测试，测试桩模拟内核真实副作用（driver 符号链接的删除与重建）。
7. 保留 cameraSwitch.sh 及现有 webCam 热键行为：热键仍按原方式启动/关闭 deepin-camera 应用。在 initCameraPrivacy 上补充算法说明注释，明确本模块是相机禁用快捷键的底层实现。

Log: 相机禁用热键分级硬件开关（V4L2遮挡控制/uvcvideo解绑），支持热插拔与持久化；热插拔经原生 netlink 监听，开关开启时重插相机保持禁用

Influence:
1. 支持 V4L2 遮挡控制的机型，按相机热键确认开关且显示 OSD。
2. 无遮挡控制的 UVC 相机，先 SetCameraPrivacy(true) 再 SetCameraPrivacy(false)，确认相机与内置麦克风均恢复。
3. 开关开启时拔插相机，确认重新插入后被自动禁用；开关关闭时拔插后恢复正常。

PMS: BUG-375443