### PR TITLE
fix: detect and refresh display gamma capability

### DIFF
--- a/display1/display.go
+++ b/display1/display.go
@@ -97,6 +97,9 @@ func SetLogLevel(level log.Priority) {
 // Cleanup 清理display模块资源
 func Cleanup() {
 	if _dpy != nil {
+		if _dpy.gammaSupportCancel != nil {
+			_dpy.gammaSupportCancel()
+		}
 		_dpy.cleanupAutoBrightness()
 		logger.Info("Display module cleaned up")
 	}

--- a/display1/manager.go
+++ b/display1/manager.go
@@ -5,6 +5,7 @@
 package display1
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -239,7 +240,9 @@ type Manager struct {
 
 	// 不支持调节色温的显卡型号
 	unsupportGammaDrmList []string
-	drmSupportGamma       bool
+	gammaSupportUpdates   chan struct{}
+	gammaSupportCtx       context.Context
+	gammaSupportCancel    context.CancelFunc
 
 	customColorTempTimer    *time.Timer
 	customColorTempFlag     bool
@@ -281,6 +284,7 @@ var _dsDefaultTemperatureManual int32 // 开启色温时，手动调节色温的
 
 func newManager(service *dbusutil.Service) *Manager {
 	isVM, _ := isInVM()
+	gammaSupportCtx, gammaSupportCancel := context.WithCancel(context.Background())
 	m := &Manager{
 		service:             service,
 		monitorMap:          make(map[uint32]*Monitor),
@@ -291,7 +295,10 @@ func newManager(service *dbusutil.Service) *Manager {
 		unsupportGammaDrmList: []string{
 			"Loongson",
 		},
-		isVM: isVM,
+		gammaSupportUpdates: make(chan struct{}, 1),
+		gammaSupportCtx:     gammaSupportCtx,
+		gammaSupportCancel:  gammaSupportCancel,
+		isVM:                isVM,
 	}
 	if !_greeterMode {
 		m.xsManager = xs.NewXSettings(m.service.Conn())
@@ -713,12 +720,16 @@ func (m *Manager) initSysDisplay() {
 		logger.Warning(err)
 	}
 	go func() {
-		m.drmSupportGamma = m.detectDrmSupportGamma()
-		if m.drmSupportGamma {
+		supported := m.detectDrmSupportGamma()
+		if m.gammaSupportCtx.Err() != nil {
+			return
+		}
+		if supported {
 			logger.Debug("setColorTempModeReal")
 			m.setColorTempModeReal(ColorTemperatureModeNone)
 		}
-		m.setPropSupportColorTemperature(!_inVM && m.drmSupportGamma)
+		m.updateGammaSupport(supported)
+		m.watchGammaSupport(m.detectDrmSupportGamma)
 	}()
 }
 
@@ -3473,32 +3484,177 @@ func (m *Manager) updateScreenSize() {
 	m.PropsMu.Unlock()
 }
 
-func getLspci() string {
+func getLspci() (string, error) {
 	out, err := exec.Command("lspci").Output()
-	if err != nil {
-		logger.Warning(err)
-		return ""
-	} else {
-		return string(out)
-	}
+	return string(out), err
 }
 
 func (m *Manager) detectDrmSupportGamma() bool {
-	pciInfos := strings.Split(getLspci(), "\n")
-	for _, info := range pciInfos {
-		if strings.Contains(info, "VGA") {
-			vgaSupportGamma := true
-			for _, drm := range m.unsupportGammaDrmList {
-				lowDrm := strings.ToLower(drm)
-				lowInfo := strings.ToLower(info)
-				if strings.Contains(lowInfo, lowDrm) {
-					vgaSupportGamma = false
-					break
-				}
+	return detectGammaSupport(getLspci, m.unsupportGammaDrmList, m.probeGammaSupport)
+}
+
+func (m *Manager) updateGammaSupport(supported bool) {
+	m.PropsMu.Lock()
+	defer m.PropsMu.Unlock()
+	m.setPropSupportColorTemperature(!m.isVM && supported)
+}
+
+// 合并积压的 RandR 通知，不阻塞显示事件处理。
+func (m *Manager) queueGammaSupportUpdate() {
+	select {
+	case m.gammaSupportUpdates <- struct{}{}:
+	default:
+	}
+}
+
+// 同一个工作循环串行探测，避免旧结果覆盖新结果；刷新不改变用户的色温设置。
+func (m *Manager) watchGammaSupport(detect func() bool) {
+	for {
+		select {
+		case <-m.gammaSupportCtx.Done():
+			return
+		case <-m.gammaSupportUpdates:
+			supported := detect()
+			if m.gammaSupportCtx.Err() != nil {
+				return
 			}
-			if vgaSupportGamma {
-				return true
+			m.updateGammaSupport(supported)
+		}
+	}
+}
+
+func detectGammaSupport(scanPCI func() (string, error), blacklist []string, probe func() bool) bool {
+	lspciOut, err := scanPCI()
+	if err != nil {
+		// 扫描失败不能视为空设备列表，否则平台 GPU 回退会绕过黑名单。
+		logger.Warning("detectGammaSupport: scan PCI devices failed:", err)
+		return false
+	}
+	foundBlacklisted := false
+	for _, info := range strings.Split(lspciOut, "\n") {
+		isVGA := strings.Contains(info, "VGA")
+		if !isVGA && !isAccelDisplayDevice(info) {
+			continue
+		}
+		if isBlacklistedDisplay(info, blacklist) {
+			foundBlacklisted = true
+			continue
+		}
+		if isVGA {
+			// 保留未命中黑名单的 VGA 设备的原有行为。
+			return true
+		}
+	}
+	if foundBlacklisted {
+		// 没有可用 VGA 时，全局 RandR 探测无法确认输出属于哪块 PCI 显卡，
+		// 因此不能让其他加速卡或黑名单设备报告的 gamma 大小覆盖黑名单。
+		return false
+	}
+	// 加速类设备和非 PCI GPU（如 ARM SoC）都需要验证输出的 gamma 能力。
+	return probe()
+}
+
+// accelDisplayClasses 为 lspci 中可能表示无输出加速卡的设备类关键字，
+// 如双显卡机器上的 "3D controller"（NVIDIA 独显/Tesla）和部分设备的
+// "Display controller"。这类设备不能仅凭存在即判定支持 gamma。
+var accelDisplayClasses = []string{"3D controller", "Display controller"}
+
+func isAccelDisplayDevice(lspciLine string) bool {
+	lowLine := strings.ToLower(lspciLine)
+	for _, class := range accelDisplayClasses {
+		if strings.Contains(lowLine, strings.ToLower(class)) {
+			return true
+		}
+	}
+	return false
+}
+
+func isBlacklistedDisplay(lspciLine string, blacklist []string) bool {
+	lowInfo := strings.ToLower(lspciLine)
+	for _, drm := range blacklist {
+		if strings.Contains(lowInfo, strings.ToLower(drm)) {
+			return true
+		}
+	}
+	return false
+}
+
+// probeGammaSupport 查询 RandR 输出的 CRTC gamma 表大小，
+// 与 brightness.setOutputCrtcGamma 的前置检查保持一致。
+// 已知黑名单由 detectGammaSupport 处理，不能仅凭 gamma 表大小解除。
+// 输出尚未启用时，只探测这些输出可使用的 CRTC，避免把无输出加速卡判为支持。
+func (m *Manager) probeGammaSupport() bool {
+	if _useWayland || m.xConn == nil || !_hasRandr1d2 {
+		return false
+	}
+	xConn := m.xConn
+	root := xConn.GetDefaultScreen().Root
+	var resources *randr.GetScreenResourcesReply
+	var err error
+	if _hasRandr1d3 {
+		// RandR 1.3 起读取当前配置，避免每次显示事件刷新都触发硬件轮询。
+		var current *randr.GetScreenResourcesCurrentReply
+		current, err = randr.GetScreenResourcesCurrent(xConn, root).Reply(xConn)
+		resources = (*randr.GetScreenResourcesReply)(current)
+	} else {
+		resources, err = randr.GetScreenResources(xConn, root).Reply(xConn)
+	}
+	if err != nil {
+		logger.Warning("probeGammaSupport: get screen resources failed:", err)
+		return false
+	}
+	return probeRandrGammaSupport(resources,
+		func(output randr.Output) (*randr.GetOutputInfoReply, error) {
+			return randr.GetOutputInfo(xConn, output, resources.ConfigTimestamp).Reply(xConn)
+		},
+		func(crtc randr.Crtc) (uint16, error) {
+			gamma, err := randr.GetCrtcGammaSize(xConn, crtc).Reply(xConn)
+			if err != nil {
+				logger.Warningf("probeGammaSupport: get gamma size for crtc %v failed: %v", crtc, err)
+				return 0, err
 			}
+			return gamma.Size, nil
+		})
+}
+
+func probeRandrGammaSupport(resources *randr.GetScreenResourcesReply,
+	getOutputInfo func(randr.Output) (*randr.GetOutputInfoReply, error),
+	getGammaSize func(randr.Crtc) (uint16, error)) bool {
+	var inactiveCrtcs []randr.Crtc
+	canProbeInactive := true
+	for _, output := range resources.Outputs {
+		outputInfo, err := getOutputInfo(output)
+		if err != nil || outputInfo.Status != randr.StatusSuccess {
+			canProbeInactive = false
+			continue
+		}
+		if outputInfo.Connection != randr.ConnectionConnected || outputInfo.Crtc == 0 {
+			inactiveCrtcs = append(inactiveCrtcs, outputInfo.Crtcs...)
+			continue
+		}
+		canProbeInactive = false
+		size, err := getGammaSize(outputInfo.Crtc)
+		if err != nil {
+			continue
+		}
+		if size > 0 {
+			return true
+		}
+	}
+	// 仅在所有输出均未启用时回退；活动输出探测失败不能由其他 CRTC 代替。
+	if !canProbeInactive {
+		return false
+	}
+	for _, crtc := range inactiveCrtcs {
+		if crtc == 0 {
+			continue
+		}
+		size, err := getGammaSize(crtc)
+		if err != nil {
+			continue
+		}
+		if size > 0 {
+			return true
 		}
 	}
 	return false

--- a/display1/manager_gamma_test.go
+++ b/display1/manager_gamma_test.go
@@ -1,0 +1,446 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package display1
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/linuxdeepin/go-lib/dbusutil"
+	"github.com/linuxdeepin/go-x11-client/ext/randr"
+)
+
+func TestDetectGammaSupport(t *testing.T) {
+	const (
+		intelVGA    = "00:02.0 VGA compatible controller: Intel Corporation UHD Graphics 620"
+		loongsonVGA = "00:06.0 VGA compatible controller: Loongson Technology 7A1000"
+		tesla3D     = "01:00.0 3D controller: NVIDIA Corporation Tesla T4"
+		amdDisplay  = "03:00.0 Display controller: Advanced Micro Devices, Inc. [AMD/ATI] Device 744c"
+		loongson3D  = "01:00.0 3D controller: Loongson Technology Test Device"
+	)
+	blacklist := []string{"Loongson"}
+	tests := []struct {
+		name           string
+		lspciOut       string
+		probeResult    bool
+		wantSupport    bool
+		wantProbeCalls int
+	}{
+		{"intel VGA preserves existing support", intelVGA, false, true, 0},
+		{"blacklisted VGA", loongsonVGA, true, false, 0},
+		// A positive global gamma query does not establish which PCI GPU owns the output.
+		{"blacklisted VGA plus headless Tesla", loongsonVGA + "\n" + tesla3D, true, false, 0},
+		{"headless Tesla before blacklisted VGA", tesla3D + "\n" + loongsonVGA, true, false, 0},
+		{"blacklisted VGA plus display controller", loongsonVGA + "\n" + amdDisplay, true, false, 0},
+		{"usable VGA after blacklisted VGA", loongsonVGA + "\n" + intelVGA, false, true, 0},
+		{"usable VGA before blacklisted VGA", intelVGA + "\n" + loongsonVGA, false, true, 0},
+		{"Tesla without gamma support", tesla3D, false, false, 1},
+		{"3D controller with output gamma support", tesla3D, true, true, 1},
+		{"display controller with output gamma support", amdDisplay, true, true, 1},
+		{"empty PCI list with platform GPU gamma", "", true, true, 1},
+		{"empty PCI list without gamma", "", false, false, 1},
+		{"no PCI displays with platform GPU gamma",
+			"00:00.0 PCI bridge: Phytium Technology Co., Ltd. Device dc01\n" +
+				"02:00.0 Network controller: Realtek Semiconductor Co., Ltd. RTL8852BE", true, true, 1},
+		{"blacklisted 3D device", loongson3D, true, false, 0},
+		{"blacklisted 3D device plus Tesla", loongson3D + "\n" + tesla3D, true, false, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			probeCalls := 0
+			got := detectGammaSupport(func() (string, error) {
+				return tt.lspciOut, nil
+			}, blacklist, func() bool {
+				probeCalls++
+				return tt.probeResult
+			})
+			if got != tt.wantSupport {
+				t.Errorf("detectGammaSupport() = %v, want %v", got, tt.wantSupport)
+			}
+			if probeCalls != tt.wantProbeCalls {
+				t.Errorf("gamma probe called %d times, want %d", probeCalls, tt.wantProbeCalls)
+			}
+		})
+	}
+}
+
+func TestDetectGammaSupportPCIEnumeration(t *testing.T) {
+	tests := []struct {
+		name           string
+		script         string
+		wantSupport    bool
+		wantProbeCalls int
+	}{
+		{name: "lspci missing"},
+		{name: "lspci exits unsuccessfully", script: "#!/bin/sh\nexit 1\n"},
+		{
+			name: "partial VGA output from a failed scan",
+			script: "#!/bin/sh\nprintf '%s\\n' " +
+				"'00:02.0 VGA compatible controller: Intel Corporation UHD Graphics 620'\nexit 1\n",
+		},
+		{
+			name:           "successful empty scan permits platform GPU probing",
+			script:         "#!/bin/sh\nexit 0\n",
+			wantSupport:    true,
+			wantProbeCalls: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			commandDir := t.TempDir()
+			if tt.script != "" {
+				if err := os.WriteFile(filepath.Join(commandDir, "lspci"), []byte(tt.script), 0700); err != nil {
+					t.Fatal(err)
+				}
+			}
+			t.Setenv("PATH", commandDir)
+			probeCalls := 0
+			got := detectGammaSupport(getLspci, []string{"Loongson"}, func() bool {
+				probeCalls++
+				return true
+			})
+			if got != tt.wantSupport || probeCalls != tt.wantProbeCalls {
+				t.Fatalf("support = %v, gamma probe calls = %d; want %v, %d",
+					got, probeCalls, tt.wantSupport, tt.wantProbeCalls)
+			}
+		})
+	}
+}
+
+func TestDetectGammaSupportPCIScanFailureAfterBlacklist(t *testing.T) {
+	commandDir := t.TempDir()
+	t.Setenv("PATH", commandDir)
+	for _, script := range []string{
+		"#!/bin/sh\nprintf '%s\\n' '00:06.0 VGA compatible controller: Loongson Technology 7A1000'\n",
+		"#!/bin/sh\nexit 1\n",
+	} {
+		if err := os.WriteFile(filepath.Join(commandDir, "lspci"), []byte(script), 0700); err != nil {
+			t.Fatal(err)
+		}
+		if detectGammaSupport(getLspci, []string{"Loongson"}, func() bool {
+			t.Error("gamma probing must not bypass the blacklist after a failed PCI scan")
+			return true
+		}) {
+			t.Fatal("an unsupported display GPU became supported")
+		}
+	}
+}
+
+func TestProbeRandrGammaSupport(t *testing.T) {
+	tests := []struct {
+		name        string
+		resources   randr.GetScreenResourcesReply
+		outputs     map[randr.Output]randr.GetOutputInfoReply
+		gammaSizes  map[randr.Crtc]uint16
+		gammaError  randr.Crtc
+		wantSupport bool
+	}{
+		{
+			name: "connected output with gamma",
+			resources: randr.GetScreenResourcesReply{
+				Outputs: []randr.Output{1},
+				Crtcs:   []randr.Crtc{10},
+			},
+			outputs: map[randr.Output]randr.GetOutputInfoReply{
+				1: {Connection: randr.ConnectionConnected, Crtc: 10},
+			},
+			gammaSizes:  map[randr.Crtc]uint16{10: 256},
+			wantSupport: true,
+		},
+		{
+			name: "headless CRTC cannot enable gamma",
+			resources: randr.GetScreenResourcesReply{
+				Crtcs: []randr.Crtc{10},
+			},
+			gammaSizes: map[randr.Crtc]uint16{10: 256},
+		},
+		{
+			name: "unused CRTC cannot override an active output without gamma",
+			resources: randr.GetScreenResourcesReply{
+				Outputs: []randr.Output{1},
+				Crtcs:   []randr.Crtc{10, 11},
+			},
+			outputs: map[randr.Output]randr.GetOutputInfoReply{
+				1: {Connection: randr.ConnectionConnected, Crtc: 10, Crtcs: []randr.Crtc{10, 11}},
+			},
+			gammaSizes: map[randr.Crtc]uint16{11: 256},
+		},
+		{
+			name: "unused CRTC cannot override an active gamma query failure",
+			resources: randr.GetScreenResourcesReply{
+				Outputs: []randr.Output{1},
+				Crtcs:   []randr.Crtc{10, 11},
+			},
+			outputs: map[randr.Output]randr.GetOutputInfoReply{
+				1: {Connection: randr.ConnectionConnected, Crtc: 10, Crtcs: []randr.Crtc{10, 11}},
+			},
+			gammaSizes: map[randr.Crtc]uint16{10: 256, 11: 256},
+			gammaError: 10,
+		},
+		{
+			name: "disconnected output with a compatible CRTC",
+			resources: randr.GetScreenResourcesReply{
+				Outputs: []randr.Output{1},
+				Crtcs:   []randr.Crtc{10},
+			},
+			outputs: map[randr.Output]randr.GetOutputInfoReply{
+				1: {Connection: randr.ConnectionDisconnected, Crtcs: []randr.Crtc{10}},
+			},
+			gammaSizes:  map[randr.Crtc]uint16{10: 256},
+			wantSupport: true,
+		},
+		{
+			name: "connected output awaiting CRTC assignment",
+			resources: randr.GetScreenResourcesReply{
+				Outputs: []randr.Output{1},
+				Crtcs:   []randr.Crtc{10},
+			},
+			outputs: map[randr.Output]randr.GetOutputInfoReply{
+				1: {Connection: randr.ConnectionConnected, Crtcs: []randr.Crtc{10}},
+			},
+			gammaSizes:  map[randr.Crtc]uint16{10: 256},
+			wantSupport: true,
+		},
+		{
+			name: "unrelated CRTC cannot cover an inactive output without gamma",
+			resources: randr.GetScreenResourcesReply{
+				Outputs: []randr.Output{1},
+				Crtcs:   []randr.Crtc{10, 11},
+			},
+			outputs: map[randr.Output]randr.GetOutputInfoReply{
+				1: {Connection: randr.ConnectionDisconnected, Crtcs: []randr.Crtc{10}},
+			},
+			gammaSizes: map[randr.Crtc]uint16{11: 256},
+		},
+		{
+			name: "output query failure cannot establish scanout capability",
+			resources: randr.GetScreenResourcesReply{
+				Outputs: []randr.Output{1},
+				Crtcs:   []randr.Crtc{10},
+			},
+			gammaSizes: map[randr.Crtc]uint16{10: 256},
+		},
+		{
+			name: "failed output status cannot enable the inactive CRTC fallback",
+			resources: randr.GetScreenResourcesReply{
+				Outputs: []randr.Output{1, 2},
+			},
+			outputs: map[randr.Output]randr.GetOutputInfoReply{
+				1: {Connection: randr.ConnectionDisconnected, Crtcs: []randr.Crtc{10}},
+				2: {Status: randr.StatusInvalidConfigTime},
+			},
+			gammaSizes: map[randr.Crtc]uint16{10: 256},
+		},
+		{
+			name: "failed output status cannot establish active gamma support",
+			resources: randr.GetScreenResourcesReply{
+				Outputs: []randr.Output{1},
+			},
+			outputs: map[randr.Output]randr.GetOutputInfoReply{
+				1: {Status: randr.StatusInvalidConfigTime, Connection: randr.ConnectionConnected, Crtc: 10},
+			},
+			gammaSizes: map[randr.Crtc]uint16{10: 256},
+		},
+		{
+			name: "valid active output can establish support after another output query fails",
+			resources: randr.GetScreenResourcesReply{
+				Outputs: []randr.Output{1, 2},
+			},
+			outputs: map[randr.Output]randr.GetOutputInfoReply{
+				1: {Status: randr.StatusInvalidConfigTime},
+				2: {Connection: randr.ConnectionConnected, Crtc: 11},
+			},
+			gammaSizes:  map[randr.Crtc]uint16{11: 256},
+			wantSupport: true,
+		},
+		{
+			name: "second connected output supports gamma",
+			resources: randr.GetScreenResourcesReply{
+				Outputs: []randr.Output{1, 2},
+				Crtcs:   []randr.Crtc{10, 11},
+			},
+			outputs: map[randr.Output]randr.GetOutputInfoReply{
+				1: {Connection: randr.ConnectionConnected, Crtc: 10},
+				2: {Connection: randr.ConnectionConnected, Crtc: 11},
+			},
+			gammaSizes:  map[randr.Crtc]uint16{11: 256},
+			wantSupport: true,
+		},
+		{name: "no resources"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := probeRandrGammaSupport(&tt.resources,
+				func(output randr.Output) (*randr.GetOutputInfoReply, error) {
+					info, ok := tt.outputs[output]
+					if !ok {
+						return nil, errors.New("output query failed")
+					}
+					return &info, nil
+				},
+				func(crtc randr.Crtc) (uint16, error) {
+					if crtc == tt.gammaError {
+						return 0, errors.New("gamma query failed")
+					}
+					return tt.gammaSizes[crtc], nil
+				})
+			if got != tt.wantSupport {
+				t.Errorf("probeRandrGammaSupport() = %v, want %v", got, tt.wantSupport)
+			}
+		})
+	}
+}
+
+func startGammaSupportTestWatcher(t *testing.T, detect func() bool) *Manager {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	m := &Manager{
+		// No object is exported, so property updates do not contact a D-Bus service.
+		service:                   dbusutil.NewService(nil),
+		gammaSupportUpdates:       make(chan struct{}, 1),
+		gammaSupportCtx:           ctx,
+		gammaSupportCancel:        cancel,
+		ColorTemperatureEnabled:   true,
+		ColorTemperatureMode:      ColorTemperatureModeCustom,
+		ColorTemperatureManual:    4200,
+		CustomColorTempTimePeriod: "20:00-07:00",
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		m.watchGammaSupport(detect)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Error("gamma support watcher did not stop")
+		}
+	})
+	return m
+}
+
+func waitForGammaSupport(t *testing.T, m *Manager, want bool) {
+	t.Helper()
+	deadline := time.NewTimer(2 * time.Second)
+	defer deadline.Stop()
+	tick := time.NewTicker(time.Millisecond)
+	defer tick.Stop()
+	for {
+		methodValue, err := m.SupportSetColorTemperature()
+		if err != nil {
+			t.Fatal(err)
+		}
+		m.PropsMu.RLock()
+		propertyValue := m.SupportColorTemperature
+		m.PropsMu.RUnlock()
+		if methodValue == want && propertyValue == want {
+			return
+		}
+		select {
+		case <-tick.C:
+		case <-deadline.C:
+			t.Fatalf("gamma support method = %v, property = %v, want %v", methodValue, propertyValue, want)
+		}
+	}
+}
+
+func TestGammaSupportRefreshAfterOutputChanges(t *testing.T) {
+	var gammaOutputEnabled atomic.Bool
+	probe := func() bool {
+		outputs := map[randr.Output]randr.GetOutputInfoReply{
+			1: {Connection: randr.ConnectionConnected, Crtc: 10, Crtcs: []randr.Crtc{10}},
+			2: {Connection: randr.ConnectionConnected, Crtcs: []randr.Crtc{11}},
+		}
+		if gammaOutputEnabled.Load() {
+			info := outputs[2]
+			info.Crtc = 11
+			outputs[2] = info
+		}
+		return detectGammaSupport(func() (string, error) {
+			return "", nil
+		}, nil, func() bool {
+			return probeRandrGammaSupport(&randr.GetScreenResourcesReply{Outputs: []randr.Output{1, 2}},
+				func(output randr.Output) (*randr.GetOutputInfoReply, error) {
+					info := outputs[output]
+					return &info, nil
+				},
+				func(crtc randr.Crtc) (uint16, error) {
+					if crtc == 11 {
+						return 256, nil
+					}
+					return 0, nil
+				})
+		})
+	}
+	m := startGammaSupportTestWatcher(t, probe)
+	m.updateGammaSupport(probe())
+	waitForGammaSupport(t, m, false)
+	for _, enabled := range []bool{true, false, true} {
+		gammaOutputEnabled.Store(enabled)
+		m.queueGammaSupportUpdate()
+		waitForGammaSupport(t, m, enabled)
+	}
+	if !m.ColorTemperatureEnabled || m.ColorTemperatureMode != ColorTemperatureModeCustom ||
+		m.ColorTemperatureManual != 4200 || m.CustomColorTempTimePeriod != "20:00-07:00" {
+		t.Fatal("capability refresh changed the user's color temperature settings")
+	}
+}
+
+func TestGammaSupportRefreshKeepsChangesDuringProbe(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	var calls atomic.Int32
+	m := startGammaSupportTestWatcher(t, func() bool {
+		if calls.Add(1) == 1 {
+			close(started)
+			<-release
+			return false
+		}
+		return true
+	})
+	// Release the blocked probe before the watcher's cleanup if an assertion fails.
+	t.Cleanup(func() { releaseOnce.Do(func() { close(release) }) })
+	m.queueGammaSupportUpdate()
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("gamma probe did not start")
+	}
+	for i := 0; i < 100; i++ {
+		m.queueGammaSupportUpdate()
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("gamma probes ran concurrently: %d probes started", got)
+	}
+	releaseOnce.Do(func() { close(release) })
+	waitForGammaSupport(t, m, true)
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("queued changes triggered %d probes, want 2", got)
+	}
+}
+
+func TestGammaSupportMethodMatchesProperty(t *testing.T) {
+	for _, inVM := range []bool{false, true} {
+		m := &Manager{service: dbusutil.NewService(nil), isVM: inVM}
+		for _, supported := range []bool{false, true, false, true} {
+			m.updateGammaSupport(supported)
+			got, err := m.SupportSetColorTemperature()
+			want := !inVM && supported
+			if err != nil || got != want || m.SupportColorTemperature != want {
+				t.Fatalf("inVM=%v gamma=%v: method=%v property=%v err=%v, want %v",
+					inVM, supported, got, m.SupportColorTemperature, err, want)
+			}
+		}
+	}
+}

--- a/display1/manager_ifc.go
+++ b/display1/manager_ifc.go
@@ -474,7 +474,9 @@ func (m *Manager) GetRealDisplayMode() (uint8, *dbus.Error) {
 }
 
 func (m *Manager) SupportSetColorTemperature() (bool, *dbus.Error) {
-	return !(m.isVM || !m.drmSupportGamma), nil
+	m.PropsMu.RLock()
+	defer m.PropsMu.RUnlock()
+	return m.SupportColorTemperature, nil
 }
 
 func (m *Manager) SetCustomColorTempTimePeriod(timePeriod string) *dbus.Error {

--- a/display1/xorg.go
+++ b/display1/xorg.go
@@ -11,8 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/linuxdeepin/dde-daemon/common/scale"
-
 	"github.com/davecgh/go-spew/spew"
 	"github.com/linuxdeepin/go-lib/log"
 	x "github.com/linuxdeepin/go-x11-client"
@@ -24,6 +22,7 @@ import (
 const concatScreenName = "DDE-CONCAT-SCREEN"
 
 var _hasRandr1d2 bool // 是否 randr 版本大于等于 1.2
+var _hasRandr1d3 bool // 是否支持 RandR 1.3 的 GetScreenResourcesCurrent
 
 var _useWayland bool
 
@@ -33,9 +32,19 @@ func Init(xConn *x.Conn, useWayland bool, inVM bool) {
 	_xConn = xConn
 	_useWayland = useWayland
 	_inVM = inVM
-	_hasRandr1d2 = scale.HasRandr1d2(xConn)
+	_hasRandr1d2 = false
+	_hasRandr1d3 = false
+	version, err := randr.QueryVersion(xConn, randr.MajorVersion, randr.MinorVersion).Reply(xConn)
+	if err != nil {
+		logger.Warning("query RandR version failed:", err)
+	} else {
+		logger.Debugf("randr version %d.%d", version.ServerMajorVersion, version.ServerMinorVersion)
+		_hasRandr1d2 = version.ServerMajorVersion > 1 ||
+			(version.ServerMajorVersion == 1 && version.ServerMinorVersion >= 2)
+		_hasRandr1d3 = version.ServerMajorVersion > 1 ||
+			(version.ServerMajorVersion == 1 && version.ServerMinorVersion >= 3)
+	}
 
-	var err error
 	if _greeterMode {
 		// 仅 greeter 需要
 		_, err = xfixes.QueryVersion(xConn, xfixes.MajorVersion, xfixes.MinorVersion).Reply(xConn)
@@ -89,10 +98,12 @@ func (m *Manager) listenXEvents() {
 				case randr.NotifyOutputChange:
 					e, _ := event.NewOutputChangeNotifyEvent()
 					m.mm.HandleEvent(e)
+					m.queueGammaSupportUpdate()
 
 				case randr.NotifyCrtcChange:
 					e, _ := event.NewCrtcChangeNotifyEvent()
 					m.mm.HandleEvent(e)
+					m.queueGammaSupportUpdate()
 
 				case randr.NotifyOutputProperty:
 					e, _ := event.NewOutputPropertyNotifyEvent()
@@ -104,6 +115,7 @@ func (m *Manager) listenXEvents() {
 				event, _ := randr.NewScreenChangeNotifyEvent(ev)
 				cfgTsChanged := m.mm.HandleScreenChanged(event)
 				m.handleScreenChanged(event, cfgTsChanged)
+				m.queueGammaSupportUpdate()
 
 			case x.GeGenericEventCode:
 				if !_greeterMode {


### PR DESCRIPTION
## BUG-376203
Non-VGA and platform GPUs can expose gamma-capable outputs while the VGA-only PCI check reports color-temperature support as unavailable. Probe their RandR outputs before reporting support, preserve the Loongson blacklist, and reject failed PCI scans and unsuccessful RandR replies.

Refresh the shared capability after output, CRTC and screen changes without resetting the user's color-temperature settings. A single worker coalesces pending notifications; RandR 1.3 and later use `GetScreenResourcesCurrent` to avoid hardware polling during refreshes, with the RandR 1.2 compatibility path retained. Keep the D-Bus property and capability method synchronized.

This resubmits #1234 after its accidental merge was reverted in #1236. The code is identical to the original merged change (`7de6aff4af0743e4e92773a312dc711a16dca069`). Human review and approval are pending and must be completed before this PR is merged.

非 VGA 和平台 GPU 即使具备 gamma 输出能力，原有仅检查 PCI VGA 设备的逻辑仍可能报告不支持色温调节。本次增加 RandR 输出能力探测，保留龙芯黑名单并处理扫描、查询失败；在显示拓扑变化后同步刷新能力属性和方法，保留用户设置，并避免新版 RandR 刷新时反复轮询硬件。

原 PR #1234 在完成人工审阅前被误合并，已通过 #1236 撤销。本 PR 基于撤销后的 `master` 重新提交相同代码，等待人工审阅及 Approve 后再合并。

Validation:

- Confirmed that the complete repository tree matches the original merged commit `7de6aff4af0743e4e92773a312dc711a16dca069` exactly.
- The PR contains one new commit with the original diff: 5 files, 649 insertions and 30 deletions.
- Passed `git diff --cached --check` before committing.
- Passed `go test -mod=readonly -p 2 ./display1 -count=1`.
- Passed `go test -mod=readonly -race -p 2 ./display1 -run 'Test(DetectGammaSupport|ProbeRandrGammaSupport|GammaSupport)' -count=1`.

Hardware gamma writes, physical display hotplug and legacy RandR 1.2 behavior were not exercised during this resubmission. Previous hardware validation is recorded in #1234.

## Summary by Sourcery

Improve display gamma capability detection and keep color-temperature support synchronized with display topology changes.

New Features:
- Detect gamma-capable displays through RandR outputs for non-VGA and platform GPUs while preserving the Loongson blacklist.
- Refresh color-temperature capability state when RandR output, CRTC, or screen topology changes.

Bug Fixes:
- Reject failed PCI scans and unsuccessful RandR responses instead of reporting misleading gamma support.
- Keep the D-Bus capability method synchronized with the capability property and preserve user color-temperature settings during refreshes.

Enhancements:
- Coalesce capability notifications into a single cancellable worker and use current RandR screen resources on RandR 1.3 and later to avoid unnecessary hardware polling while retaining the RandR 1.2 path.

Tests:
- Add coverage for PCI detection, RandR gamma probing, capability refresh behavior, notification coalescing, cancellation, and method/property consistency.