### PR TITLE
fix: unscale brightness even at minimum brightness in power-saving mode

### DIFF
--- a/display1/brightness_scale.go
+++ b/display1/brightness_scale.go
@@ -167,11 +167,9 @@ func scaleBrightness(base, scale float64) float64 {
 }
 
 // unscaleBrightness 将硬件实际亮度还原为未缩放的原始亮度，用于保存到配置。
-// 与 scaleBrightness 互逆：scaleBrightness(unscaleBrightness(v, s), s) == v（未饱和区间内）。
+// 用户主动调节的亮度是缩放后的显示值，必须无条件除以 scale 还原为原始值，
+// 否则节能模式下调到最低亮度（如 10%）时，保存的原始值错误，切回非节能模式无法恢复。
 func unscaleBrightness(effective, scale float64) float64 {
-	if effective <= minBrightness {
-		return minBrightness
-	}
 	if scale <= 0 {
 		// scale 为 0 时缩放不可逆（任意原始值都映射到最低亮度），
 		// 保持原值，避免覆盖用户设置的亮度。

--- a/display1/brightness_scale_boundary_test.go
+++ b/display1/brightness_scale_boundary_test.go
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+package display1
+
+import (
+	"math"
+	"testing"
+)
+
+func TestUnscaleBrightnessBoundary(t *testing.T) {
+	// 场景1：balance 模式（scale=1.0）设 10%，应保持 0.1
+	if got := unscaleBrightness(0.1, 1.0); math.Abs(got-0.1) > 1e-9 {
+		t.Errorf("balance 设10%%: got %v, want 0.1", got)
+	}
+	// 场景2：节能模式（scale=0.6，drop=40%）调到最低 10%，应还原为 0.167（17%）
+	got := unscaleBrightness(0.1, 0.6)
+	if math.Abs(got-0.167) > 0.001 {
+		t.Errorf("节能设10%%: got %v, want 0.167", got)
+	}
+	// 场景3：切回 balance 后恢复（scaleBrightness(0.167, 1.0)）
+	if restored := scaleBrightness(got, 1.0); math.Abs(restored-got) > 1e-9 {
+		t.Errorf("恢复失败: %v", restored)
+	}
+	// 场景4：节能设 50%，还原为 0.833
+	if got := unscaleBrightness(0.5, 0.6); math.Abs(got-0.833) > 0.001 {
+		t.Errorf("节能设50%%: got %v, want 0.833", got)
+	}
+	// 场景5：scale=0（drop=100%）不可逆，保持原值
+	if got := unscaleBrightness(0.5, 0.0); math.Abs(got-0.5) > 1e-9 {
+		t.Errorf("scale=0: got %v, want 0.5", got)
+	}
+	// 场景6：还原后不超过 1.0（节能设 100%，drop=40% → 1.67 clamp 到 1.0）
+	if got := unscaleBrightness(1.0, 0.6); math.Abs(got-1.0) > 1e-9 {
+		t.Errorf("上限 clamp: got %v, want 1.0", got)
+	}
+}


### PR DESCRIPTION
fix: unscale brightness even at minimum brightness in power-saving mode

1. Remove the minBrightness short-circuit in unscaleBrightness so the
   effective brightness is always divided by the scale before saving
2. The short-circuit caused brightness manually adjusted to minimum 10%
   in power-saving mode to be saved as 0.1 instead of 0.1/scale, so
   switching back to non-power-saving mode could not restore the
   original brightness

Influence:
1. In power-saving mode with 40% drop, adjust brightness to minimum 10%
   then switch back to balance; brightness should restore to about 17%
2. In power-saving mode adjust brightness to 90% then change the drop
   percent; brightness should stay 90% instead of being scaled again

fix: 节能模式下最低亮度也正确还原未缩放值

1. 移除 unscaleBrightness 中的 minBrightness 短路，保存前始终除以 scale 还原为原始亮度
2. 该短路导致节能模式下把亮度调到最低10%时保存为0.1而非0.1/scale，
   切回非节能模式后无法恢复原始亮度

Influence:
1. 节能模式（降低40%）下把亮度调到最低10%，切回平衡后亮度应恢复约17%
2. 节能模式下把亮度调到90%，再修改降低比例，亮度应保持90%而非再次缩放

PMS: BUG-376299
PMS: BUG-376307

## Summary by Sourcery

Restore the original brightness value consistently when saving brightness adjusted under power-saving scaling.

Bug Fixes:
- Correctly preserve and restore user brightness when adjusting brightness to the minimum in power-saving mode.
- Prevent brightness from being scaled repeatedly when the power-saving level changes.

Tests:
- Add boundary coverage for brightness unscaling across normal mode, power-saving mode, zero scale, and upper-limit clamping.