### PR TITLE
chore: bump version to 6.1.99.4

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-daemon (6.1.99.4) unstable; urgency=medium
+
+  * feat: tiered camera disable hotkey with hardware persistence
+
+ -- fuleyi <fuleyi@uniontech.com>  Mon, 07 Sep 2026 16:57:38 +0800
+
 dde-daemon (6.1.99.3) unstable; urgency=medium
 
   * fix(inputdevices): fsync udev rule and rebuild on boot for touchpad


### PR DESCRIPTION
update changelog to 6.1.99.4

Log: update changelog to 6.1.99.4

## Summary by Sourcery

Build:
- Update the Debian package version and changelog to 6.1.99.4.