### PR TITLE
fix: unscale brightness before saving when power-saving mode is on

### DIFF
--- a/display1/brightness.go
+++ b/display1/brightness.go
@@ -106,7 +106,7 @@ func (m *Manager) changeBrightness(raised bool) error {
 			logger.Warning(err)
 			continue
 		}
-		successMap[monitor.Name] = br
+		successMap[monitor.Name] = unscaleBrightness(br, m.getBrightnessScale())
 	}
 	err := m.saveBrightnessInCfg(successMap)
 	if err != nil {

--- a/display1/brightness_scale.go
+++ b/display1/brightness_scale.go
@@ -165,3 +165,24 @@ func scaleBrightness(base, scale float64) float64 {
 	}
 	return math.Round(v*1000) / 1000
 }
+
+// unscaleBrightness 将硬件实际亮度还原为未缩放的原始亮度，用于保存到配置。
+// 与 scaleBrightness 互逆：scaleBrightness(unscaleBrightness(v, s), s) == v（未饱和区间内）。
+func unscaleBrightness(effective, scale float64) float64 {
+	if effective <= minBrightness {
+		return minBrightness
+	}
+	if scale <= 0 {
+		// scale 为 0 时缩放不可逆（任意原始值都映射到最低亮度），
+		// 保持原值，避免覆盖用户设置的亮度。
+		return effective
+	}
+	v := effective / scale
+	if v < minBrightness {
+		v = minBrightness
+	}
+	if v > 1.0 {
+		v = 1.0
+	}
+	return math.Round(v*1000) / 1000
+}

--- a/display1/manager_ifc.go
+++ b/display1/manager_ifc.go
@@ -235,7 +235,7 @@ func (m *Manager) SetAndSaveBrightness(outputName string, value float64) *dbus.E
 	}
 
 	err = m.saveBrightnessInCfg(map[string]float64{
-		outputName: value,
+		outputName: unscaleBrightness(value, m.getBrightnessScale()),
 	})
 	if err != nil {
 		logger.Warning(err)


### PR DESCRIPTION
fix: unscale brightness before saving when power-saving mode is on

1. Add unscaleBrightness to convert the effective brightness back to the
   unscaled value before persisting it to the monitor config
2. Apply the conversion in SetAndSaveBrightness and changeBrightness so
   the stored value stays independent of the power-saving scale

Influence:
1. Manually adjust brightness with power-saving mode enabled, then logout
   and login; brightness should remain unchanged instead of dropping again

fix: 节能模式下保存亮度前先还原未缩放值

1. 新增 unscaleBrightness，将实际亮度还原为未缩放原始值后再写入显示器配置
2. 在 SetAndSaveBrightness 与 changeBrightness 中应用该还原，使保存的亮度值
   不再受节能缩放系数影响

Influence:
1. 开启节能模式后手动调节亮度并注销重进，亮度应保持不变而非再次降低

PMS: BUG-375767

## Summary by Sourcery

Restore effective brightness to its unscaled value before persisting monitor configuration.

Bug Fixes:
- Preserve user brightness settings across logout and login when power-saving mode is enabled by saving the unscaled brightness value.

Enhancements:
- Keep persisted monitor brightness independent of the active power-saving brightness scale.