### PR TITLE
feat(display1): migrate default brightness curve from startdde

### DIFF
--- a/display1/brightness.go
+++ b/display1/brightness.go
@@ -5,11 +5,14 @@
 package display1
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/godbus/dbus/v5"
 
 	"github.com/linuxdeepin/dde-daemon/display1/brightness"
 	"github.com/linuxdeepin/dde-daemon/display1/utils"
@@ -17,6 +20,218 @@ import (
 
 type InvalidOutputNameError struct {
 	Name string
+}
+
+// initBacklightCurve 初始化背光曲线相关特征配置
+// 与 startdde 保持相同的特征判定逻辑：
+//  1. backLight-max-brightness-choose-big：ProductName 命中列表
+//  2. BoardName 匹配：custom-brightness-curves 配置 boardName 与 DMI 板名匹配
+func (m *Manager) initBacklightCurve() {
+	brightness.SetProductName(getDmiProductName())
+	brightness.SetDeviceBoardName(getDmiBoardName())
+
+	m.getBackLightMaxBrightnessChooseBigConfig()
+	m.getDsgBrightnessPercentage()
+	m.getCustomBrightnessCurves()
+	m.getDefaultBrightnessCurve()
+	m.getMaxBrightnessUnlimited()
+
+	m.refreshMaxBacklightBrightness()
+}
+
+// getDsgBrightnessPercentage 读取实际亮度百分比（取值范围 [50,100]）
+func (m *Manager) getDsgBrightnessPercentage() {
+	v, err := m.displayConfigMgr.Value(0, DSettingsKeyBrightnessPercentage)
+	if err != nil {
+		logger.Warning(err)
+		m.dsgBrightnessPercentage = 100
+		return
+	}
+	switch vType := v.Value().(type) {
+	case float64:
+		m.dsgBrightnessPercentage = int32(vType)
+	case int64:
+		m.dsgBrightnessPercentage = int32(vType)
+	default:
+		logger.Warning("type is wrong!")
+		m.dsgBrightnessPercentage = 100
+	}
+
+	// limit min/max value
+	if m.dsgBrightnessPercentage < 50 {
+		m.dsgBrightnessPercentage = 50
+	} else if m.dsgBrightnessPercentage > 100 {
+		m.dsgBrightnessPercentage = 100
+	}
+	logger.Info("Brightness percentage value:", m.dsgBrightnessPercentage)
+}
+
+// refreshMaxBacklightBrightness 重新计算并刷新 MaxBacklightBrightness 属性
+func (m *Manager) refreshMaxBacklightBrightness() {
+	m.setPropMaxBacklightBrightness(uint32(brightness.GetMaxBacklightBrightness()))
+}
+
+// getBackLightMaxBrightnessChooseBigConfig 读取 ProductName 命中后选最大亮度的机型列表
+func (m *Manager) getBackLightMaxBrightnessChooseBigConfig() {
+	v, err := m.displayConfigMgr.Value(0, DSettingsKeyBackLightMaxBrightnessChooseBigConfig)
+	if err != nil {
+		logger.Warning(err)
+		return
+	}
+	itemList, ok := v.Value().([]dbus.Variant)
+	if !ok {
+		logger.Warning("Backlight choose big product names configuration is not a list")
+		return
+	}
+	var list []string
+	for _, i := range itemList {
+		item, ok := i.Value().(string)
+		if !ok {
+			logger.Warning("Backlight choose big product name is not a string")
+			return
+		}
+		list = append(list, item)
+	}
+	m.chooseBigProductNames = list
+	brightness.SetChooseBigProductNames(list)
+	logger.Info("Backlight choose big product names:", list)
+}
+
+// getCustomBrightnessCurves 读取自定义亮度曲线配置
+func (m *Manager) getCustomBrightnessCurves() {
+	v, err := m.displayConfigMgr.Value(0, DSettingsKeyCustomBrightnessCurves)
+	if err != nil {
+		logger.Warning(err)
+		return
+	}
+	jsonStr, ok := v.Value().(string)
+	if !ok {
+		logger.Warning("Custom brightness curves configuration is not a string")
+		return
+	}
+	brightness.SetCustomBrightnessCurves(jsonStr)
+	m.setPropCurveMaxScale(brightness.GetCurrentMaxScale())
+}
+
+// getDefaultBrightnessCurve 读取默认亮度曲线配置
+func (m *Manager) getDefaultBrightnessCurve() {
+	v, err := m.displayConfigMgr.Value(0, DSettingsKeyDefaultBrightnessCurve)
+	if err != nil {
+		logger.Warning(err)
+		return
+	}
+	jsonStr, ok := v.Value().(string)
+	if !ok {
+		logger.Warning("Default brightness curve configuration is not a string")
+		return
+	}
+	brightness.SetDefaultBrightnessCurve(jsonStr)
+}
+
+// getMaxBrightnessUnlimited 读取最大亮度不受限开关，并在 BoardName 匹配时启用
+func (m *Manager) getMaxBrightnessUnlimited() {
+	v, err := m.displayConfigMgr.Value(0, DSettingsKeyMaxBrightnessUnlimited)
+	if err != nil {
+		logger.Warning(err)
+		return
+	}
+	enabled, ok := v.Value().(bool)
+	if !ok {
+		logger.Warning("max-brightness-unlimited is not bool type")
+		return
+	}
+
+	brightness.SetDeviceBoardName(getDmiBoardName())
+	boardSupported := brightness.IsDeviceSupported()
+	if !boardSupported {
+		logger.Warningf("Current board %s not match config", getDmiBoardName())
+		return
+	}
+
+	maxScale := brightness.GetCurrentMaxScale()
+	if maxScale <= 100 {
+		logger.Warningf("Curve scale %d too low", maxScale)
+		return
+	}
+
+	logger.Info("Max brightness unlimited:", enabled)
+
+	// 同步 DBus 属性与受限亮度（setMaxBrightnessUnlimited 内部会触发 resetLimitedBrightness）
+	m.setMaxBrightnessUnlimited(enabled)
+}
+
+// resetLimitedBrightness 根据缩放值变化调整亮度属性值
+func (m *Manager) resetLimitedBrightness() {
+	builtinMonitor := m.getBuiltinMonitor()
+	if builtinMonitor == nil {
+		return
+	}
+	currentBr := builtinMonitor.Brightness
+	var newBr float64
+	maxScale := brightness.GetCurrentMaxScale()
+	if maxScale <= 100 {
+		return
+	}
+	if m.MaxBrightnessUnlimited {
+		newBr = currentBr * 100.0 / float64(maxScale)
+	} else {
+		newBr = currentBr * float64(maxScale) / 100.0
+	}
+	logger.Debugf("Updating brightness property for scale change: %f -> %f", currentBr, newBr)
+
+	if newBr > 1.0 {
+		newBr = 1.0
+		m.SetBrightness(builtinMonitor.Name, newBr)
+	} else {
+		builtinMonitor.setPropBrightnessWithLock(newBr)
+		m.syncPropBrightness()
+	}
+}
+
+// setMaxBrightnessUnlimited 设置最大亮度不受限功能（DBus 属性写回调）
+func (m *Manager) setMaxBrightnessUnlimited(enabled bool) error {
+	logger.Infof("SetMaxBrightnessUnlimited called with: %v", enabled)
+
+	brightness.SetDeviceBoardName(getDmiBoardName())
+	boardSupported := brightness.IsDeviceSupported()
+	if !boardSupported {
+		logger.Warningf("Current board %s not match config, cannot enable max brightness limit", getDmiBoardName())
+		return errors.New("board name mismatch: current board not supported")
+	}
+
+	maxScale := brightness.GetCurrentMaxScale()
+	if maxScale <= 100 {
+		logger.Warningf("Curve max scale too small: %d", maxScale)
+		return errors.New("Curve config: max scale too low")
+	}
+
+	brightness.SetMaxBrightnessUnlimited(enabled)
+
+	if m.MaxBrightnessUnlimited != enabled {
+		m.MaxBrightnessUnlimited = enabled
+		m.emitPropChangedMaxBrightnessUnlimited(enabled)
+	}
+
+	m.resetLimitedBrightness()
+
+	return nil
+}
+
+// emitPropChangedMaxBrightnessUnlimited 发送 MaxBrightnessUnlimited 属性变化信号
+func (m *Manager) emitPropChangedMaxBrightnessUnlimited(value bool) error {
+	return m.service.EmitPropertyChanged(m, "MaxBrightnessUnlimited", value)
+}
+
+// setPropCurveMaxScale 设置 CurveMaxScale 属性
+func (m *Manager) setPropCurveMaxScale(value int32) {
+	if m.CurveMaxScale != value {
+		m.CurveMaxScale = value
+		m.emitPropChangedCurveMaxScale(value)
+	}
+}
+
+func (m *Manager) emitPropChangedCurveMaxScale(value int32) error {
+	return m.service.EmitPropertyChanged(m, "CurveMaxScale", value)
 }
 
 func (err InvalidOutputNameError) Error() string {
@@ -178,6 +393,10 @@ func (m *Manager) isBuiltinMonitor(name string) bool {
 }
 
 func (m *Manager) setMonitorBrightness(monitor *Monitor, brightnessValue float64) error {
+	// 根据dsg调整实际亮度百分比
+	brightnessValue = math.Round(brightnessValue*float64(m.dsgBrightnessPercentage)) / 100.0
+	logger.Debug("setMonitorBrightness reality value:", brightnessValue)
+
 	setter := m.createBrightnessSetter(monitor)
 	if setter == nil {
 		return fmt.Errorf("failed to create brightness setter for monitor %s", monitor.Name)

--- a/display1/brightness/brightness.go
+++ b/display1/brightness/brightness.go
@@ -5,6 +5,7 @@
 package brightness
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"sync"
@@ -18,9 +19,30 @@ import (
 )
 
 var _useWayland bool
+var _productName string
+var _chooseBigProductNames []string
 
 func SetUseWayland(value bool) {
 	_useWayland = value
+}
+
+// SetProductName 设置设备 ProductName，用于 backLight-max-brightness-choose-big 特征判断
+func SetProductName(productName string) {
+	_productName = productName
+}
+
+// SetChooseBigProductNames 设置 ProductName 命中后选最大背光亮度的机型列表
+func SetChooseBigProductNames(list []string) {
+	_chooseBigProductNames = list
+}
+
+func isChooseBigProduct() bool {
+	for _, name := range _chooseBigProductNames {
+		if name == _productName {
+			return true
+		}
+	}
+	return false
 }
 
 const (
@@ -83,10 +105,20 @@ func GetMaxBacklightBrightness() int {
 	if len(controllers) == 0 {
 		return 0
 	}
+
 	maxBrightness := controllers[0].MaxBrightness
-	for _, controller := range controllers {
-		if maxBrightness > controller.MaxBrightness {
-			maxBrightness = controller.MaxBrightness
+	if isChooseBigProduct() {
+		// backLight-max-brightness-choose-big 命中的机型取最大亮度
+		for _, controller := range controllers {
+			if maxBrightness < controller.MaxBrightness {
+				maxBrightness = controller.MaxBrightness
+			}
+		}
+	} else {
+		for _, controller := range controllers {
+			if maxBrightness > controller.MaxBrightness {
+				maxBrightness = controller.MaxBrightness
+			}
 		}
 	}
 	return maxBrightness
@@ -177,10 +209,43 @@ func init() {
 }
 
 func _setBacklight(value float64, controller *displayBl.Controller) error {
+	// 通过曲线函数计算亮度值
 	br := int32(float64(controller.MaxBrightness) * value)
 
+	v, ok := GetBacklightCurveValue(value, controller)
+	if ok {
+		logger.Debugf("Brightness curve value: %v", v)
+		br = v
+	}
+
 	const backlightTypeDisplay = 1
+	logger.Infof("help set brightness %q max %v value %v br %v",
+		controller.Name, controller.MaxBrightness, value, br)
 	return helper.SetBrightness(0, backlightTypeDisplay, controller.Name, br)
+}
+
+// search the backlight devices and prefer the types:
+// firmware -> platform -> raw
+func getBestBacklightController(controllers displayBl.Controllers) *displayBl.Controller {
+	var ret *displayBl.Controller
+	for _, controller := range controllers {
+		if ret == nil || ret.Type > controller.Type {
+			ret = controller
+		}
+	}
+
+	return ret
+}
+
+func setBestBacklightController(controllers displayBl.Controllers, value float64) error {
+	if controller := getBestBacklightController(controllers); controller != nil {
+		err := _setBacklight(value, controller)
+		if err != nil {
+			logger.Warningf("failed to set backlight by %s: %v", controller.Name, err)
+		}
+		return err
+	}
+	return errors.New("setBestBacklightController failed to set best backlight.")
 }
 
 // backlightControllerCache 背光控制器缓存
@@ -222,12 +287,26 @@ func SetBacklight(brightness float64) error {
 		return fmt.Errorf("no backlight controllers available")
 	}
 
-	for _, controller := range controllers {
-		err := _setBacklight(brightness, controller)
-		if err != nil {
-			logger.Warningf("Failed to set backlight %s: %v", controller.Name, err)
-		}
+	return setBacklight(brightness, controllers)
+}
+
+func setBacklight(value float64, controllers displayBl.Controllers) error {
+	if err := setBestBacklightController(controllers, value); err != nil {
+		logger.Warning(err)
+	} else {
+		return nil
 	}
+
+	// 有些厂商机器存在写背光文件延时，bug-307835
+	go func() {
+		for _, controller := range controllers {
+			err := _setBacklight(value, controller)
+			if err != nil {
+				logger.Warningf("WARN: failed to set backlight %s: %v", controller.Name, err)
+			}
+		}
+	}()
+
 	return nil
 }
 

--- a/display1/brightness/curve.go
+++ b/display1/brightness/curve.go
@@ -1,0 +1,409 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package brightness
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"strings"
+	"sync"
+
+	displayBl "github.com/linuxdeepin/go-lib/backlight/display"
+)
+
+const (
+	DefaultScale = 100
+)
+
+// BrightnessPoint 亮度曲线点
+type BrightnessPoint struct {
+	Percentage int32 `json:"percentage"` // 亮度百分比 (0-100)
+	Value      int32 `json:"value"`      // 对应的亮度百分比 (0-100)，表示最大亮度的百分比
+}
+
+// BrightnessCurveConfig 自定义亮度曲线配置
+type BrightnessCurveConfig struct {
+	EDID        string            `json:"edid,omitempty"` // 屏幕EDID标识（可选，默认曲线不需要）
+	CurvePoints []BrightnessPoint `json:"curve_points"`   // 亮度曲线点
+	MaxLimit    int32             `json:"max_limit"`      // 最大亮度限制百分比 (0-100)，表示最大亮度的百分比
+	MaxScale    int32             `json:"max_scale"`      // 告知外部曲线最大比例
+}
+
+// CurveManager 管理亮度曲线的配置和计算
+type CurveManager struct {
+	mu sync.RWMutex // 统一的锁保护所有状态
+
+	// 亮度限制功能使用的硬件信息
+	configBoardName string
+	deviceBoardName string
+
+	// 亮度限制功能开关与缩放值
+	maxBrightnessUnlimited bool
+	maxScale               int32
+
+	// 默认曲线函数
+	defaultCurveFunc func(percentage float64, maxBrightness int) int32
+
+	// 受限曲线
+	// 配置上可能会有多项，但只应用第一个匹配上的，因为多控制器可能导致亮度设置错乱
+	limitedCurveFunc func(percentage float64) int32
+}
+
+// 全局 CurveManager 实例
+var _curveManager = &CurveManager{
+	maxBrightnessUnlimited: true,
+	maxScale:               DefaultScale,
+	defaultCurveFunc:       nil,
+	limitedCurveFunc:       nil,
+}
+
+func SetCustomBrightnessCurves(jsonStr string) {
+	_curveManager.setCustomBrightnessCurves(jsonStr)
+}
+
+func SetMaxBrightnessUnlimited(enabled bool) {
+	_curveManager.setMaxBrightnessUnlimited(enabled)
+}
+
+func GetBacklightCurveValue(v float64, c *displayBl.Controller) (int32, bool) {
+	return _curveManager.getCurveValue(v, c)
+}
+
+func SetDeviceBoardName(boardName string) {
+	_curveManager.setDeviceBoardName(boardName)
+}
+
+// SetDefaultBrightnessCurve 设置默认亮度曲线（不依赖硬件信息）
+func SetDefaultBrightnessCurve(jsonStr string) {
+	_curveManager.setDefaultBrightnessCurve(jsonStr)
+}
+
+func IsDeviceSupported() bool {
+	return _curveManager.isDeviceSupported()
+}
+
+func IsMaxLimitCurveSupported() bool {
+	return _curveManager.isMaxLimitCurveSupported()
+}
+
+func GetCurrentMaxScale() int32 {
+	return _curveManager.getCurrentMaxScale()
+}
+
+// interpolateCurveValue 对曲线点进行线性插值计算
+// percentage: 输入百分比 (0-100)
+// curvePoints: 曲线点数组
+// 返回插值后的曲线值（百分比形式）
+func interpolateCurveValue(percentage float64, curvePoints []BrightnessPoint) float64 {
+	if percentage <= 0 {
+		return float64(curvePoints[0].Value)
+	}
+
+	if percentage >= 100 {
+		return float64(curvePoints[len(curvePoints)-1].Value)
+	}
+
+	// 线性插值
+	curveValue := float64(curvePoints[0].Value)
+	for i := 0; i < len(curvePoints)-1; i++ {
+		p1, p2 := curvePoints[i], curvePoints[i+1]
+		if percentage >= float64(p1.Percentage) && percentage <= float64(p2.Percentage) {
+			x1, x2 := float64(p1.Percentage), float64(p2.Percentage)
+			y1, y2 := float64(p1.Value), float64(p2.Value)
+			if x2 == x1 {
+				curveValue = y1
+			} else {
+				curveValue = y1 + (y2-y1)*(percentage-x1)/(x2-x1)
+			}
+			break
+		}
+	}
+
+	return curveValue
+}
+
+func matchControllerByEDID(controller *displayBl.Controller, configEDID string) bool {
+	if configEDID == "" || controller.DeviceEDID == nil {
+		return false
+	}
+
+	// 厂商把产品型号作为字符串存于edid中，可以直接读到
+	s := string(controller.DeviceEDID)
+	// 检查配置中的EDID标识是否包含在完整的EDID中
+	return strings.Contains(strings.ToLower(s), strings.ToLower(configEDID))
+}
+
+// 配置验证
+func validateBrightnessCurve(curve BrightnessCurveConfig) error {
+	if curve.MaxLimit < 0 {
+		return fmt.Errorf("max_limit must be over 0, got: %d", curve.MaxLimit)
+	}
+
+	if len(curve.CurvePoints) == 0 {
+		return fmt.Errorf("curve_points cannot be empty")
+	}
+
+	// 验证曲线点非递减
+	for i := 1; i < len(curve.CurvePoints); i++ {
+		if curve.CurvePoints[i].Percentage < curve.CurvePoints[i-1].Percentage {
+			return fmt.Errorf("curve points must be in non-descending order")
+		}
+	}
+
+	return nil
+}
+
+// generateDefaultCurveFuncLocked 生成默认曲线函数（全局唯一）
+// 注意：调用此方法前必须持有写锁
+func (cm *CurveManager) generateDefaultCurveFuncLocked(curve BrightnessCurveConfig) {
+	logger.Debugf("Generating default curve function with %d points", len(curve.CurvePoints))
+
+	// 默认曲线函数：根据百分比和最大亮度计算实际亮度值
+	cm.defaultCurveFunc = func(percentage float64, maxBrightness int) int32 {
+		// 使用统一的插值函数
+		curveValue := interpolateCurveValue(percentage, curve.CurvePoints)
+
+		// 默认曲线不使用 max_limit，曲线点已经定义了完整的映射关系
+
+		// 转换为实际亮度值
+		return int32(math.Round(curveValue * float64(maxBrightness) / 100.0))
+	}
+
+	logger.Debug("Default curve function generated")
+}
+
+// setCustomBrightnessCurves 设置自定义亮度曲线配置（内部方法）
+func (cm *CurveManager) setCustomBrightnessCurves(jsonStr string) {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+
+	cm.limitedCurveFunc = nil
+
+	// 解析配置
+	err := cm.parseCustomBrightnessCurves(jsonStr)
+	if err != nil {
+		logger.Debugf("Failed to parse custom brightness curves: %v", err)
+		return
+	}
+
+	logger.Info("Custom brightness curves set successfully")
+}
+
+// setMaxBrightnessUnlimited 设置最大亮度不受限制（内部方法）
+func (cm *CurveManager) setMaxBrightnessUnlimited(enabled bool) {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+
+	cm.maxBrightnessUnlimited = enabled
+	logger.Infof("Set max brightness unlimited: %v", enabled)
+}
+
+// isMaxBrightnessUnlimited 检查是否启用最大亮度不受限制（内部方法）
+func (cm *CurveManager) isMaxBrightnessUnlimited() bool {
+	return cm.maxBrightnessUnlimited
+}
+
+// parseCustomBrightnessCurves 解析自定义亮度曲线配置
+func (cm *CurveManager) parseCustomBrightnessCurves(jsonStr string) error {
+	var config struct {
+		BoardName string                  `json:"boardName"`
+		Curves    []BrightnessCurveConfig `json:"curves"`
+	}
+
+	// Remove any backslash characters from the input JSON string
+	jsonStr = strings.ReplaceAll(jsonStr, "\\", "")
+
+	logger.Debugf("Parsing custom brightness curves: %s", jsonStr)
+
+	if err := json.Unmarshal([]byte(jsonStr), &config); err != nil {
+		return fmt.Errorf("Custom curve failed to parse JSON: %v", err)
+	}
+
+	// 存储 boardName
+	cm.configBoardName = config.BoardName
+
+	if config.Curves == nil {
+		return fmt.Errorf("Custom curve json contains nothing")
+	}
+
+	controllers, err := displayBl.List()
+	if err != nil {
+		return fmt.Errorf("Custom curve failed to list controllers: %v", err)
+	}
+
+	for _, curve := range config.Curves {
+		// 验证 EDID 字段不能为空
+		if curve.EDID == "" {
+			logger.Debug("Skipping curve config with empty EDID")
+			continue
+		}
+
+		if err := validateBrightnessCurve(curve); err != nil {
+			logger.Warningf("Curve validation failed for EDID %s: %v", curve.EDID, err)
+			continue
+		}
+
+		for _, controller := range controllers {
+			if matchControllerByEDID(controller, curve.EDID) {
+				logger.Infof("Found matching controller for EDID %s: %s", curve.EDID, controller.Name)
+				cm.limitedCurveFunc = cm.generateCustomCurveFunc(curve, int32(controller.MaxBrightness))
+				cm.maxScale = curve.MaxScale
+				return nil
+			}
+		}
+	}
+
+	logger.Debug("Custom curve config missed all controller")
+	return nil
+}
+
+func (cm *CurveManager) generateCustomCurveFunc(curve BrightnessCurveConfig, controllerMaxBrightness int32) func(float64) int32 {
+	return func(percentage float64) int32 {
+		// 使用统一的插值函数
+		curveValue := interpolateCurveValue(percentage, curve.CurvePoints)
+
+		// 应用max_limit限制
+		cm.mu.RLock()
+		unlimited := cm.maxBrightnessUnlimited
+		cm.mu.RUnlock()
+
+		if !unlimited && curve.MaxLimit > 0 && curve.MaxLimit < 100 {
+			curveValue = curveValue * float64(curve.MaxLimit) / 100.0
+		}
+
+		// 转换为实际亮度值
+		return int32(math.Round(curveValue * float64(controllerMaxBrightness) / 100.0))
+	}
+}
+
+// 根据当前设置亮度百分比与控制器，返回由曲线控制的实际亮度
+func (cm *CurveManager) getCurveValue(v float64, c *displayBl.Controller) (int32, bool) {
+	// 将v转为合适的值，注意精度，不要过早转为整数
+	vv := 100 * v
+
+	cm.mu.RLock()
+	supported := cm.isDeviceSupportedLocked()
+	unlimited := cm.maxBrightnessUnlimited
+	limitedFunc := cm.limitedCurveFunc
+	defaultFunc := cm.defaultCurveFunc
+	cm.mu.RUnlock()
+
+	// 如果存在自定义曲线，检查适用性
+	if !supported || unlimited || limitedFunc == nil {
+		logger.Debugf("Limited curve not working now, maxBrightnessUnlimited=%v, func exist=%v", unlimited, limitedFunc != nil)
+	} else {
+		return limitedFunc(vv), true
+	}
+
+	if defaultFunc != nil {
+		return defaultFunc(vv, c.MaxBrightness), true
+	}
+
+	// 默认无处理的值
+	return int32(v * float64(c.MaxBrightness)), false
+}
+
+// setDeviceBoardName 设置设备板名（内部方法）
+func (cm *CurveManager) setDeviceBoardName(boardName string) {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	cm.deviceBoardName = boardName
+}
+
+// setDefaultBrightnessCurve 设置默认亮度曲线（内部方法）
+func (cm *CurveManager) setDefaultBrightnessCurve(jsonStr string) {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+
+	cm.defaultCurveFunc = nil
+
+	err := cm.parseDefaultBrightnessCurve(jsonStr)
+	if err != nil {
+		logger.Warningf("Failed to parse default brightness curve: %v", err)
+		return
+	}
+
+	logger.Info("Default brightness curve set successfully")
+}
+
+// parseDefaultBrightnessCurve 解析默认亮度曲线配置
+func (cm *CurveManager) parseDefaultBrightnessCurve(jsonStr string) error {
+	// Remove any backslash characters from the input JSON string
+	jsonStr = strings.ReplaceAll(jsonStr, "\\", "")
+
+	logger.Debugf("Parsing default brightness curve: %s", jsonStr)
+
+	var curve BrightnessCurveConfig
+	if err := json.Unmarshal([]byte(jsonStr), &curve); err != nil {
+		return fmt.Errorf("failed to parse JSON: %v", err)
+	}
+
+	// 验证曲线配置
+	if err := validateBrightnessCurve(curve); err != nil {
+		return fmt.Errorf("invalid curve config: %v", err)
+	}
+
+	cm.generateDefaultCurveFuncLocked(curve)
+
+	logger.Infof("Default brightness curve parsed successfully: %d points", len(curve.CurvePoints))
+
+	return nil
+}
+
+// isDeviceSupported 检查设备是否支持（内部方法）
+func (cm *CurveManager) isDeviceSupported() bool {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+	return cm.isDeviceSupportedLocked()
+}
+
+// isDeviceSupportedLocked 检查设备是否支持（需要持有锁）
+func (cm *CurveManager) isDeviceSupportedLocked() bool {
+	if cm.configBoardName == "" {
+		return true
+	}
+
+	if cm.deviceBoardName == "" {
+		return false
+	}
+
+	if !strings.Contains(strings.ToLower(cm.configBoardName), strings.ToLower(cm.deviceBoardName)) {
+		return false
+	}
+
+	return true
+}
+
+// isMaxLimitCurveSupported 检查是否支持最大亮度限制曲线（内部方法）
+func (cm *CurveManager) isMaxLimitCurveSupported() bool {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+
+	if !cm.isDeviceSupportedLocked() {
+		return false
+	}
+
+	// 检查是否有任何控制器在自定义曲线映射中存在
+	return cm.limitedCurveFunc != nil
+}
+
+// getCurrentMaxScale 获取当前最大缩放值（内部方法）
+func (cm *CurveManager) getCurrentMaxScale() int32 {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+
+	// 如果没有自定义曲线配置，返回默认值 100（表示100%）
+	if cm.limitedCurveFunc == nil || !cm.isDeviceSupportedLocked() {
+		return DefaultScale
+	}
+
+	if cm.maxScale > DefaultScale {
+		return cm.maxScale
+	}
+
+	// 如果没有设置 MaxScale，返回默认值 100（表示100%）
+	return DefaultScale
+}

--- a/display1/display.go
+++ b/display1/display.go
@@ -63,6 +63,26 @@ func Start(service *dbusutil.Service) error {
 				err = m.setColorTempMode(mode)
 				return dbusutil.ToError(err)
 			})
+
+			err = so.SetWriteCallback(m, "MaxBrightnessUnlimited", func(write *dbusutil.PropertyWrite) *dbus.Error {
+				value, ok := write.Value.(bool)
+				if !ok {
+					err = errors.New("Type is not bool")
+					logger.Warning(err)
+					return dbusutil.ToError(err)
+				}
+				err = m.setMaxBrightnessUnlimited(value)
+				if err != nil {
+					return dbusutil.ToError(err)
+				}
+				// 持久化配置
+				err = setGlobalDconfValue(DSettingsAppID, DSettingsDisplayName, "", DSettingsKeyMaxBrightnessUnlimited, dbus.MakeVariant(value))
+				if err != nil {
+					logger.Warning("failed to save max brightness unlimited config:", err)
+					return dbusutil.ToError(err)
+				}
+				return nil
+			})
 		}
 
 		err = service.RequestName(dbusServiceName)

--- a/display1/manager.go
+++ b/display1/manager.go
@@ -99,6 +99,13 @@ const (
 	DSettingsKeyTransitionStepPercent     = "transition-step-percent"
 	DSettingsKeyTransitionMinStepInterval = "transition-min-step-interval"
 
+	// 背光曲线配置
+	DSettingsKeyBackLightMaxBrightnessChooseBigConfig = "backLight-max-brightness-choose-big"
+	DSettingsKeyBrightnessPercentage                  = "brightness-percentage"
+	DSettingsKeyCustomBrightnessCurves                = "custom-brightness-curves"
+	DSettingsKeyDefaultBrightnessCurve                = "default-brightness-curve"
+	DSettingsKeyMaxBrightnessUnlimited                = "max-brightness-unlimited"
+
 	customModeDelim              = "+"
 	monitorsIdDelimiter          = ","
 	defaultTemperatureMode       = ColorTemperatureModeNone
@@ -230,6 +237,10 @@ type Manager struct {
 	ScreenHeight           uint16
 	MaxBacklightBrightness uint32
 
+	// 背光曲线相关属性
+	CurveMaxScale          int32 `prop:"access:r"`
+	MaxBrightnessUnlimited bool  `prop:"access:rw"`
+
 	// TODO 删除下面 2 个色温相关字段
 	// 存在gsetting中的色温模式
 	gsColorTemperatureMode int32
@@ -267,6 +278,10 @@ type Manager struct {
 	sysPower syspower.Power
 
 	dsAutoChangeScaleEnabled bool
+
+	// 背光曲线相关配置
+	dsgBrightnessPercentage int32
+	chooseBigProductNames   []string
 }
 
 type monitorSizeInfo struct {
@@ -509,6 +524,17 @@ func (m *Manager) initDConfig(sysBus *dbus.Conn) {
 			m.getAutoChangeScaleEnabled()
 		case DSettingsKeyCanSetBrightnessDelay:
 			m.getBrightnessDelaySet()
+		case DSettingsKeyBrightnessPercentage:
+			m.getDsgBrightnessPercentage()
+		case DSettingsKeyCustomBrightnessCurves:
+			m.getCustomBrightnessCurves()
+		case DSettingsKeyDefaultBrightnessCurve:
+			m.getDefaultBrightnessCurve()
+		case DSettingsKeyMaxBrightnessUnlimited:
+			m.getMaxBrightnessUnlimited()
+		case DSettingsKeyBackLightMaxBrightnessChooseBigConfig:
+			m.getBackLightMaxBrightnessChooseBigConfig()
+			m.refreshMaxBacklightBrightness()
 		default:
 			break
 		}
@@ -527,6 +553,7 @@ func (m *Manager) loadInitialConfigValues() {
 	m.getBrightnessDelaySet()
 	// ColorTemperatureManual will be loaded from user config via applyColorTempConfig()
 	m.getAutoChangeScaleEnabled()
+	m.initBacklightCurve()
 }
 
 func (m *Manager) getDefaultTemperatureManual() {

--- a/display1/util.go
+++ b/display1/util.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -306,6 +306,28 @@ func getConfigVersion(filename string) (string, error) {
 		return "", err
 	}
 	return string(bytes.TrimSpace(content)), nil
+}
+
+// getDmiBoardName 获取设备主板名称（DMI board_name）
+func getDmiBoardName() string {
+	const boardNamePath = "/sys/class/dmi/id/board_name"
+	content, err := os.ReadFile(boardNamePath)
+	if err != nil {
+		logger.Warning("failed to read dmi board name:", err)
+		return ""
+	}
+	return strings.TrimSpace(string(content))
+}
+
+// getDmiProductName 获取设备产品名称（DMI product_name）
+func getDmiProductName() string {
+	const productNamePath = "/sys/class/dmi/id/product_name"
+	content, err := os.ReadFile(productNamePath)
+	if err != nil {
+		logger.Warning("failed to read dmi product name:", err)
+		return ""
+	}
+	return strings.TrimSpace(string(content))
 }
 
 func getComputeChassis() (string, error) {

--- a/misc/dsg-configs/org.deepin.Display.json
+++ b/misc/dsg-configs/org.deepin.Display.json
@@ -181,10 +181,72 @@
     "autoChangeScaleEnabled": {
       "value": true,
       "serial": 0,
-      "flags": ["global"],
+      "flags": [
+        "global"
+      ],
       "name": "autoChangeScaleEnabled",
       "description": "auto change scale enabled",
       "description[zh_CN]": "是否启用自动缩放",
+      "permissions": "readwrite",
+      "visibility": "private"
+    },
+    "backLight-max-brightness-choose-big": {
+      "value": [
+        "PN100F3",
+        "ChaoXiang Series"
+      ],
+      "serial": 0,
+      "flags": [
+        "global"
+      ],
+      "name": "backLight max brightness choose big",
+      "name[zh_CN]": "背光最大亮度选大机型列表",
+      "description": "Product names whose backlight max brightness chooses the biggest controller",
+      "description[zh_CN]": "ProductName 命中该列表时，MaxBacklightBrightness 选择最大亮度的背光控制器",
+      "permissions": "readwrite",
+      "visibility": "private"
+    },
+    "brightness-percentage": {
+      "value": 100,
+      "serial": 0,
+      "flags": [],
+      "name": "brightnessPercentage",
+      "name[zh_CN]": "实际亮度百分比",
+      "description": "actual brightness percentage, range [50, 100], default 100",
+      "description[zh_CN]": "实际亮度百分比，取值范围：[50, 100]，默认100",
+      "permissions": "readwrite",
+      "visibility": "private"
+    },
+    "custom-brightness-curves": {
+      "value": "",
+      "serial": 0,
+      "flags": [],
+      "name": "customBrightnessCurves",
+      "name[zh_CN]": "自定义亮度曲线",
+      "description": "custom brightness curves and max limit config",
+      "description[zh_CN]": "内置屏亮度曲线与最大限制配置",
+      "permissions": "readwrite",
+      "visibility": "private"
+    },
+    "default-brightness-curve": {
+      "value": "",
+      "serial": 0,
+      "flags": [],
+      "name": "defaultBrightnessCurve",
+      "name[zh_CN]": "默认亮度曲线",
+      "description": "default brightness curve config (not depends on hardware)",
+      "description[zh_CN]": "默认亮度曲线配置（不依赖硬件信息）",
+      "permissions": "readwrite",
+      "visibility": "private"
+    },
+    "max-brightness-unlimited": {
+      "value": false,
+      "serial": 0,
+      "flags": [],
+      "name": "maxBrightnessUnlimited",
+      "name[zh_CN]": "最大亮度不受限开关",
+      "description": "builtin screen max brightness unlimited switch, default false",
+      "description[zh_CN]": "内置屏幕最大亮度不受限制开关，默认为false",
       "permissions": "readwrite",
       "visibility": "private"
     }


### PR DESCRIPTION
1. Add display1/brightness/curve.go CurveManager porting the default brightness curve from startdde, supporting default-brightness-curve (hardware-independent) and custom-brightness-curves (matched by board name and EDID, with max_limit/max_scale), replacing the default linear percentage-to-backlight mapping.
2. Add DConfig keys: default-brightness-curve, custom-brightness-curves, max-brightness-unlimited, brightness-percentage and backLight-max-brightness-choose-big.
3. Add MaxBrightnessUnlimited (read-write, persisted to DConfig) and CurveMaxScale (read-only) D-Bus properties.
4. Support backLight-max-brightness-choose-big: on product-name matched machines MaxBacklightBrightness picks the biggest backlight controller.
5. Keep the M900 (IsM900Config) adaptation and the choose-big backlight characteristics.

Log: migrate default brightness curve feature from startdde, supporting default/custom brightness curves, max brightness limit and choose-big backlight

Influence:
1. On a machine without curve config, verify brightness keeps the linear mapping (e.g. 0.5 -> 127 with max 255).
2. Deploy the 21-point curve override and verify brightness follows the curve (e.g. 0.5 -> 31, 1.0 -> 252).
3. Verify MaxBrightnessUnlimited is read/write and persists across daemon restart.

feat(display1): 移植 startdde 默认亮度曲线功能

1. 新增 display1/brightness/curve.go 曲线管理器，移植 startdde 默认亮度 曲线，支持 default-brightness-curve（不依赖硬件）与 custom-brightness-curves（按 boardName + EDID 匹配，含 max_limit/max_scale），替换百分比到背光亮度的默认线性映射。
2. 新增 DConfig 配置项：default-brightness-curve、 custom-brightness-curves、max-brightness-unlimited、 brightness-percentage、backLight-max-brightness-choose-big。
3. 新增 MaxBrightnessUnlimited（可读写，持久化到 DConfig）与 CurveMaxScale（只读）DBus 属性。
4. 支持 backLight-max-brightness-choose-big：ProductName 命中列表的机型， MaxBacklightBrightness 取最大亮度的背光控制器。
5. 保留 M900（IsM900Config）适配与 choose-big 背光特征。

Log: 移植 startdde 默认亮度曲线功能，支持默认/自定义曲线、最大亮度限制与
choose-big 背光

Influence:
1. 未配置曲线的机型，验证亮度保持线性映射（如 max=255 时 0.5 -> 127）。
2. 下发 21 点曲线 override，验证亮度按曲线映射（如 0.5 -> 31、1.0 -> 252）。
3. 验证 MaxBrightnessUnlimited 属性可读写并在重启后持久化。

PMS: TASK-394863

## Summary by Sourcery

Migrate startdde’s brightness-curve support into display1 with configurable curves, maximum-brightness controls, and device-specific backlight handling.

New Features:
- Add configurable default and hardware-matched custom brightness curves for backlight control.
- Expose MaxBrightnessUnlimited and CurveMaxScale through D-Bus, with persistent configuration for the unlimited-brightness setting.
- Support product-specific selection of the backlight controller with the greatest maximum brightness.

Enhancements:
- Preserve linear brightness mapping when no curve is configured and retain existing device-specific brightness adaptations.
- Apply configurable brightness scaling and maximum-limit behavior when setting and reporting built-in display brightness.
- Improve backlight updates by preferring the best controller and falling back across available controllers.

Chores:
- Add DConfig entries for brightness curves, percentage scaling, maximum-brightness behavior, and controller selection.